### PR TITLE
chore: fix lint warning

### DIFF
--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -408,7 +408,11 @@ impl Agent {
         })
     }
 
-    pub fn update<S: ToString>(&self, canister_id: &Principal, method_name: S) -> UpdateBuilder {
+    pub fn update<S: ToString>(
+        &self,
+        canister_id: &Principal,
+        method_name: S,
+    ) -> UpdateBuilder<'_> {
         UpdateBuilder::new(self, canister_id.clone(), method_name.to_string())
     }
 


### PR DESCRIPTION
fixes
```
warning: hidden lifetime parameters in types are deprecated
   --> /Users/prithvishahi/dev/repo/rust-agent/ic-agent/src/agent/mod.rs:411:83
    |
411 |     pub fn update<S: ToString>(&self, canister_id: &Principal, method_name: S) -> UpdateBuilder {
    |                                                                                   ^^^^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
    |
    = note: `-W elided-lifetimes-in-paths` implied by `-W rust-2018-idioms`
```

but these should be caught by CI