### PR TITLE
feat: add provisional, raw_rand, etc to mgmt canister

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - build: linux-stable
             ghc: '8.8.4'
-            spec: '0.14.1'
+            spec: '0.14.0'
             os: ubuntu-latest
             rust: stable
 

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - build: linux-stable
             ghc: '8.8.4'
-            spec: 'release-0.14'
+            spec: '0.14.1'
             os: ubuntu-latest
             rust: stable
 

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -390,7 +390,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(format!("{}", status), "Running");
+        assert_eq!(format!("{}", status.status), "Running");
 
         let canister_wasm = b"\0asm\x01\0\0\0";
         management_canister

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -283,15 +283,7 @@ impl<'agent> Canister<'agent, ManagementCanister> {
                 canister_id: canister_id.clone(),
             })
             .build()
-            .map(|result: (StatusCallResult,)| {
-                (StatusCallResult {
-                    status: result.0.status,
-                    module_hash: result.0.module_hash,
-                    controller: result.0.controller,
-                    memory_size: result.0.memory_size,
-                    cycles: result.0.cycles,
-                },)
-            })
+            .map(|result: (StatusCallResult,)| (result.0,))
     }
 
     /// Create a canister, returning a caller that returns a Canister Id.

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -44,8 +44,8 @@ pub struct StatusCallResult {
     pub status: CanisterStatus,
     pub module_hash: Option<Vec<u8>>,
     pub controller: Principal,
-    pub memory_size: u64,
-    pub cycles: u64,
+    pub memory_size: candid::Nat,
+    pub cycles: candid::Nat,
 }
 
 impl std::fmt::Display for StatusCallResult {

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -300,16 +300,15 @@ impl<'agent> Canister<'agent, ManagementCanister> {
             .map(|result: (Out,)| (result.0.canister_id,))
     }
 
-    ///
-    pub fn raw_rand<'canister: 'agent>(&'canister self) -> impl 'agent + AsyncCall<(Principal,)> {
+    /// This method takes no input and returns 32 pseudo-random bytes to the caller.
+    /// The return value is unknown to any part of the IC at time of the submission of this call.
+    /// A new return value is generated for each call to this method.
+    pub fn raw_rand<'canister: 'agent>(&'canister self) -> impl 'agent + AsyncCall<(Vec<u8>,)> {
         #[derive(Deserialize)]
-        struct Out {
-            canister_id: Principal,
-        }
 
         self.update_("raw_rand")
             .build()
-            .map(|result: (Out,)| (result.0.canister_id,))
+            .map(|result: (Vec<u8>,)| (result.0,))
     }
 
     /// Until developers can convert real ICP tokens to provision a new canister with cycles,

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -338,6 +338,29 @@ impl<'agent> Canister<'agent, ManagementCanister> {
             .map(|result: (Out,)| (result.0.canister_id,))
     }
 
+    /// Until developers can convert real ICP tokens to a top up an existing canister,
+    /// the system provides the provisional_top_up_canister method.
+    /// It adds amount cycles to the balance of canister identified by amount
+    /// (implicitly capping it at MAX_CANISTER_BALANCE).
+    pub fn provisional_top_up_canister<'canister: 'agent>(
+        &'canister self,
+        canister_id: &Principal,
+        amount: u64,
+    ) -> impl 'agent + AsyncCall<()> {
+        #[derive(CandidType)]
+        struct Argument {
+            canister_id: Principal,
+            amount: u64,
+        }
+
+        self.update_("provisional_top_up_canister")
+            .with_arg(Argument {
+                canister_id: canister_id.clone(),
+                amount,
+            })
+            .build()
+    }
+
     /// This method deposits the cycles included in this call into the specified canister.
     /// Only the controller of the canister can deposit cycles.
     pub fn deposit_cycles<'canister: 'agent>(

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -48,6 +48,12 @@ pub struct StatusCallResult {
     cycles: u64,
 }
 
+impl std::fmt::Display for StatusCallResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
 /// The status of a Canister, whether it's running, in the process of stopping, or
 /// stopped.
 

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -360,7 +360,7 @@ impl<'agent> Canister<'agent, ManagementCanister> {
 
         self.update_("provisional_create_canister_with_cycles")
             .with_arg(Argument {
-                amount: amount.map(|v| candid::Nat::from(v)),
+                amount: amount.map(candid::Nat::from),
             })
             .build()
             .map(|result: (Out,)| (result.0.canister_id,))

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -311,14 +311,10 @@ impl<'agent> Canister<'agent, ManagementCanister> {
         }
 
         self.update_("provisional_create_canister_with_cycles")
-            .with_arg(Argument {
-                amount
-            })
+            .with_arg(Argument { amount })
             .build()
             .map(|result: (Out,)| (result.0.canister_id,))
     }
-
-
 
     /// Deletes a canister.
     pub fn delete_canister<'canister: 'agent>(

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -41,11 +41,11 @@ impl ManagementCanister {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct StatusCallResult {
-    status: CanisterStatus,
-    module_hash: Option<Vec<u8>>,
-    controller: Principal,
-    memory_size: u64,
-    cycles: u64,
+    pub status: CanisterStatus,
+    pub module_hash: Option<Vec<u8>>,
+    pub controller: Principal,
+    pub memory_size: u64,
+    pub cycles: u64,
 }
 
 impl std::fmt::Display for StatusCallResult {

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -290,6 +290,36 @@ impl<'agent> Canister<'agent, ManagementCanister> {
             .map(|result: (Out,)| (result.0.canister_id,))
     }
 
+    /// Until developers can convert real ICP tokens to provision a new canister with cycles,
+    /// the system provides the provisional_create_canister_with_cycles method.
+    /// It behaves as create_canister, but initializes the canister’s balance with amount fresh cycles
+    /// (using MAX_CANISTER_BALANCE if amount = null, else capping the balance at MAX_CANISTER_BALANCE).
+    /// Cycles added to this call via ic0.call_cycles_add are returned to the caller.
+    /// This method is only available in local development instances, and will be removed in the future.
+    pub fn provisional_create_canister_with_cycles<'canister: 'agent>(
+        &'canister self,
+        amount: Option<u64>,
+    ) -> impl 'agent + AsyncCall<(Principal,)> {
+        #[derive(CandidType)]
+        struct Argument {
+            amount: Option<u64>,
+        }
+
+        #[derive(Deserialize)]
+        struct Out {
+            canister_id: Principal,
+        }
+
+        self.update_("provisional_create_canister_with_cycles")
+            .with_arg(Argument {
+                amount
+            })
+            .build()
+            .map(|result: (Out,)| (result.0.canister_id,))
+    }
+
+
+
     /// Deletes a canister.
     pub fn delete_canister<'canister: 'agent>(
         &'canister self,

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 pub mod attributes;
 pub use attributes::ComputeAllocation;
 pub use attributes::MemoryAllocation;
+use std::convert::From;
 use std::convert::TryInto;
 
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
@@ -349,7 +350,7 @@ impl<'agent> Canister<'agent, ManagementCanister> {
     ) -> impl 'agent + AsyncCall<(Principal,)> {
         #[derive(CandidType)]
         struct Argument {
-            amount: Option<u64>,
+            amount: Option<candid::Nat>,
         }
 
         #[derive(Deserialize)]
@@ -358,7 +359,9 @@ impl<'agent> Canister<'agent, ManagementCanister> {
         }
 
         self.update_("provisional_create_canister_with_cycles")
-            .with_arg(Argument { amount })
+            .with_arg(Argument {
+                amount: amount.map(|v| candid::Nat::from(v)),
+            })
             .build()
             .map(|result: (Out,)| (result.0.canister_id,))
     }

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -305,7 +305,6 @@ impl<'agent> Canister<'agent, ManagementCanister> {
     /// A new return value is generated for each call to this method.
     pub fn raw_rand<'canister: 'agent>(&'canister self) -> impl 'agent + AsyncCall<(Vec<u8>,)> {
         #[derive(Deserialize)]
-
         self.update_("raw_rand")
             .build()
             .map(|result: (Vec<u8>,)| (result.0,))

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -14,7 +14,6 @@ openssl = "0.10.24"
 ring = "0.16.11"
 serde = { version = "1.0.101", features = ["derive"] }
 tokio = "0.2.22"
-num-bigint = "0.3.0"
 
 [dev-dependencies]
 serde_cbor = "0.11.1"

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -10,6 +10,7 @@ candid = "0.6.7"
 delay = "0.3.0"
 ic-agent = { path = "../ic-agent" }
 ic-utils = { path = "../ic-utils", features = ["raw"] }
+openssl = "0.10.24"
 ring = "0.16.11"
 serde = { version = "1.0.101", features = ["derive"] }
 tokio = "0.2.22"

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -14,6 +14,7 @@ openssl = "0.10.24"
 ring = "0.16.11"
 serde = { version = "1.0.101", features = ["derive"] }
 tokio = "0.2.22"
+num-bigint = "0.3.0"
 
 [dev-dependencies]
 serde_cbor = "0.11.1"

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -13,7 +13,7 @@
 use ref_tests::universal_canister;
 use ref_tests::with_agent;
 
-const EXPECTED_IC_API_VERSION: &str = "0.14.1";
+const EXPECTED_IC_API_VERSION: &str = "0.14.0";
 
 #[ignore]
 #[test]

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -40,7 +40,9 @@ mod management_canister {
     use ic_agent::AgentError;
     use ic_agent::Identity;
     use ic_utils::call::AsyncCall;
-    use ic_utils::interfaces::management_canister::{CanisterStatus, InstallMode};
+    use ic_utils::interfaces::management_canister::{
+        CanisterStatus, InstallMode, StatusCallResult,
+    };
     use ic_utils::interfaces::ManagementCanister;
     use ref_tests::{create_agent, create_identity, create_waiter, with_agent};
 
@@ -342,9 +344,7 @@ mod management_canister {
                 }) if reject_message
                     == format!("canister no longer exists: {}", canister_id.to_text()) =>
                     true,
-                Ok((CanisterStatus::Stopped,)) => false,
-                Ok((CanisterStatus::Stopping,)) => false,
-                Ok((CanisterStatus::Running,)) => false,
+                Ok((StatusCallResult,)) => false,
                 _ => false,
             });
 

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -505,7 +505,7 @@ mod management_canister {
                 .await?;
 
             // this should fail but currently passes
-            assert_eq!(result.0.cycles.clone(), max_canister_balance);
+            assert_eq!(result.0.cycles, max_canister_balance);
 
             // TODO: enable this when provisional_create_canister_with_cycles is fixed
             // this should pass but currently fails

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -44,8 +44,8 @@ mod management_canister {
         CanisterStatus, InstallMode, StatusCallResult,
     };
     use ic_utils::interfaces::ManagementCanister;
-    use ref_tests::{create_agent, create_identity, create_waiter, with_agent};
     use openssl::sha::Sha256;
+    use ref_tests::{create_agent, create_identity, create_waiter, with_agent};
 
     mod create_canister {
         use super::{create_waiter, with_agent};
@@ -206,7 +206,8 @@ mod management_canister {
             assert_eq!(result.0.module_hash, None);
 
             // Install wasm.
-            other_ic00.install_code(&canister_id_3, &canister_wasm)
+            other_ic00
+                .install_code(&canister_id_3, &canister_wasm)
                 .with_mode(InstallMode::Install)
                 .call_and_wait(create_waiter())
                 .await?;

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -496,7 +496,8 @@ mod management_canister {
                 BigUint::from(max_canister_balance)
             );
 
-            //
+            // cycle balance should be amount specified to
+            // provisional_create_canister_with_cycles call
             let amount: u64 = 1 << 40; // 1099511627776
             let (canister_id_2,) = ic00
                 .provisional_create_canister_with_cycles(Some(amount))

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -469,18 +469,9 @@ mod management_canister {
     fn randomness() {
         with_agent(|agent| async move {
             let ic00 = ManagementCanister::create(&agent);
-            let (rand_1,) = ic00
-                .raw_rand()
-                .call_and_wait(create_waiter())
-                .await?;
-            let (rand_2,) = ic00
-                .raw_rand()
-                .call_and_wait(create_waiter())
-                .await?;
-            let (rand_3,) = ic00
-                .raw_rand()
-                .call_and_wait(create_waiter())
-                .await?;
+            let (rand_1,) = ic00.raw_rand().call_and_wait(create_waiter()).await?;
+            let (rand_2,) = ic00.raw_rand().call_and_wait(create_waiter()).await?;
+            let (rand_3,) = ic00.raw_rand().call_and_wait(create_waiter()).await?;
 
             assert_eq!(rand_1.len(), 32);
             assert_eq!(rand_2.len(), 32);

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -463,6 +463,36 @@ mod management_canister {
             Ok(())
         })
     }
+
+    #[ignore]
+    #[test]
+    fn randomness() {
+        with_agent(|agent| async move {
+            let ic00 = ManagementCanister::create(&agent);
+            let (rand_1,) = ic00
+                .raw_rand()
+                .call_and_wait(create_waiter())
+                .await?;
+            let (rand_2,) = ic00
+                .raw_rand()
+                .call_and_wait(create_waiter())
+                .await?;
+            let (rand_3,) = ic00
+                .raw_rand()
+                .call_and_wait(create_waiter())
+                .await?;
+
+            assert_eq!(rand_1.len(), 32);
+            assert_eq!(rand_2.len(), 32);
+            assert_eq!(rand_3.len(), 32);
+
+            assert_ne!(rand_1, rand_2);
+            assert_ne!(rand_1, rand_3);
+            assert_ne!(rand_2, rand_3);
+
+            Ok(())
+        })
+    }
 }
 
 mod simple_calls {

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -504,11 +504,12 @@ mod management_canister {
                 .call_and_wait(create_waiter())
                 .await?;
 
-            // this should fail?
+            // this should fail but currently passes
             assert_eq!(result.0.cycles.clone(), max_canister_balance);
 
-            // this should pass?
-            assert_eq!(result.0.cycles, amount);
+            // TODO: enable this when provisional_create_canister_with_cycles is fixed
+            // this should pass but currently fails
+            // assert_eq!(result.0.cycles, amount);
 
             Ok(())
         })

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -503,13 +503,7 @@ mod management_canister {
                 .canister_status(&canister_id_2)
                 .call_and_wait(create_waiter())
                 .await?;
-
-            // this should fail but currently passes
-            assert_eq!(result.0.cycles, max_canister_balance);
-
-            // TODO: enable this when provisional_create_canister_with_cycles is fixed
-            // this should pass but currently fails
-            // assert_eq!(result.0.cycles, amount);
+            assert_eq!(result.0.cycles, amount);
 
             Ok(())
         })

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -13,7 +13,7 @@
 use ref_tests::universal_canister;
 use ref_tests::with_agent;
 
-const EXPECTED_IC_API_VERSION: &str = "0.14.0";
+const EXPECTED_IC_API_VERSION: &str = "0.14.1";
 
 #[ignore]
 #[test]

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -212,7 +212,7 @@ mod management_canister {
                 .canister_status(&canister_id)
                 .call_and_wait(create_waiter())
                 .await;
-            assert_eq!(result?.0, CanisterStatus::Running);
+            assert_eq!(result?.0.status, CanisterStatus::Running);
 
             // Stop should succeed.
             ic00.stop_canister(&canister_id)
@@ -224,7 +224,7 @@ mod management_canister {
                 .canister_status(&canister_id)
                 .call_and_wait(create_waiter())
                 .await;
-            assert_eq!(result?.0, CanisterStatus::Stopped);
+            assert_eq!(result?.0.status, CanisterStatus::Stopped);
 
             // Another stop is a noop
             ic00.stop_canister(&canister_id)
@@ -262,7 +262,7 @@ mod management_canister {
                 .canister_status(&canister_id)
                 .call_and_wait(create_waiter())
                 .await;
-            assert_eq!(result?.0, CanisterStatus::Running);
+            assert_eq!(result?.0.status, CanisterStatus::Running);
 
             // Can call update
             let result = agent

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -42,7 +42,6 @@ mod management_canister {
     use ic_utils::call::AsyncCall;
     use ic_utils::interfaces::management_canister::{CanisterStatus, InstallMode};
     use ic_utils::interfaces::ManagementCanister;
-    use num_bigint::BigUint;
     use openssl::sha::Sha256;
     use ref_tests::{create_agent, create_identity, create_waiter, with_agent};
 
@@ -479,7 +478,7 @@ mod management_canister {
                 .canister_status(&canister_id)
                 .call_and_wait(create_waiter())
                 .await?;
-            assert_eq!(BigUint::from(result.0.cycles), BigUint::from(0 as u64));
+            assert_eq!(result.0.cycles, 0 as u64);
 
             // cycle balance is max_canister_balance when creating with
             // provisional_create_canister_with_cycles(None)
@@ -491,10 +490,7 @@ mod management_canister {
                 .canister_status(&canister_id_1)
                 .call_and_wait(create_waiter())
                 .await?;
-            assert_eq!(
-                BigUint::from(result.0.cycles),
-                BigUint::from(max_canister_balance)
-            );
+            assert_eq!(result.0.cycles, max_canister_balance);
 
             // cycle balance should be amount specified to
             // provisional_create_canister_with_cycles call
@@ -509,13 +505,10 @@ mod management_canister {
                 .await?;
 
             // this should fail?
-            assert_eq!(
-                BigUint::from(result.0.cycles.clone()),
-                BigUint::from(max_canister_balance)
-            );
+            assert_eq!(result.0.cycles.clone(), max_canister_balance);
 
             // this should pass?
-            assert_eq!(BigUint::from(result.0.cycles), BigUint::from(amount));
+            assert_eq!(result.0.cycles, amount);
 
             Ok(())
         })


### PR DESCRIPTION
This adds `deposit_cycles`, `provisional_create_canister_with_cycles`, `provisional_top_up_canister`, `raw_rand`, and updates `canister_status` to return a record
