### PR TITLE
chore: bump candid to 0.6.0

### DIFF
--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = "0.1.35"
 base32 = "0.4.0"
 base64 = "0.12.3"
 byteorder = "1.3.2"
-candid = "0.5.4"
+candid = "0.6.0"
 delay = "0.2.0"
 hex = "0.4.0"
 ic-types = { path = "../ic-types", version = "0.1", features = [ "serde" ] }

--- a/ic-agent/src/canister/management_canister.rs
+++ b/ic-agent/src/canister/management_canister.rs
@@ -83,9 +83,9 @@ impl<'agent> ManagementCanister<'agent> {
         canister_id: &Principal,
     ) -> Result<CanisterStatus, AgentError> {
         let canister_to_install = CanisterRecord {
-            canister_id: Principal::from_text(canister_id.to_text())?,
+            canister_id: canister_id.to_owned(),
         };
-        let bytes: Vec<u8> = candid::Encode!(&canister_to_install).unwrap();
+        let bytes: Vec<u8> = candid::Encode!(&canister_to_install)?;
         let bytes_to_decode = self
             .agent
             .update(&Principal::management_canister(), STATUS_METHOD_NAME)
@@ -101,7 +101,7 @@ impl<'agent> ManagementCanister<'agent> {
         waiter: W,
     ) -> Result<Principal, AgentError> {
         // candid encoding of () i.e. no arguments
-        let bytes: Vec<u8> = candid::Encode!().unwrap();
+        let bytes: Vec<u8> = candid::Encode!()?;
         let bytes_to_decode = self
             .agent
             .update(&Principal::management_canister(), CREATE_METHOD_NAME)
@@ -119,9 +119,9 @@ impl<'agent> ManagementCanister<'agent> {
         canister_id: &Principal,
     ) -> Result<(), AgentError> {
         let canister_to_install = CanisterRecord {
-            canister_id: Principal::from_text(canister_id.to_text())?,
+            canister_id: canister_id.to_owned(),
         };
-        let bytes: Vec<u8> = candid::Encode!(&canister_to_install).unwrap();
+        let bytes: Vec<u8> = candid::Encode!(&canister_to_install)?;
         let bytes_to_decode = self
             .agent
             .update(&Principal::management_canister(), DELETE_METHOD_NAME)
@@ -139,9 +139,9 @@ impl<'agent> ManagementCanister<'agent> {
         canister_id: &Principal,
     ) -> Result<(), AgentError> {
         let canister_to_install = CanisterRecord {
-            canister_id: Principal::from_text(canister_id.to_text())?,
+            canister_id: canister_id.to_owned(),
         };
-        let bytes: Vec<u8> = candid::Encode!(&canister_to_install).unwrap();
+        let bytes: Vec<u8> = candid::Encode!(&canister_to_install)?;
         let bytes_to_decode = self
             .agent
             .update(&Principal::management_canister(), START_METHOD_NAME)
@@ -159,9 +159,9 @@ impl<'agent> ManagementCanister<'agent> {
         canister_id: &Principal,
     ) -> Result<(), AgentError> {
         let canister_to_install = CanisterRecord {
-            canister_id: Principal::from_text(canister_id.to_text())?,
+            canister_id: canister_id.to_owned(),
         };
-        let bytes: Vec<u8> = candid::Encode!(&canister_to_install).unwrap();
+        let bytes: Vec<u8> = candid::Encode!(&canister_to_install)?;
         let bytes_to_decode = self
             .agent
             .update(&Principal::management_canister(), STOP_METHOD_NAME)
@@ -184,12 +184,12 @@ impl<'agent> ManagementCanister<'agent> {
     ) -> Result<(), AgentError> {
         let canister_to_install = CanisterInstall {
             mode,
-            canister_id: Principal::from_text(canister_id.to_text())?,
+            canister_id: canister_id.to_owned(),
             wasm_module: module.to_vec(),
             arg: arg.to_vec(),
             compute_allocation: attributes.compute_allocation.map(|x| x.into()),
         };
-        let bytes: Vec<u8> = candid::Encode!(&canister_to_install).unwrap();
+        let bytes: Vec<u8> = candid::Encode!(&canister_to_install)?;
         let bytes_to_decode = self
             .agent
             .update(&Principal::management_canister(), INSTALL_METHOD_NAME)

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! #[derive(CandidType, Deserialize)]
 //! struct CreateCanisterResult {
-//!   canister_id: candid::Principal,
+//!   canister_id: Principal,
 //! }
 //!
 //! # fn create_identity() -> impl ic_agent::Identity {
@@ -55,7 +55,7 @@
 //!     .await?;
 //!
 //!   let result = Decode!(response.as_slice(), CreateCanisterResult)?;
-//!   let canister_id: Principal = Principal::from_text(&result.canister_id.to_text())?;
+//!   let canister_id: Principal = result.canister_id;
 //!   Ok(canister_id)
 //! }
 //!

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-candid = "0.5.4"
+candid = "0.6.0"
 clap = "3.0.0-beta.1"
 delay = "0.2.0"
 hex = "0.4.2"


### PR DESCRIPTION
It's the same as 0.5.4. But the use of ic-types is a breaking change. I will yank 0.5.4 after this.