### PR TITLE
chore: ic-ref CI: Use ghc-8.8.4

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - next
   pull_request_target:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -14,7 +14,7 @@ jobs:
         build: [ linux-stable ]
         include:
           - build: linux-stable
-            ghc: '8.6.5'
+            ghc: '8.8.4'
             spec: 'release-0.11'
             os: ubuntu-latest
             rust: stable

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - next
   pull_request_target:
-  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -69,7 +69,7 @@ jobs:
           ls -l /opt/ghc/
           export PATH=/opt/ghc/bin:$PATH
           cabal --version
-          ghc --version
+          ghc-${{ matrix.ghc }} --version
           mkdir -p $HOME/bin
           cd ic-ref/impl
           cabal update


### PR DESCRIPTION
to match what’s in nixpkgs-20.09

(This is https://github.com/dfinity/agent-rs/pull/64 again, this time from within the repo, to test the workflow changes.)