### PR TITLE
feat: response authentication (certificate verification, root key lookup, delegations)

### DIFF
--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -78,6 +78,15 @@ pub enum AgentError {
 
     #[error("The request status ({1}) at path {0:?} is invalid.")]
     InvalidRequestStatus(Vec<Label>, String),
+
+    #[error("Certificate verification failed.")]
+    CertificateVerificationFailed(),
+
+    #[error(r#"BLS DER-encoded public key must be ${expected} bytes long, but is {actual} bytes long."#)]
+    DerKeyLengthMismatch { expected: usize, actual: usize },
+
+    #[error("BLS DER-encoded public key is invalid. Expected the following prefix: ${expected:?}, but got ${actual:?}")]
+    DerPrefixMismatch{ expected: Vec<u8>, actual: Vec<u8> },
 }
 
 impl PartialEq for AgentError {

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -1,3 +1,4 @@
+use crate::agent::status::Status;
 use crate::hash_tree::Label;
 use crate::RequestIdError;
 use leb128::read;
@@ -90,8 +91,11 @@ pub enum AgentError {
     #[error("BLS DER-encoded public key is invalid. Expected the following prefix: ${expected:?}, but got ${actual:?}")]
     DerPrefixMismatch { expected: Vec<u8>, actual: Vec<u8> },
 
-    #[error("The status response did not contain a root key")]
-    NoRootKeyInStatus(),
+    #[error("The status response did not contain a root key.  Status: {0}")]
+    NoRootKeyInStatus(Status),
+
+    #[error("Could not read the root key")]
+    CouldNotReadRootKey(),
 
     #[error("Failed to initialize the BLS library")]
     BlsInitializationFailure(),

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -92,6 +92,9 @@ pub enum AgentError {
 
     #[error("The status response did not contain a root key")]
     NoRootKeyInStatus(),
+
+    #[error("Failed to initialize the BLS library")]
+    BlsInitializationFailure(),
 }
 
 impl PartialEq for AgentError {

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -82,11 +82,13 @@ pub enum AgentError {
     #[error("Certificate verification failed.")]
     CertificateVerificationFailed(),
 
-    #[error(r#"BLS DER-encoded public key must be ${expected} bytes long, but is {actual} bytes long."#)]
+    #[error(
+        r#"BLS DER-encoded public key must be ${expected} bytes long, but is {actual} bytes long."#
+    )]
     DerKeyLengthMismatch { expected: usize, actual: usize },
 
     #[error("BLS DER-encoded public key is invalid. Expected the following prefix: ${expected:?}, but got ${actual:?}")]
-    DerPrefixMismatch{ expected: Vec<u8>, actual: Vec<u8> },
+    DerPrefixMismatch { expected: Vec<u8>, actual: Vec<u8> },
 }
 
 impl PartialEq for AgentError {

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -89,6 +89,9 @@ pub enum AgentError {
 
     #[error("BLS DER-encoded public key is invalid. Expected the following prefix: ${expected:?}, but got ${actual:?}")]
     DerPrefixMismatch { expected: Vec<u8>, actual: Vec<u8> },
+
+    #[error("The status response did not contain a root key")]
+    NoRootKeyInStatus(),
 }
 
 impl PartialEq for AgentError {

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -447,12 +447,7 @@ impl Agent {
                     delegation.subnet_id.clone().into(),
                     "public_key".into(),
                 ];
-                match cert.tree.lookup_path(&public_key_path) {
-                    LookupResult::Absent => Err(AgentError::LookupPathAbsent(public_key_path)),
-                    LookupResult::Unknown => Err(AgentError::LookupPathAbsent(public_key_path)),
-                    LookupResult::Found(root_key) => Ok(root_key.to_vec()),
-                    LookupResult::Error => Err(AgentError::LookupPathError(public_key_path)),
-                }
+                lookup_value(&cert, public_key_path).map(|pk|pk.to_vec())
             }
         }
     }

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -31,6 +31,7 @@ use status::Status;
 use crate::bls::bls12381::bls;
 use std::convert::TryFrom;
 use std::str::from_utf8;
+use std::sync::Once;
 use std::sync::RwLock;
 use std::time::Duration;
 
@@ -38,6 +39,8 @@ const IC_REQUEST_DOMAIN_SEPARATOR: &[u8; 11] = b"\x0Aic-request";
 const IC_STATE_ROOT_DOMAIN_SEPARATOR: &[u8; 14] = b"\x0Dic-state-root";
 const DER_PREFIX: &[u8; 37] = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x01\x02\x01\x06\x0c\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x02\x01\x03\x61\x00";
 const KEY_LENGTH: usize = 96;
+
+static INIT_BLS: Once = Once::new();
 
 /// A low level Agent to make calls to a Replica endpoint.
 ///
@@ -118,7 +121,9 @@ impl Agent {
 
     /// Create an instance of an [`Agent`].
     pub fn new(config: AgentConfig) -> Result<Agent, AgentError> {
-        bls::init(); // todo where to put this? we need to call it once globally.
+        INIT_BLS.call_once(|| {
+            bls::init();
+        });
 
         let url = config.url;
         let mut tls_config = rustls::ClientConfig::new();

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -162,7 +162,7 @@ impl Agent {
         let root_key = status
             .root_key
             .clone()
-            .ok_or_else(|| AgentError::NoRootKeyInStatus(status))?;
+            .ok_or(AgentError::NoRootKeyInStatus(status))?;
         if let Ok(mut write_guard) = self.root_key.write() {
             *write_guard = root_key;
         }

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -75,6 +75,7 @@ static INIT_BLS: Once = Once::new();
 ///     .with_url(URL)
 ///     .with_identity(create_identity())
 ///     .build()?;
+///   agent.fetch_root_key().await?;
 ///   let management_canister_id = Principal::from_text("aaaaa-aa")?;
 ///
 ///   let waiter = delay::Delay::builder()

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -16,7 +16,9 @@ pub use response::{Replied, RequestStatusResponse};
 #[cfg(test)]
 mod agent_test;
 
-use crate::agent::replica_api::{AsyncContent, Certificate, Envelope, ReadStateResponse, SyncContent, Delegation};
+use crate::agent::replica_api::{
+    AsyncContent, Certificate, Delegation, Envelope, ReadStateResponse, SyncContent,
+};
 use crate::export::Principal;
 use crate::hash_tree::{Label, LookupResult};
 use crate::identity::Identity;
@@ -26,11 +28,11 @@ use reqwest::Method;
 use serde::Serialize;
 use status::Status;
 
+use crate::bls::bls12381::bls;
 use std::convert::TryFrom;
 use std::str::from_utf8;
 use std::sync::RwLock;
 use std::time::Duration;
-use crate::bls::bls12381::bls;
 
 const DOMAIN_SEPARATOR: &[u8; 11] = b"\x0Aic-request";
 const IC_STATE_ROOT_DOMAIN_SEPARATOR: &[u8; 14] = b"\x0Dic-state-root";
@@ -484,12 +486,18 @@ impl Agent {
 fn extract_der(buf: Vec<u8>) -> Result<Vec<u8>, AgentError> {
     let expected_length = DER_PREFIX.len() + KEY_LENGTH;
     if buf.len() != expected_length {
-        return Err(AgentError::DerKeyLengthMismatch { expected: expected_length, actual: buf.len() } );
+        return Err(AgentError::DerKeyLengthMismatch {
+            expected: expected_length,
+            actual: buf.len(),
+        });
     }
 
     let prefix = &buf[0..DER_PREFIX.len()];
     if &prefix[..] != &DER_PREFIX[..] {
-        return Err(AgentError::DerPrefixMismatch { expected: DER_PREFIX.to_vec(), actual: prefix.to_vec() } );
+        return Err(AgentError::DerPrefixMismatch {
+            expected: DER_PREFIX.to_vec(),
+            actual: prefix.to_vec(),
+        });
     }
 
     let key = &buf[DER_PREFIX.len()..];

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -150,10 +150,13 @@ impl Agent {
         })
     }
 
-    /// Only an agent communicating with a local/custom instance of the Internet Computer
-    /// should call this method.
-    /// It is not necessary to call this when communicating with
-    /// the DFINITY foundation-managed Internet Computer.
+    /// Fetch the root key of the replica using its status end point, and update the agent's
+    /// root key. This only uses the agent's specific upstream replica, and does not ensure
+    /// the root key validity. In order to prevent any MITM attack, developers should try
+    /// to contact multiple replicas.
+    ///
+    /// The root key is necessary for validating state and certificates sent by the replica.
+    /// By default, it is set to [None] and validating methods will return an error.
     pub async fn fetch_root_key(&self) -> Result<(), AgentError> {
         let status = self.status().await?;
         let root_key = status

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -153,6 +153,8 @@ impl Agent {
         })
     }
 
+    /// Fetch the root key from the status endpoint.
+    /// It is not necessary to call this when communicating with "the" Internet Computer.
     pub async fn fetch_root_key(&self) -> Result<(), AgentError> {
         let status = self.status().await?;
         let root_key = status.root_key.ok_or_else(AgentError::NoRootKeyInStatus)?;

--- a/ic-agent/src/agent/replica_api.rs
+++ b/ic-agent/src/agent/replica_api.rs
@@ -62,6 +62,17 @@ pub(crate) struct Certificate {
 
     #[serde(with = "serde_bytes")]
     pub signature: Vec<u8>,
+
+    pub delegation: Option<Delegation>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct Delegation {
+    #[serde(with = "serde_bytes")]
+    pub subnet_id: Vec<u8>,
+
+    #[serde(with = "serde_bytes")]
+    pub certificate: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -1,0 +1,137 @@
+use crate::{AgentError, RequestId};
+
+use crate::agent::replica_api::Certificate;
+use crate::agent::{Replied, RequestStatusResponse};
+use crate::bls::bls12381::bls;
+use crate::hash_tree::{Label, LookupResult};
+use std::str::from_utf8;
+use std::sync::Once;
+
+const DER_PREFIX: &[u8; 37] = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x01\x02\x01\x06\x0c\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x02\x01\x03\x61\x00";
+const KEY_LENGTH: usize = 96;
+
+static INIT_BLS: Once = Once::new();
+
+pub fn initialize_bls() -> Result<(), AgentError> {
+    let mut result = Ok(());
+    INIT_BLS.call_once(|| {
+        if bls::init() != bls::BLS_OK {
+            result = Err(AgentError::BlsInitializationFailure());
+        }
+    });
+    result
+}
+
+pub fn extract_der(buf: Vec<u8>) -> Result<Vec<u8>, AgentError> {
+    let expected_length = DER_PREFIX.len() + KEY_LENGTH;
+    if buf.len() != expected_length {
+        return Err(AgentError::DerKeyLengthMismatch {
+            expected: expected_length,
+            actual: buf.len(),
+        });
+    }
+
+    let prefix = &buf[0..DER_PREFIX.len()];
+    if prefix[..] != DER_PREFIX[..] {
+        return Err(AgentError::DerPrefixMismatch {
+            expected: DER_PREFIX.to_vec(),
+            actual: prefix.to_vec(),
+        });
+    }
+
+    let key = &buf[DER_PREFIX.len()..];
+    Ok(key.to_vec())
+}
+
+pub(crate) fn lookup_request_status(
+    certificate: Certificate,
+    request_id: &RequestId,
+) -> Result<RequestStatusResponse, AgentError> {
+    let path_status = vec![
+        "request_status".into(),
+        request_id.to_vec().into(),
+        "status".into(),
+    ];
+    match certificate.tree.lookup_path(&path_status) {
+        LookupResult::Absent => Err(AgentError::LookupPathAbsent(path_status)),
+        LookupResult::Unknown => Ok(RequestStatusResponse::Unknown),
+        LookupResult::Found(status) => match from_utf8(status)? {
+            "done" => Ok(RequestStatusResponse::Done),
+            "processing" => Ok(RequestStatusResponse::Processing),
+            "received" => Ok(RequestStatusResponse::Received),
+            "rejected" => lookup_rejection(&certificate, request_id),
+            "replied" => lookup_reply(&certificate, request_id),
+            other => Err(AgentError::InvalidRequestStatus(
+                path_status,
+                other.to_string(),
+            )),
+        },
+        LookupResult::Error => Err(AgentError::LookupPathError(path_status)),
+    }
+}
+
+pub(crate) fn lookup_rejection(
+    certificate: &Certificate,
+    request_id: &RequestId,
+) -> Result<RequestStatusResponse, AgentError> {
+    let reject_code = lookup_reject_code(certificate, request_id)?;
+    let reject_message = lookup_reject_message(certificate, request_id)?;
+
+    Ok(RequestStatusResponse::Rejected {
+        reject_code,
+        reject_message,
+    })
+}
+
+pub(crate) fn lookup_reject_code(
+    certificate: &Certificate,
+    request_id: &RequestId,
+) -> Result<u64, AgentError> {
+    let path = vec![
+        "request_status".into(),
+        request_id.to_vec().into(),
+        "reject_code".into(),
+    ];
+    let code = lookup_value(&certificate, path)?;
+    let mut readable = &code[..];
+    Ok(leb128::read::unsigned(&mut readable)?)
+}
+
+pub(crate) fn lookup_reject_message(
+    certificate: &Certificate,
+    request_id: &RequestId,
+) -> Result<String, AgentError> {
+    let path = vec![
+        "request_status".into(),
+        request_id.to_vec().into(),
+        "reject_message".into(),
+    ];
+    let msg = lookup_value(&certificate, path)?;
+    Ok(from_utf8(msg)?.to_string())
+}
+
+pub(crate) fn lookup_reply(
+    certificate: &Certificate,
+    request_id: &RequestId,
+) -> Result<RequestStatusResponse, AgentError> {
+    let path = vec![
+        "request_status".into(),
+        request_id.to_vec().into(),
+        "reply".into(),
+    ];
+    let reply_data = lookup_value(&certificate, path)?;
+    let reply = Replied::CallReplied(Vec::from(reply_data));
+    Ok(RequestStatusResponse::Replied { reply })
+}
+
+pub(crate) fn lookup_value(
+    certificate: &Certificate,
+    path: Vec<Label>,
+) -> Result<&[u8], AgentError> {
+    match certificate.tree.lookup_path(&path) {
+        LookupResult::Absent => Err(AgentError::LookupPathAbsent(path)),
+        LookupResult::Unknown => Err(AgentError::LookupPathUnknown(path)),
+        LookupResult::Found(value) => Ok(value),
+        LookupResult::Error => Err(AgentError::LookupPathError(path)),
+    }
+}

--- a/ic-agent/src/agent/status.rs
+++ b/ic-agent/src/agent/status.rs
@@ -52,6 +52,9 @@ pub struct Status {
     /// Optional. The precise git revision of the Internet Computer implementation.
     pub impl_revision: Option<String>,
 
+    /// Optional.  The root key
+    pub root_key: Option<Vec<u8>>,
+
     /// Contains any additional values that the replica gave as status.
     pub values: BTreeMap<String, Box<Value>>,
 }
@@ -136,12 +139,20 @@ impl std::convert::TryFrom<&serde_cbor::Value> for Status {
                         None
                     }
                 });
+                let root_key: Option<Vec<u8>> = map.get("root_key").and_then(|v| {
+                    if let Value::Bytes(bytes) = v.as_ref() {
+                        Some(bytes.to_owned())
+                    } else {
+                        None
+                    }
+                });
 
                 Ok(Status {
                     ic_api_version,
                     impl_source,
                     impl_version,
                     impl_revision,
+                    root_key,
                     values: map,
                 })
             }

--- a/ic-agent/src/agent/status.rs
+++ b/ic-agent/src/agent/status.rs
@@ -52,7 +52,7 @@ pub struct Status {
     /// Optional. The precise git revision of the Internet Computer implementation.
     pub impl_revision: Option<String>,
 
-    /// Optional.  The root key
+    /// Optional.  The root (public) key used to verify certificates.
     pub root_key: Option<Vec<u8>>,
 
     /// Contains any additional values that the replica gave as status.

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -57,6 +57,7 @@
 //!     .with_url(URL)
 //!     .with_identity(create_identity())
 //!     .build()?;
+//!   agent.fetch_root_key().await?;
 //!   let management_canister_id = Principal::from_text("aaaaa-aa")?;
 //!
 //!   let waiter = delay::Delay::builder()

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -55,7 +55,10 @@ where
         let agent = create_agent(agent_identity)
             .await
             .expect("Could not create an agent.");
-        agent.fetch_root_key().await.expect("could not fetch root key");
+        agent
+            .fetch_root_key()
+            .await
+            .expect("could not fetch root key");
         match f(agent).await {
             Ok(_) => {}
             Err(e) => assert!(false, "{:?}", e),

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -55,6 +55,7 @@ where
         let agent = create_agent(agent_identity)
             .await
             .expect("Could not create an agent.");
+        agent.fetch_root_key().await.expect("could not fetch root key");
         match f(agent).await {
             Ok(_) => {}
             Err(e) => assert!(false, "{:?}", e),

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -91,7 +91,7 @@ mod management_canister {
         }
     }
 
-    //#[ignore]
+    #[ignore]
     #[test]
     fn management() {
         with_agent(|agent| async move {

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -91,7 +91,7 @@ mod management_canister {
         }
     }
 
-    #[ignore]
+    //#[ignore]
     #[test]
     fn management() {
         with_agent(|agent| async move {
@@ -128,6 +128,7 @@ mod management_canister {
             let other_agent_identity = create_identity().await?;
             let other_agent_principal = other_agent_identity.sender()?;
             let other_agent = create_agent(other_agent_identity).await?;
+            other_agent.fetch_root_key().await?;
             let other_ic00 = ManagementCanister::create(&other_agent);
 
             // Reinstall with another agent should fail.
@@ -382,6 +383,7 @@ mod management_canister {
             // Create another agent with different identity.
             let other_agent_identity = create_identity().await?;
             let other_agent = create_agent(other_agent_identity).await?;
+            other_agent.fetch_root_key().await?;
             let other_ic00 = ManagementCanister::create(&other_agent);
 
             // Start as a wrong controller should fail.


### PR DESCRIPTION
Implements from doc:
- Checking BLS signature
- Fetching root key from /api/v1/status for dev instances
- Hard-coding Sodium key (**still need the actual key**).  (Note doc says this would be the Mercury key)
- Support for delegations 

See also companion PR [sdk #1197](https://github.com/dfinity/sdk/pull/1197)