### PR TITLE
ci: use pull_request_target for some workflows that need write access

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,6 +1,6 @@
 name: Check PR title
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -1,6 +1,10 @@
 name: ic-ref
 
-on: [push]
+on:
+  push:
+    branches:
+      - next
+  pull_request_target:
 
 jobs:
   test:

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -1,9 +1,11 @@
+name: Publish Cargo docs
+
 on:
   push:
     branches:
       - next
-  pull_request:
-name: Publish Cargo docs
+  pull_request_target:
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [push]
+on:
+  push:
+    branches:
+      - next
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
Basically the ic-ref workflow which uses a secret, the netlify which writes
a comment, and the conventional commits which needs comment as well.

Also made it better for forks to be able to run workflows.