### PR TITLE
chore: 0.1.2 of ic-types, and add metadata for cargo publish for others

### DIFF
--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -3,6 +3,14 @@ name = "ic-agent"
 version = "0.1.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
+description = "Agent library to communicate with the Internet Computer, following the Public Specification."
+homepage = "https://docs.rs/ic-agent"
+documentation = "https://docs.rs/ic-agent"
+license = "Apache-2.0"
+readme = "README.md"
+categories = ["api-bindings", "data-structures", "no-std"]
+keywords = ["internet-computer", "agent", "icp", "dfinity"]
+include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 async-trait = "0.1.35"

--- a/ic-agent/README.md
+++ b/ic-agent/README.md
@@ -1,18 +1,7 @@
 `ic-agent` is simple to use library to interact with the [Internet Computer](https://dfinity.org)
 in Rust. It is the backend for [`dfx`](https://sdk.dfinity.org).
 
-## Documentation
-To read the documentation, clone this repo and run `cargo doc`:
-
-```sh
-git clone https://github.com/dfinity-lab/agent-rust.git
-cd agent-rust
-cargo doc
-open target/doc/ic-agent/index.html
-```
-
-Once this repository is published on crates.io, this document will be updated to point to the
-latest documentation on docs.rs.
-
 ## Useful links
-TBD.
+
+- [Documentation (master)](https://agent-rust.netlify.app/ic_agent)
+- [Documentation (published)](https://docs.rs/ic_agent)

--- a/ic-types/Cargo.toml
+++ b/ic-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-types"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Types related to the Internet Computer Public Specification."

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -1,8 +1,16 @@
 [package]
 name = "ic-utils"
 version = "0.1.0"
-authors = ["Hans Larsen <hans@larsen.online>"]
+authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
+description = "Collection of utilities for Rust, on top of ic-agent, to communicate with the Internet Computer, following the Public Specification."
+homepage = "https://docs.rs/ic-utils"
+documentation = "https://docs.rs/ic-utils"
+license = "Apache-2.0"
+readme = "README.md"
+categories = ["api-bindings", "data-structures", "no-std"]
+keywords = ["internet-computer", "agent", "utility", "icp", "dfinity"]
+include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,8 +18,8 @@ edition = "2018"
 async-trait = "0.1.40"
 candid = "0.6.1"
 delay = "0.3.0"
-ic-agent = { path = "../ic-agent", version = "0.1" }
-ic-types = { path = "../ic-types", version = "0.1" }
+ic-agent = { path = "../ic-agent", version = "0.1.0" }
+ic-types = { path = "../ic-types", version = "0.1.2" }
 serde = "1.0.115"
 thiserror = "1.0.20"
 

--- a/ic-utils/README.md
+++ b/ic-utils/README.md
@@ -1,0 +1,8 @@
+`ic-utils` is a collection of utilities to help communicating with the
+Internet Computer. It abstracts a few concepts over the lower level
+`ic-agent`.
+
+## Useful links
+
+- [Documentation (master)](https://agent-rust.netlify.app/ic_utils)
+- [Documentation (published)](https://docs.rs/ic_utils)


### PR DESCRIPTION
And publish them to crate.io.