### PR TITLE
ci: fix setup-haskell step

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -46,9 +46,10 @@ jobs:
             ~/.cabal/store
           key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-store
 
-      - uses: actions/setup-haskell@v1.1
+      - uses: actions/setup-haskell@v1.1.3
         with:
           ghc-version: ${{ matrix.ghc }}
+          cabal-version: '3.2'
 
       - name: Cargo cache
         uses: actions/cache@v2


### PR DESCRIPTION
See https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16/

The setup-haskell step, previous of versions 1.1.3, was not updated properly for the change. Just using a sliding v1.1 was apparently not enough to get the latest, so we force it.