### PR TITLE
fix: allow conversion from Compute/MemoryAllocation to itself

### DIFF
--- a/ic-utils/src/interfaces/management_canister/attributes.rs
+++ b/ic-utils/src/interfaces/management_canister/attributes.rs
@@ -81,6 +81,7 @@ try_from_memory_alloc_decl!(i32);
 try_from_memory_alloc_decl!(i64);
 
 #[test]
+#[allow(clippy::useless_conversion)]
 fn can_convert_compute_allocation() {
     use std::convert::{TryFrom, TryInto};
 
@@ -99,6 +100,7 @@ fn can_convert_compute_allocation() {
 }
 
 #[test]
+#[allow(clippy::useless_conversion)]
 fn can_convert_memory_allocation() {
     use std::convert::{TryFrom, TryInto};
 

--- a/ic-utils/src/interfaces/management_canister/attributes.rs
+++ b/ic-utils/src/interfaces/management_canister/attributes.rs
@@ -79,3 +79,39 @@ try_from_memory_alloc_decl!(i8);
 try_from_memory_alloc_decl!(i16);
 try_from_memory_alloc_decl!(i32);
 try_from_memory_alloc_decl!(i64);
+
+#[test]
+fn can_convert_compute_allocation() {
+    use std::convert::{TryFrom, TryInto};
+
+    // This is more of a compiler test than an actual test.
+    let _ca_u8: ComputeAllocation = 1u8.try_into().unwrap();
+    let _ca_u16: ComputeAllocation = 1u16.try_into().unwrap();
+    let _ca_u32: ComputeAllocation = 1u32.try_into().unwrap();
+    let _ca_u64: ComputeAllocation = 1u64.try_into().unwrap();
+    let _ca_i8: ComputeAllocation = 1i8.try_into().unwrap();
+    let _ca_i16: ComputeAllocation = 1i16.try_into().unwrap();
+    let _ca_i32: ComputeAllocation = 1i32.try_into().unwrap();
+    let _ca_i64: ComputeAllocation = 1i64.try_into().unwrap();
+
+    let ca = ComputeAllocation(100);
+    let _ca_ca: ComputeAllocation = ComputeAllocation::try_from(ca).unwrap();
+}
+
+#[test]
+fn can_convert_memory_allocation() {
+    use std::convert::{TryFrom, TryInto};
+
+    // This is more of a compiler test than an actual test.
+    let _ma_u8: MemoryAllocation = 1u8.try_into().unwrap();
+    let _ma_u16: MemoryAllocation = 1u16.try_into().unwrap();
+    let _ma_u32: MemoryAllocation = 1u32.try_into().unwrap();
+    let _ma_u64: MemoryAllocation = 1u64.try_into().unwrap();
+    let _ma_i8: MemoryAllocation = 1i8.try_into().unwrap();
+    let _ma_i16: MemoryAllocation = 1i16.try_into().unwrap();
+    let _ma_i32: MemoryAllocation = 1i32.try_into().unwrap();
+    let _ma_i64: MemoryAllocation = 1i64.try_into().unwrap();
+
+    let ma = MemoryAllocation(100);
+    let _ma_ma: MemoryAllocation = MemoryAllocation::try_from(ma).unwrap();
+}

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -561,6 +561,7 @@ mod simple_calls {
 
 mod extras {
     use ic_utils::call::AsyncCall;
+    use ic_utils::interfaces::management_canister::ComputeAllocation;
     use ic_utils::interfaces::ManagementCanister;
     use ref_tests::{create_waiter, with_agent};
 
@@ -595,6 +596,8 @@ mod extras {
     #[ignore]
     #[test]
     fn compute_allocation() {
+        use std::convert::TryFrom;
+
         with_agent(|agent| async move {
             let ic00 = ManagementCanister::create(&agent);
             let (canister_id,) = ic00
@@ -603,8 +606,10 @@ mod extras {
                 .await?;
             let canister_wasm = b"\0asm\x01\0\0\0".to_vec();
 
+            let ca = ComputeAllocation::try_from(10).unwrap();
+
             ic00.install_code(&canister_id, &canister_wasm)
-                .with_compute_allocation(10)
+                .with_compute_allocation(ca)
                 .call_and_wait(create_waiter())
                 .await?;
 


### PR DESCRIPTION
It was a problem before because conversion to itself has an error type of `Infallible`.