### PR TITLE
feat: try to decode agent HttpError plain text values (display as text, not as array of ints)

### DIFF
--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -10,6 +10,7 @@ candid = "0.6.7"
 delay = "0.3.0"
 ic-agent = { path = "../ic-agent" }
 ic-utils = { path = "../ic-utils", features = ["raw"] }
+mime = "0.3.16"
 ring = "0.16.11"
 serde = { version = "1.0.101", features = ["derive"] }
 tokio = "0.2.22"

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -2,7 +2,7 @@ use candid::CandidType;
 use delay::Delay;
 use ic_agent::export::Principal;
 use ic_agent::identity::BasicIdentity;
-use ic_agent::Agent;
+use ic_agent::{Agent, AgentError};
 use ic_utils::call::AsyncCall;
 use ic_utils::interfaces::ManagementCanister;
 use ring::signature::Ed25519KeyPair;
@@ -55,11 +55,35 @@ where
         let agent = create_agent(agent_identity)
             .await
             .expect("Could not create an agent.");
-        match f(agent).await {
-            Ok(_) => {}
-            Err(e) => assert!(false, "{:?}", e),
+        if let Err(e) = f(agent).await {
+            match e.downcast_ref::<AgentError>() {
+                Some(AgentError::HttpError {
+                    status,
+                    content,
+                    content_type,
+                }) if is_plain_text_utf8(content_type) => assert!(
+                    false,
+                    "Agent Error: Http Error: status: {}, content type: {}, content: {}",
+                    status,
+                    content_type.as_ref().unwrap(),
+                    String::from_utf8(content.to_vec()).unwrap_or_else(|from_utf8_err| format!(
+                        "(unable to decode content: {:#?})",
+                        from_utf8_err
+                    ))
+                ),
+                _ => assert!(false, "{:?}", e),
+            }
         };
     })
+}
+
+fn is_plain_text_utf8(content_type: &Option<String>) -> bool {
+    // text/plain is also sometimes returned by the replica (or ic-ref),
+    // depending on where in the stack the error happens.
+    matches!(
+        content_type.as_ref().and_then(|s|s.parse::<mime::Mime>().ok()),
+        Some(mt) if mt == mime::TEXT_PLAIN || mt == mime::TEXT_PLAIN_UTF_8
+    )
 }
 
 pub async fn create_universal_canister(agent: &Agent) -> Result<Principal, Box<dyn Error>> {


### PR DESCRIPTION
Display something like
```
thread 'extras::compute_allocation' panicked at 'Agent Error: Http Error:
  status: 400, content type: text/plain, content: Unknown request type "request_status"',
/home/runner/work/agent-rs/agent-rs/main/ref-tests/src/utils.rs:64:59
```
instead of 
```
thread 'extras::compute_allocation' panicked at 'HttpError { status: 400, content_type: Some("text/plain"),
content: [85, 110, 107, 110, 111, 119, 110, 32, 114, 101, 113, 117, 101, 115, 116, 32, 116, 121, 112, 101, 32, 34, 114, 101, 113, 117, 101, 115, 116, 95, 115, 116, 97, 116, 117, 115, 34] }',
/home/runner/work/agent-rs/agent-rs/main/ref-tests/src/utils.rs:60:23
```