### PR TITLE
Use provisional_create_canister_with_cycles instead of create_canister

### DIFF
--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -285,7 +285,7 @@ impl<'agent> Canister<'agent, ManagementCanister> {
             canister_id: Principal,
         }
 
-        self.update_("create_canister")
+        self.update_("provisional_create_canister_with_cycles")
             .build()
             .map(|result: (Out,)| (result.0.canister_id,))
     }


### PR DESCRIPTION
In replica, we want to restrict create_canister to be only callable by other canisters.  Hence, we need to update the agent to use
provisional_create_canister_with_cycles which provides the same semantics as create_canister does right now.