### PR TITLE
feat: call forwarding from a wallet canister

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -30,6 +30,11 @@ jobs:
           token: ${{ secrets.IC_REF_TOKEN }}
           path: ic-ref
           ref: ${{ matrix.spec }}
+      - uses: actions/checkout@v2
+        with:
+          repository: 'dfinity/wallet-rs'
+          path: wallet-rs
+          ref: latest
 
       - name: Cache ~/.cabal/store
         uses: actions/cache@v2
@@ -74,13 +79,20 @@ jobs:
           cargo build --target wasm32-unknown-unknown --release
           cp target/wasm32-unknown-unknown/release/universal_canister.wasm $HOME/canister.wasm
 
-      - name: Run Tests
+      - name: Build wallet canister
+        run: |
+          cd wallet-rs/wallet
+          sh build.sh
+          cp wallet/target/wasm32-unknown-unknown/release/wallet-opt.wasm $HOME/wallet.wasm
+
+      - name: Run Integration Tests
         run: |
           set -ex
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
           sleep 1
           export IC_REF_PORT=$(cat $HOME/ic_ref_port)
           export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
+          export IC_WALLET_CANISTER_PATH=$HOME/wallet.wasm
           cd main/ref-tests
           cargo test --all-features -- --ignored
           killall ic-ref

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -220,12 +220,7 @@ fn status() -> Result<(), AgentError> {
     let result = runtime.block_on(async { agent.status().await });
 
     read_mock.assert();
-    assert!(match result {
-        Ok(Status {
-            ic_api_version: v, ..
-        }) if v == ic_api_version => true,
-        _ => false,
-    });
+    assert!(matches!(result, Ok(Status { ic_api_version: v, .. }) if v == ic_api_version));
 
     Ok(())
 }

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -497,10 +497,10 @@ impl<'agent> QueryBuilder<'agent> {
 /// if you want to wait or not.
 pub struct UpdateBuilder<'agent> {
     agent: &'agent Agent,
-    canister_id: Principal,
-    method_name: String,
-    arg: Vec<u8>,
-    ingress_expiry_datetime: Option<u64>,
+    pub canister_id: Principal,
+    pub method_name: String,
+    pub arg: Vec<u8>,
+    pub ingress_expiry_datetime: Option<u64>,
 }
 
 impl<'agent> UpdateBuilder<'agent> {

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -207,6 +207,8 @@ impl<'agent, Out> AsyncCaller<'agent, Out>
 where
     Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
 {
+    /// Build an UpdateBuilder call that can be used directly with the [Agent]. This is
+    /// essentially downleveling this type into the lower level [ic-agent] abstraction.
     pub fn build_call(self) -> Result<UpdateBuilder<'agent>, AgentError> {
         let mut builder = self.agent.update(&self.canister_id, &self.method_name);
         self.expiry.apply_to_update(&mut builder);
@@ -214,10 +216,12 @@ where
         Ok(builder)
     }
 
+    /// Perform this call and returns .
     pub async fn call(self) -> Result<RequestId, AgentError> {
         self.build_call()?.call().await
     }
 
+    ///
     pub async fn call_and_wait<W>(self, waiter: W) -> Result<Out, AgentError>
     where
         W: Waiter,

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -123,18 +123,26 @@ where
     /// eprintln!("{}", canister_id);
     /// # });
     /// ```
-    async fn and_then<Out2, R, AndThen>(
+    fn and_then<Out2, R, AndThen>(
         self,
         and_then: AndThen,
     ) -> AndThenAsyncCaller<Out, Out2, Self, R, AndThen>
     where
         Self: Sized + Sync + Send,
-        Out: 'async_trait,
         Out2: for<'de> ArgumentDecoder<'de> + Send + Sync,
         R: Future<Output = Result<Out2, AgentError>> + Send + Sync,
         AndThen: Sync + Send + Fn(Out) -> R,
     {
         AndThenAsyncCaller::new(self, and_then)
+    }
+
+    fn map<Out2, Map>(self, map: Map) -> MappedAsyncCaller<Out, Out2, Self, Map>
+    where
+        Self: Sized + Sync + Send,
+        Out2: for<'de> ArgumentDecoder<'de> + Send + Sync,
+        Map: Sync + Send + Fn(Out) -> Out2,
+    {
+        MappedAsyncCaller::new(self, map)
     }
 }
 
@@ -199,7 +207,7 @@ impl<'agent, Out> AsyncCaller<'agent, Out>
 where
     Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
 {
-    fn build_call(self) -> Result<UpdateBuilder<'agent>, AgentError> {
+    pub fn build_call(self) -> Result<UpdateBuilder<'agent>, AgentError> {
         let mut builder = self.agent.update(&self.canister_id, &self.method_name);
         self.expiry.apply_to_update(&mut builder);
         builder.with_arg(&self.arg?);

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -286,9 +286,9 @@ impl<'agent, 'canister: 'agent, Interface> SyncCallBuilder<'agent, 'canister, In
 ///
 /// See [AsyncCaller] for a description of this structure.
 pub struct AsyncCallBuilder<'agent, 'canister: 'agent, T> {
-    pub canister: &'canister Canister<'agent, T>,
-    pub method_name: String,
-    pub arg: Argument,
+    canister: &'canister Canister<'agent, T>,
+    method_name: String,
+    arg: Argument,
 }
 
 impl<'agent, 'canister: 'agent, T> AsyncCallBuilder<'agent, 'canister, T> {

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -112,18 +112,18 @@ pub struct Canister<'agent, T = ()> {
 
 impl<'agent, T> Canister<'agent, T> {
     /// Get the canister ID of this canister.
-    pub fn canister_id_(&self) -> Principal {
-        self.canister_id.clone()
+    pub fn canister_id_<'canister: 'agent>(&'canister self) -> &Principal {
+        &self.canister_id
     }
 
     /// Get the interface object from this canister. Sometimes those interfaces might have
     /// custom methods that are useful.
-    pub fn interface_(&self) -> &T {
+    pub fn interface_<'canister: 'agent>(&'canister self) -> &T {
         &self.interface
     }
 
     /// Create an AsyncCallBuilder to do an update call.
-    pub fn update_<'canister>(
+    pub fn update_<'canister: 'agent>(
         &'canister self,
         method_name: &str,
     ) -> AsyncCallBuilder<'agent, 'canister, T> {
@@ -131,7 +131,7 @@ impl<'agent, T> Canister<'agent, T> {
     }
 
     /// Create a SyncCallBuilder to do a query call.
-    pub fn query_<'canister>(
+    pub fn query_<'canister: 'agent>(
         &'canister self,
         method_name: &str,
     ) -> SyncCallBuilder<'agent, 'canister, T> {
@@ -286,9 +286,9 @@ impl<'agent, 'canister: 'agent, Interface> SyncCallBuilder<'agent, 'canister, In
 ///
 /// See [AsyncCaller] for a description of this structure.
 pub struct AsyncCallBuilder<'agent, 'canister: 'agent, T> {
-    canister: &'canister Canister<'agent, T>,
-    method_name: String,
-    arg: Argument,
+    pub canister: &'canister Canister<'agent, T>,
+    pub method_name: String,
+    pub arg: Argument,
 }
 
 impl<'agent, 'canister: 'agent, T> AsyncCallBuilder<'agent, 'canister, T> {

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -154,10 +154,10 @@ impl<'agent> Canister<'agent, Wallet> {
         self.query_("cycle_balance").build()
     }
 
-    /// Send cycles to another canister.
+    /// Send cycles to another (hopefully Wallet) canister.
     pub fn send_cycles<'canister: 'agent>(
         &'canister self,
-        destination: Canister<'agent>,
+        destination: &'_ Canister<'agent, Wallet>,
         amount: u64,
     ) -> impl 'agent + AsyncCall<()> {
         self.update_("send_cycles")

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -3,24 +3,26 @@ use crate::canister::{Argument, CanisterBuilder};
 use crate::Canister;
 use async_trait::async_trait;
 use candid::de::ArgumentDecoder;
-use candid::CandidType;
+use candid::{decode_args, CandidType};
 use delay::Waiter;
+use ic_agent::agent::UpdateBuilder;
 use ic_agent::export::Principal;
 use ic_agent::{Agent, AgentError, RequestId};
 
-pub struct CallForward<'agent, 'canister: 'agent, Out>
+pub struct CallForwarder<'agent, 'canister: 'agent, Out>
 where
+    Self: 'canister,
     Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
 {
     wallet: &'canister Canister<'agent, Wallet>,
-    destination: &'agent Canister<'agent, ()>,
+    destination: Principal,
     method_name: String,
     amount: u64,
     arg: Argument,
     phantom_out: std::marker::PhantomData<Out>,
 }
 
-impl<'agent, 'canister: 'agent, Out> CallForward<'agent, 'canister, Out>
+impl<'agent, 'canister: 'agent, Out> CallForwarder<'agent, 'canister, Out>
 where
     Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
 {
@@ -41,15 +43,19 @@ where
         self
     }
 
-    pub fn build(self) -> Result<AsyncCaller<'canister, Out>, AgentError> {
+    pub fn build(self) -> Result<impl 'agent + AsyncCall<Out>, AgentError> {
         Ok(self
             .wallet
             .update_("call")
-            .with_arg(self.destination.canister_id_())
+            .with_arg(self.destination)
             .with_arg(self.method_name)
-            .with_arg(self.arg.serialize()?)
+            .with_arg(self.arg.serialize()?.to_vec())
             .with_arg(self.amount)
-            .build())
+            .build()
+            .and_then(|(result,): (Vec<u8>,)| async move {
+                decode_args::<Out>(result.as_slice())
+                    .map_err(|e| AgentError::CandidError(Box::new(e)))
+            }))
     }
 
     pub async fn call(self) -> Result<RequestId, AgentError> {
@@ -58,7 +64,6 @@ where
 
     pub async fn call_and_wait<W>(self, waiter: W) -> Result<Out, AgentError>
     where
-        Out: 'agent + for<'de> ArgumentDecoder<'de> + Send + Sync,
         W: Waiter,
     {
         self.build()?.call_and_wait(waiter).await
@@ -66,7 +71,7 @@ where
 }
 
 #[async_trait]
-impl<'agent, 'canister: 'agent, Out> AsyncCall<Out> for CallForward<'agent, 'canister, Out>
+impl<'agent, 'canister: 'agent, Out> AsyncCall<Out> for CallForwarder<'agent, 'canister, Out>
 where
     Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
 {
@@ -163,22 +168,53 @@ impl<'agent> Canister<'agent, Wallet> {
 
     /// Forward a call to another canister, including an amount of cycles
     /// from the wallet.
-    pub fn call<'canister: 'agent, Out>(
+    pub fn call<'canister: 'agent, Out, M: ToString>(
         &'canister self,
-        destination: &'agent Canister<'agent>,
-        method_name: &str,
+        destination: &'canister Canister<'canister>,
+        method_name: M,
         amount: u64,
-    ) -> CallForward<'agent, 'canister, Out>
+    ) -> CallForwarder<'agent, 'canister, Out>
     where
         Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
     {
-        CallForward {
+        CallForwarder {
             wallet: self,
-            destination,
+            destination: destination.canister_id_().clone(),
             method_name: method_name.to_string(),
             amount,
             arg: Argument::default(),
             phantom_out: std::marker::PhantomData,
         }
+    }
+
+    /// Forward a call using another call's builder. This takes an UpdateBuilder,
+    /// marshalls it to a buffer, and sends it through the wallet canister, adding
+    /// a separate amount.
+    pub fn call_forward<'canister: 'agent, Out: 'agent>(
+        &'canister self,
+        call: AsyncCaller<'agent, Out>,
+        amount: u64,
+    ) -> Result<impl 'agent + AsyncCall<Out>, AgentError>
+    where
+        Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
+    {
+        let UpdateBuilder {
+            canister_id,
+            method_name,
+            arg,
+            ..
+        } = call.build_call()?;
+        let mut argument = Argument::default();
+        argument.set_raw_arg(arg);
+
+        CallForwarder {
+            wallet: self,
+            destination: canister_id,
+            method_name,
+            amount,
+            arg: argument,
+            phantom_out: std::marker::PhantomData,
+        }
+        .build()
     }
 }

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -11,8 +11,8 @@ delay = "0.3.0"
 ic-agent = { path = "../ic-agent" }
 ic-utils = { path = "../ic-utils", features = ["raw"] }
 ring = "0.16.11"
-tokio = "0.2.22"
 serde = { version = "1.0.101", features = ["derive"] }
+tokio = "0.2.22"
 
 [dev-dependencies]
 serde_cbor = "0.11.1"

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -6,12 +6,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+candid = "0.6.7"
 delay = "0.3.0"
 ic-agent = { path = "../ic-agent" }
 ic-utils = { path = "../ic-utils", features = ["raw"] }
 ring = "0.16.11"
 tokio = "0.2.22"
+serde = { version = "1.0.101", features = ["derive"] }
 
 [dev-dependencies]
-serde = { version = "1.0.101", features = ["derive"] }
 serde_cbor = "0.11.1"

--- a/ref-tests/src/universal_canister.rs
+++ b/ref-tests/src/universal_canister.rs
@@ -6,21 +6,6 @@
 //! it possible to test different canister behaviors without having to write up
 //! custom Wat files.
 use ic_agent::export::Principal;
-use std::path::Path;
-
-/// Load the Universal Canister code from the environment and return its WASM as a blob.
-pub fn wasm() -> Vec<u8> {
-    let canister_env = std::env::var("IC_UNIVERSAL_CANISTER_PATH")
-        .expect("Need to specify the IC_UNIVERSAL_CANISTER_PATH environment variable.");
-
-    let canister_path = Path::new(&canister_env);
-
-    if !canister_path.exists() {
-        panic!("Could not find the universal canister WASM file.");
-    } else {
-        std::fs::read(&canister_path).expect("Could not read file.")
-    }
-}
 
 /// Operands used in encoding UC payloads.
 #[repr(u8)]

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -1,4 +1,3 @@
-use crate::universal_canister;
 use delay::Delay;
 use ic_agent::export::Principal;
 use ic_agent::identity::BasicIdentity;
@@ -6,7 +5,9 @@ use ic_agent::Agent;
 use ic_utils::call::AsyncCall;
 use ic_utils::interfaces::ManagementCanister;
 use ring::signature::Ed25519KeyPair;
+use std::error::Error;
 use std::future::Future;
+use std::path::Path;
 
 pub fn create_waiter() -> Delay {
     Delay::builder()
@@ -41,7 +42,7 @@ pub async fn create_agent(identity: BasicIdentity) -> Result<Agent, String> {
 
 pub fn with_agent<F, R>(f: F)
 where
-    R: Future<Output = Result<(), Box<dyn std::error::Error>>>,
+    R: Future<Output = Result<(), Box<dyn Error>>>,
     F: FnOnce(Agent) -> R,
 {
     let mut runtime = tokio::runtime::Runtime::new().expect("Could not create tokio runtime.");
@@ -59,36 +60,78 @@ where
     })
 }
 
+pub async fn create_universal_canister(agent: &Agent) -> Result<Principal, Box<dyn Error>> {
+    let canister_env = std::env::var("IC_UNIVERSAL_CANISTER_PATH")
+        .expect("Need to specify the IC_UNIVERSAL_CANISTER_PATH environment variable.");
+
+    let canister_path = Path::new(&canister_env);
+
+    let canister_wasm = if !canister_path.exists() {
+        panic!("Could not find the universal canister WASM file.");
+    } else {
+        std::fs::read(&canister_path).expect("Could not read file.")
+    };
+
+    let ic00 = ManagementCanister::create(&agent);
+
+    let (canister_id,) = ic00
+        .create_canister()
+        .call_and_wait(create_waiter())
+        .await?;
+
+    ic00.install_code(&canister_id, &canister_wasm)
+        .with_raw_arg(vec![])
+        .call_and_wait(create_waiter())
+        .await?;
+
+    Ok(canister_id)
+}
+
+pub async fn create_wallet_canister(agent: &Agent) -> Result<Principal, Box<dyn Error>> {
+    let canister_env = std::env::var("IC_WALLET_CANISTER_PATH")
+        .expect("Need to specify the IC_WALLET_CANISTER_PATH environment variable.");
+
+    let canister_path = Path::new(&canister_env);
+
+    let canister_wasm = if !canister_path.exists() {
+        panic!("Could not find the wallet canister WASM file.");
+    } else {
+        std::fs::read(&canister_path).expect("Could not read file.")
+    };
+
+    let ic00 = ManagementCanister::create(&agent);
+
+    let (canister_id,) = ic00
+        .create_canister()
+        .call_and_wait(create_waiter())
+        .await?;
+
+    ic00.install_code(&canister_id, &canister_wasm)
+        .with_raw_arg(vec![])
+        .call_and_wait(create_waiter())
+        .await?;
+
+    Ok(canister_id)
+}
+
 pub fn with_universal_canister<F, R>(f: F)
 where
-    R: Future<Output = Result<(), Box<dyn std::error::Error>>>,
+    R: Future<Output = Result<(), Box<dyn Error>>>,
     F: FnOnce(Agent, Principal) -> R,
 {
-    let mut runtime = tokio::runtime::Runtime::new().expect("Could not create tokio runtime.");
-    match runtime.block_on(async {
-        let canister_wasm = universal_canister::wasm();
-
-        let agent_identity = create_identity()
-            .await
-            .expect("Could not create an identity.");
-        let agent = create_agent(agent_identity)
-            .await
-            .expect("Could not create an agent.");
-        let ic00 = ManagementCanister::create(&agent);
-
-        let (canister_id,) = ic00
-            .create_canister()
-            .call_and_wait(create_waiter())
-            .await?;
-
-        ic00.install_code(&canister_id, &canister_wasm)
-            .with_raw_arg(vec![])
-            .call_and_wait(create_waiter())
-            .await?;
-
+    with_agent(|agent| async move {
+        let canister_id = create_universal_canister(&agent).await?;
         f(agent, canister_id).await
-    }) {
-        Ok(_) => {}
-        Err(e) => assert!(false, "{:?}", e),
-    };
+    })
+}
+
+pub fn with_wallet_canister<F, R>(f: F)
+where
+    R: Future<Output = Result<(), Box<dyn Error>>>,
+    F: FnOnce(Agent, Principal) -> R,
+{
+    with_agent(|agent| async move {
+        let canister_id = create_wallet_canister(&agent).await?;
+        f(agent, canister_id).await
+    })
 }

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -13,7 +13,7 @@
 use ref_tests::universal_canister;
 use ref_tests::with_agent;
 
-const EXPECTED_IC_API_VERSION: &str = "0.10.3";
+const EXPECTED_IC_API_VERSION: &str = "0.11.1";
 
 #[ignore]
 #[test]

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -83,11 +83,8 @@ mod management_canister {
                     .call_and_wait(create_waiter())
                     .await;
 
-                assert!(match result {
-                    Err(AgentError::ReplicaError { reject_code: c, .. }) if c == 3 || c == 5 =>
-                        true,
-                    _ => false,
-                });
+                assert!(matches!(result,
+                    Err(AgentError::ReplicaError { reject_code: c, .. }) if c == 3 || c == 5));
 
                 Ok(())
             })
@@ -119,10 +116,7 @@ mod management_canister {
                 .call_and_wait(create_waiter())
                 .await;
 
-            assert!(match result {
-                Err(AgentError::ReplicaError { .. }) => true,
-                _ => false,
-            });
+            assert!(matches!(result, Err(AgentError::ReplicaError { .. })));
 
             // Reinstall should succeed.
             ic00.install_code(&canister_id, &canister_wasm)
@@ -142,10 +136,7 @@ mod management_canister {
                 .with_mode(InstallMode::Reinstall)
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError { .. }) => true,
-                _ => false,
-            });
+            assert!(matches!(result, Err(AgentError::ReplicaError { .. })));
 
             // Upgrade should succeed.
             ic00.install_code(&canister_id, &canister_wasm)
@@ -159,10 +150,7 @@ mod management_canister {
                 .with_mode(InstallMode::Upgrade)
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError { .. }) => true,
-                _ => false,
-            });
+            assert!(matches!(result, Err(AgentError::ReplicaError { .. })));
 
             // Change controller.
             ic00.set_controller(&canister_id, &other_agent_principal)
@@ -174,13 +162,10 @@ mod management_canister {
                 .set_controller(&canister_id, &other_agent_principal)
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 5,
                     reject_message,
-                }) if reject_message.contains("is not authorized to manage canister") => true,
-                _ => false,
-            });
+                }) if reject_message.contains("is not authorized to manage canister")));
 
             // Reinstall as new controller
             other_ic00
@@ -250,13 +235,10 @@ mod management_canister {
                 .update(&canister_id, "update")
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 5,
                     reject_message,
-                }) if reject_message == "canister is stopped" => true,
-                _ => false,
-            });
+                }) if reject_message == "canister is stopped"));
 
             // Can't call query on a stopped canister
             let result = agent
@@ -264,13 +246,10 @@ mod management_canister {
                 .with_arg(&[])
                 .call()
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 5,
                     reject_message,
-                }) if reject_message == "canister is stopped" => true,
-                _ => false,
-            });
+                }) if reject_message == "canister is stopped"));
 
             // Start should succeed.
             ic00.start_canister(&canister_id)
@@ -289,13 +268,10 @@ mod management_canister {
                 .update(&canister_id, "update")
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 3,
                     reject_message,
-                }) if reject_message == "method does not exist: update" => true,
-                _ => false,
-            });
+                }) if reject_message == "method does not exist: update"));
 
             // Can call query
             let result = agent
@@ -303,13 +279,10 @@ mod management_canister {
                 .with_arg(&[])
                 .call()
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 3,
                     reject_message,
-                }) if reject_message == "query method does not exist" => true,
-                _ => false,
-            });
+                }) if reject_message == "query method does not exist"));
 
             // Another start is a noop
             ic00.start_canister(&canister_id)
@@ -321,10 +294,7 @@ mod management_canister {
                 .delete_canister(&canister_id)
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError { .. }) => true,
-                _ => false,
-            });
+            assert!(matches!(result, Err(AgentError::ReplicaError { .. })));
 
             // Stop should succeed.
             ic00.stop_canister(&canister_id)
@@ -341,15 +311,11 @@ mod management_canister {
                 .update(&canister_id, "update")
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 3,
                     reject_message,
                 }) if reject_message
-                    == format!("canister no longer exists: {}", canister_id.to_text()) =>
-                    true,
-                _ => false,
-            });
+                    == format!("canister no longer exists: {}", canister_id.to_text())));
 
             // Cannot call query
             let result = agent
@@ -357,15 +323,11 @@ mod management_canister {
                 .with_arg(&[])
                 .call()
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 3,
                     reject_message,
                 }) if reject_message
-                    == format!("canister no longer exists: {}", canister_id.to_text()) =>
-                    true,
-                _ => false,
-            });
+                    == format!("canister no longer exists: {}", canister_id.to_text())));
 
             // Cannot query canister status
             let result = ic00
@@ -390,15 +352,11 @@ mod management_canister {
                 .delete_canister(&canister_id)
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 5,
                     reject_message,
                 }) if reject_message
-                    == format!("canister no longer exists: {}", canister_id.to_text()) =>
-                    true,
-                _ => false,
-            });
+                    == format!("canister no longer exists: {}", canister_id.to_text())));
 
             Ok(())
         })
@@ -431,52 +389,40 @@ mod management_canister {
                 .start_canister(&canister_id)
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 5,
                     reject_message,
-                }) if reject_message.contains("is not authorized to manage canister") => true,
-                _ => false,
-            });
+                }) if reject_message.contains("is not authorized to manage canister")));
 
             // Stop as a wrong controller should fail.
             let result = other_ic00
                 .stop_canister(&canister_id)
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 5,
                     reject_message,
-                }) if reject_message.contains("is not authorized to manage canister") => true,
-                _ => false,
-            });
+                }) if reject_message.contains("is not authorized to manage canister")));
 
             // Get canister status as a wrong controller should fail.
             let result = other_ic00
                 .canister_status(&canister_id)
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 5,
                     reject_message,
-                }) if reject_message.contains("is not authorized to manage canister") => true,
-                _ => false,
-            });
+                }) if reject_message.contains("is not authorized to manage canister")));
 
             // Delete as a wrong controller should fail.
             let result = other_ic00
                 .delete_canister(&canister_id)
                 .call_and_wait(create_waiter())
                 .await;
-            assert!(match result {
-                Err(AgentError::ReplicaError {
+            assert!(matches!(result, Err(AgentError::ReplicaError {
                     reject_code: 5,
                     reject_message,
-                }) if reject_message.contains("is not authorized to manage canister") => true,
-                _ => false,
-            });
+                }) if reject_message.contains("is not authorized to manage canister")));
 
             Ok(())
         })
@@ -531,10 +477,10 @@ mod simple_calls {
                 .call_and_wait(create_waiter())
                 .await;
 
-            assert!(match result {
-                Err(AgentError::ReplicaError { reject_code: 3, .. }) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                result,
+                Err(AgentError::ReplicaError { reject_code: 3, .. })
+            ));
             Ok(())
         })
     }
@@ -550,10 +496,10 @@ mod simple_calls {
                 .call()
                 .await;
 
-            assert!(match result {
-                Err(AgentError::ReplicaError { reject_code: 3, .. }) => true,
-                _ => false,
-            });
+            assert!(matches!(
+                result,
+                Err(AgentError::ReplicaError { reject_code: 3, .. })
+            ));
             Ok(())
         })
     }


### PR DESCRIPTION
This can happen either by passing raw bytes arguments (using the previous `call()`), or by building a Call and passing the Call in.