### PR TITLE
test: Run tests using a software HSM

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -131,12 +131,12 @@ jobs:
           softhsm2-util --version
           ls -l $HSM_PKCS11_LIBRARY_PATH
           softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
-          # no slots: pkcs11-tool -L
+          pkcs11-tool -L --module $HSM_PKCS11_LIBRARY_PATH
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-token-slots
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot-index $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
-          pkcs11-tool -L
+          pkcs11-tool -L --module $HSM_PKCS11_LIBRARY_PATH
         env:
           RUST_BACKTRACE: 1
           HSM_PKCS11_LIBRARY_PATH: ${{ env.INSTALLED_PKCS11_SOFTHSM_MODULE }}

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -131,7 +131,7 @@ jobs:
           softhsm2-util --version
           ls -l $HSM_PKCS11_LIBRARY_PATH
           softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
-          pkcs11-tool -L
+          # no slots: pkcs11-tool -L
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-token-slots

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -128,6 +128,7 @@ jobs:
       - name: Run Integration Tests with SoftHSM
         run: |
           set -ex
+          softhsm2-util --version
           softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -105,6 +105,44 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+      - name: Install SoftHSM (linux)
+        if: matrix.config.build = 'linux-stable'
+        uses: actions/checkout@v2
+        run:|
+          sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ eoan universe"
+          sudo apt-get install -f libsofthsm2
+          sudo usermod -a -G softhsm $USER
+          echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/lib/softhsm/libsofthsm2.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Install SoftHSM (macos)
+        if: matrix.config.os = 'macos-latest'
+        uses: actions/checkout@v2
+        run:|
+          brew install -f softhsm opensc
+          echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/local/lib/softhsm/libsofthsm2.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "PKCS11_TOOL=/Library/OpenSC/bin/pkcs11-tool" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          #echo "PKCS11_MODULE=/Library/OpenSC/lib/opensc-pkcs11.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Run Integration Tests (SoftHSM)
+        run: |
+          set -ex
+          softhsm2-util --init-token --slot 0 --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
+          $PKCS11_TOOL --login --test
+          $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
+          sleep 1
+          export IC_REF_PORT=$(cat $HOME/ic_ref_port)
+          export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
+          export IC_WALLET_CANISTER_PATH=$HOME/wallet.wasm
+          cd main/ref-tests
+          cargo test --all-features -- --ignored
+          killall ic-ref
+        env:
+          RUST_BACKTRACE: 1
+          HSM_PKCS11_LIBRARY_PATH: ${{ env.INSTALLED_PKCS11_SOFTHSM_MODULE }}
+          HSM_SO_PIN: 123456
+          HSM_PIN: 1234
+
+
       - name: Run Doc Tests
         run: |
           set -ex

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -139,7 +139,7 @@ jobs:
           export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
           export IC_WALLET_CANISTER_PATH=$HOME/wallet.wasm
           cd main/ref-tests
-          cargo test --all-features -- --ignored
+          cargo test --all-features -- --ignored --nocapture
           killall ic-ref
         env:
           RUST_BACKTRACE: 1

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -106,8 +106,6 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Install SoftHSM Linux
-        #if: matrix.config.build == 'linux-stable'
-        #sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ eoan universe"
         run: |
           sudo apt-get install -f libsofthsm2 opensc-pkcs11 opensc
           sudo usermod -a -G softhsm $USER
@@ -116,27 +114,12 @@ jobs:
           echo "directories.tokendir = $HOME/softhsm/tokens/" >$HOME/softhsm.conf
           mkdir -p $HOME/softhsm/tokens
 
-      # ic-ref test only run on linux
-      #- name: Install SoftHSM Macos
-      #  if: matrix.config.os == 'macos-latest'
-      #  run: |
-      #    brew install -f softhsm opensc
-      #    echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/local/lib/softhsm/libsofthsm2.so" >>$GITHUB_ENV
-      #    echo "PKCS11_TOOL=/Library/OpenSC/bin/pkcs11-tool" >>$GITHUB_ENV
-      #    #echo "PKCS11_MODULE=/Library/OpenSC/lib/opensc-pkcs11.so" >>$GITHUB_ENV
-
       - name: Run Integration Tests with SoftHSM
         run: |
           set -ex
-          softhsm2-util --version
-          ls -l $HSM_PKCS11_LIBRARY_PATH
-          softhsm2-util --init-token --slot $HSM_SLOT_INDEX --label "agent-rs-token-0" --so-pin $HSM_SO_PIN --pin $HSM_PIN
-          pkcs11-tool -L --module $HSM_PKCS11_LIBRARY_PATH
-          #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
-          #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots
-          #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-token-slots
-          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot-index $HSM_SLOT_INDEX -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
-          pkcs11-tool -L --module $HSM_PKCS11_LIBRARY_PATH
+          softhsm2-util --init-token --slot $HSM_SLOT_INDEX --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
+          # create key:
+          pkcs11-tool -k --module $HSM_PKCS11_LIBRARY_PATH --login --slot-index $HSM_SLOT_INDEX -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
 
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
           sleep 1

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -129,7 +129,9 @@ jobs:
         run: |
           set -ex
           softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
-          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --test --pin $HSM_PIN
+          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
+          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots
+          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-token-slots
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
           sleep 1

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -129,9 +129,9 @@ jobs:
         run: |
           set -ex
           softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
-          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
-          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots
-          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-token-slots
+          #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
+          #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots
+          #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-token-slots
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot-index $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
           sleep 1

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -107,8 +107,8 @@ jobs:
 
       - name: Install SoftHSM Linux
         #if: matrix.config.build == 'linux-stable'
+        #sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ eoan universe"
         run: |
-          sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ eoan universe"
           sudo apt-get install -f libsofthsm2 opensc-pkcs11
           sudo usermod -a -G softhsm $USER
           echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/lib/softhsm/libsofthsm2.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -109,7 +109,7 @@ jobs:
         #if: matrix.config.build == 'linux-stable'
         #sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ eoan universe"
         run: |
-          sudo apt-get install -f libsofthsm2 opensc-pkcs11
+          sudo apt-get install -f libsofthsm2 opensc-pkcs11 opensc
           sudo usermod -a -G softhsm $USER
           echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/lib/softhsm/libsofthsm2.so" >>$GITHUB_ENV
           echo "SOFTHSM2_CONF=$HOME/softhsm.conf" >>$GITHUB_ENV
@@ -129,6 +129,8 @@ jobs:
         run: |
           set -ex
           softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
+          echo "PATH: $PATH"
+          find / -name pkcs11-tool -print
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --test
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --slot $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -130,7 +130,8 @@ jobs:
           set -ex
           softhsm2-util --version
           ls -l $HSM_PKCS11_LIBRARY_PATH
-          softhsm2-util --init-token --slot 0 --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
+          softhsm2-util --init-token --slot 0 --label "agent-rs-token-0" --so-pin $HSM_SO_PIN --pin $HSM_PIN
+          softhsm2-util --init-token --slot 1 --label "agent-rs-token-1" --so-pin $HSM_SO_PIN --pin $HSM_PIN
           pkcs11-tool -L --module $HSM_PKCS11_LIBRARY_PATH
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -128,8 +128,9 @@ jobs:
       - name: Run Integration Tests with SoftHSM
         run: |
           set -ex
-          softhsm2-util --init-token --slot 0 --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
-          $PKCS11_TOOL --login --test
+          softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
+          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --test
+          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --slot $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
           sleep 1
           export IC_REF_PORT=$(cat $HOME/ic_ref_port)
@@ -143,6 +144,8 @@ jobs:
           HSM_PKCS11_LIBRARY_PATH: ${{ env.INSTALLED_PKCS11_SOFTHSM_MODULE }}
           HSM_SO_PIN: 123456
           HSM_PIN: 1234
+          HSM_SLOT: 0
+          HSM_KEY_ID: abcdef
 
       - name: Run Doc Tests
         run: |

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -129,8 +129,6 @@ jobs:
         run: |
           set -ex
           softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
-          echo "PATH: $PATH"
-          find / -name pkcs11-tool -print
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --test
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --slot $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -130,7 +130,7 @@ jobs:
           set -ex
           softhsm2-util --version
           ls -l $HSM_PKCS11_LIBRARY_PATH
-          softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
+          softhsm2-util --init-token --slot 0 --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
           pkcs11-tool -L --module $HSM_PKCS11_LIBRARY_PATH
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -125,16 +125,28 @@ jobs:
       #    echo "PKCS11_TOOL=/Library/OpenSC/bin/pkcs11-tool" >>$GITHUB_ENV
       #    #echo "PKCS11_MODULE=/Library/OpenSC/lib/opensc-pkcs11.so" >>$GITHUB_ENV
 
-      - name: Run Integration Tests with SoftHSM
+      - name: Set up SoftHSM
         run: |
           set -ex
           softhsm2-util --version
           ls -l $HSM_PKCS11_LIBRARY_PATH
           softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
+          pkcs11-tool -L
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-token-slots
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot-index $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
+          pkcs11-tool -L
+        env:
+          RUST_BACKTRACE: 1
+          HSM_PKCS11_LIBRARY_PATH: ${{ env.INSTALLED_PKCS11_SOFTHSM_MODULE }}
+          HSM_SO_PIN: 123456
+          HSM_PIN: 1234
+          HSM_SLOT: 0
+          HSM_KEY_ID: abcdef
+
+      - name: Run Integration Tests with SoftHSM
+        run: |
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
           sleep 1
           export IC_REF_PORT=$(cat $HOME/ic_ref_port)

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v2
         run:|
           sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ eoan universe"
-          sudo apt-get install -f libsofthsm2
+          sudo apt-get install -f libsofthsm2 opensc-pkcs11
           sudo usermod -a -G softhsm $USER
           echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/lib/softhsm/libsofthsm2.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -111,15 +111,15 @@ jobs:
         run: |
           sudo apt-get install -f libsofthsm2 opensc-pkcs11
           sudo usermod -a -G softhsm $USER
-          echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/lib/softhsm/libsofthsm2.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/lib/softhsm/libsofthsm2.so" >>$GITHUB_ENV
 
       - name: Install SoftHSM Macos
         #if: matrix.config.os == 'macos-latest'
         run: |
           brew install -f softhsm opensc
-          echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/local/lib/softhsm/libsofthsm2.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "PKCS11_TOOL=/Library/OpenSC/bin/pkcs11-tool" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          #echo "PKCS11_MODULE=/Library/OpenSC/lib/opensc-pkcs11.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/local/lib/softhsm/libsofthsm2.so" >>$GITHUB_ENV
+          echo "PKCS11_TOOL=/Library/OpenSC/bin/pkcs11-tool" >>$GITHUB_ENV
+          #echo "PKCS11_MODULE=/Library/OpenSC/lib/opensc-pkcs11.so" >>$GITHUB_ENV
 
       - name: Run Integration Tests with SoftHSM
         run: |

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           set -ex
           softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
-          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --test
+          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --test --pin $HSM_PIN
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --slot $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
           sleep 1

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -106,8 +106,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Install SoftHSM (linux)
-        if: matrix.config.build = 'linux-stable'
-        uses: actions/checkout@v2
+        if: matrix.config.build == 'linux-stable'
         run:|
           sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ eoan universe"
           sudo apt-get install -f libsofthsm2 opensc-pkcs11
@@ -115,8 +114,7 @@ jobs:
           echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/lib/softhsm/libsofthsm2.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Install SoftHSM (macos)
-        if: matrix.config.os = 'macos-latest'
-        uses: actions/checkout@v2
+        if: matrix.config.os == 'macos-latest'
         run:|
           brew install -f softhsm opensc
           echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/local/lib/softhsm/libsofthsm2.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -125,7 +125,7 @@ jobs:
       #    echo "PKCS11_TOOL=/Library/OpenSC/bin/pkcs11-tool" >>$GITHUB_ENV
       #    #echo "PKCS11_MODULE=/Library/OpenSC/lib/opensc-pkcs11.so" >>$GITHUB_ENV
 
-      - name: Set up SoftHSM
+      - name: Run Integration Tests with SoftHSM
         run: |
           set -ex
           softhsm2-util --version
@@ -135,18 +135,10 @@ jobs:
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-token-slots
-          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot-index $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
+          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot-index 0 -d aaaaaa --key-type EC:prime256v1 --pin $HSM_PIN
+          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot-index 1 -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
           pkcs11-tool -L --module $HSM_PKCS11_LIBRARY_PATH
-        env:
-          RUST_BACKTRACE: 1
-          HSM_PKCS11_LIBRARY_PATH: ${{ env.INSTALLED_PKCS11_SOFTHSM_MODULE }}
-          HSM_SO_PIN: 123456
-          HSM_PIN: 1234
-          HSM_SLOT: 0
-          HSM_KEY_ID: abcdef
 
-      - name: Run Integration Tests with SoftHSM
-        run: |
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
           sleep 1
           export IC_REF_PORT=$(cat $HOME/ic_ref_port)
@@ -160,7 +152,7 @@ jobs:
           HSM_PKCS11_LIBRARY_PATH: ${{ env.INSTALLED_PKCS11_SOFTHSM_MODULE }}
           HSM_SO_PIN: 123456
           HSM_PIN: 1234
-          HSM_SLOT: 0
+          HSM_SLOT: 1
           HSM_KEY_ID: abcdef
 
       - name: Run Doc Tests

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -129,6 +129,7 @@ jobs:
         run: |
           set -ex
           softhsm2-util --version
+          ls -l $HSM_PKCS11_LIBRARY_PATH
           softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots
@@ -140,7 +141,7 @@ jobs:
           export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
           export IC_WALLET_CANISTER_PATH=$HOME/wallet.wasm
           cd main/ref-tests
-          cargo test --all-features -- --ignored --nocapture
+          cargo test --all-features -- --ignored --nocapture --test-threads=1
           killall ic-ref
         env:
           RUST_BACKTRACE: 1

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -105,11 +105,11 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
-      - name: Install SoftHSM Linux
+      - name: Install and Configure SoftHSM
         run: |
+          set -ex
           sudo apt-get install -f libsofthsm2 opensc-pkcs11 opensc
           sudo usermod -a -G softhsm $USER
-          echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/lib/softhsm/libsofthsm2.so" >>$GITHUB_ENV
           echo "SOFTHSM2_CONF=$HOME/softhsm.conf" >>$GITHUB_ENV
           echo "directories.tokendir = $HOME/softhsm/tokens/" >$HOME/softhsm.conf
           mkdir -p $HOME/softhsm/tokens
@@ -131,7 +131,7 @@ jobs:
           killall ic-ref
         env:
           RUST_BACKTRACE: 1
-          HSM_PKCS11_LIBRARY_PATH: ${{ env.INSTALLED_PKCS11_SOFTHSM_MODULE }}
+          HSM_PKCS11_LIBRARY_PATH: /usr/lib/softhsm/libsofthsm2.so
           HSM_SO_PIN: 123456
           HSM_PIN: 1234
           HSM_SLOT_INDEX: 0

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -105,23 +105,23 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
-      - name: Install SoftHSM (linux)
-        if: matrix.config.build == 'linux-stable'
-        run:|
+      - name: Install SoftHSM Linux
+        #if: matrix.config.build == 'linux-stable'
+        run: |
           sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ eoan universe"
           sudo apt-get install -f libsofthsm2 opensc-pkcs11
           sudo usermod -a -G softhsm $USER
           echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/lib/softhsm/libsofthsm2.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Install SoftHSM (macos)
-        if: matrix.config.os == 'macos-latest'
-        run:|
+      - name: Install SoftHSM Macos
+        #if: matrix.config.os == 'macos-latest'
+        run: |
           brew install -f softhsm opensc
           echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/local/lib/softhsm/libsofthsm2.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "PKCS11_TOOL=/Library/OpenSC/bin/pkcs11-tool" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           #echo "PKCS11_MODULE=/Library/OpenSC/lib/opensc-pkcs11.so" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Run Integration Tests (SoftHSM)
+      - name: Run Integration Tests with SoftHSM
         run: |
           set -ex
           softhsm2-util --init-token --slot 0 --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
@@ -139,7 +139,6 @@ jobs:
           HSM_PKCS11_LIBRARY_PATH: ${{ env.INSTALLED_PKCS11_SOFTHSM_MODULE }}
           HSM_SO_PIN: 123456
           HSM_PIN: 1234
-
 
       - name: Run Doc Tests
         run: |

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -112,6 +112,9 @@ jobs:
           sudo apt-get install -f libsofthsm2 opensc-pkcs11
           sudo usermod -a -G softhsm $USER
           echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/lib/softhsm/libsofthsm2.so" >>$GITHUB_ENV
+          echo "SOFTHSM2_CONF=$HOME/softhsm.conf" >>$GITHUB_ENV
+          echo "directories.tokendir = $HOME/softhsm/tokens/" >$HOME/softhsm.conf
+          mkdir -p $HOME/softhsm/tokens
 
       # ic-ref test only run on linux
       #- name: Install SoftHSM Macos

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -113,13 +113,14 @@ jobs:
           sudo usermod -a -G softhsm $USER
           echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/lib/softhsm/libsofthsm2.so" >>$GITHUB_ENV
 
-      - name: Install SoftHSM Macos
-        #if: matrix.config.os == 'macos-latest'
-        run: |
-          brew install -f softhsm opensc
-          echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/local/lib/softhsm/libsofthsm2.so" >>$GITHUB_ENV
-          echo "PKCS11_TOOL=/Library/OpenSC/bin/pkcs11-tool" >>$GITHUB_ENV
-          #echo "PKCS11_MODULE=/Library/OpenSC/lib/opensc-pkcs11.so" >>$GITHUB_ENV
+      # ic-ref test only run on linux
+      #- name: Install SoftHSM Macos
+      #  if: matrix.config.os == 'macos-latest'
+      #  run: |
+      #    brew install -f softhsm opensc
+      #    echo "INSTALLED_PKCS11_SOFTHSM_MODULE=/usr/local/lib/softhsm/libsofthsm2.so" >>$GITHUB_ENV
+      #    echo "PKCS11_TOOL=/Library/OpenSC/bin/pkcs11-tool" >>$GITHUB_ENV
+      #    #echo "PKCS11_MODULE=/Library/OpenSC/lib/opensc-pkcs11.so" >>$GITHUB_ENV
 
       - name: Run Integration Tests with SoftHSM
         run: |

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -132,7 +132,7 @@ jobs:
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-token-slots
-          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
+          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot-index $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
           sleep 1
           export IC_REF_PORT=$(cat $HOME/ic_ref_port)

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -130,7 +130,7 @@ jobs:
           set -ex
           softhsm2-util --init-token --slot $HSM_SLOT --label "agent-rs-token" --so-pin $HSM_SO_PIN --pin $HSM_PIN
           pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --test --pin $HSM_PIN
-          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --slot $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
+          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot $HSM_SLOT -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
           sleep 1
           export IC_REF_PORT=$(cat $HOME/ic_ref_port)

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - build: linux-stable
             ghc: '8.8.4'
-            spec: '0.14.0'
+            spec: '0.15.0'
             os: ubuntu-latest
             rust: 1.47.0
 

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -130,14 +130,12 @@ jobs:
           set -ex
           softhsm2-util --version
           ls -l $HSM_PKCS11_LIBRARY_PATH
-          softhsm2-util --init-token --slot 0 --label "agent-rs-token-0" --so-pin $HSM_SO_PIN --pin $HSM_PIN
-          softhsm2-util --init-token --slot 1 --label "agent-rs-token-1" --so-pin $HSM_SO_PIN --pin $HSM_PIN
+          softhsm2-util --init-token --slot $HSM_SLOT_INDEX --label "agent-rs-token-0" --so-pin $HSM_SO_PIN --pin $HSM_PIN
           pkcs11-tool -L --module $HSM_PKCS11_LIBRARY_PATH
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --test
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-slots
           #pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH --login --pin $HSM_PIN --list-token-slots
-          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot-index 0 -d aaaaaa --key-type EC:prime256v1 --pin $HSM_PIN
-          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot-index 1 -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
+          pkcs11-tool --module $HSM_PKCS11_LIBRARY_PATH -k --login --slot-index $HSM_SLOT_INDEX -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
           pkcs11-tool -L --module $HSM_PKCS11_LIBRARY_PATH
 
           $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
@@ -153,7 +151,7 @@ jobs:
           HSM_PKCS11_LIBRARY_PATH: ${{ env.INSTALLED_PKCS11_SOFTHSM_MODULE }}
           HSM_SO_PIN: 123456
           HSM_PIN: 1234
-          HSM_SLOT: 1
+          HSM_SLOT_INDEX: 0
           HSM_KEY_ID: abcdef
 
       - name: Run Doc Tests

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -103,24 +103,6 @@ impl HardwareIdentity {
             public_key,
         })
     }
-
-    // create an ECDSA key to be later used with the new() function.
-    pub fn create_key<P, PinFn>(
-        pkcs11_lib_path: P,
-        slot_id: CK_SLOT_ID,
-        key_id: &str,
-        pin_fn: PinFn,
-    ) -> Result<(), HardwareIdentityError>
-    where
-        P: AsRef<Path>,
-        PinFn: FnOnce() -> Result<String, String>,
-    {
-        let ctx = Ctx::new_and_initialize(pkcs11_lib_path)?;
-        let session_handle = open_session(&ctx, slot_id)?;
-        let logged_in = login_if_required(&ctx, session_handle, pin_fn, slot_id)?;
-        let key_id = str_to_key_id(key_id)?;
-        Ok(())
-    }
 }
 
 impl Identity for HardwareIdentity {

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -92,19 +92,13 @@ impl HardwareIdentity {
         P: AsRef<Path>,
         PinFn: FnOnce() -> Result<String, String>,
     {
-        println!("Ctx::new_and_initialize...");
         let ctx = Ctx::new_and_initialize(pkcs11_lib_path)?;
-        println!("get_slot_id...");
         let slot_id = get_slot_id(&ctx, slot_index)?;
-        println!("open_session...");
         let session_handle = open_session(&ctx, slot_id)?;
-        println!("login_if_required...");
         let logged_in = login_if_required(&ctx, session_handle, pin_fn, slot_id)?;
         let key_id = str_to_key_id(key_id)?;
-        println!("get_der_encoded_public_key...");
         let public_key = get_der_encoded_public_key(&ctx, session_handle, &key_id)?;
 
-        println!("return HardwareIdentity.");
         Ok(HardwareIdentity {
             key_id,
             ctx,
@@ -164,9 +158,7 @@ where
     let login_required = token_info.flags & CKF_LOGIN_REQUIRED != 0;
 
     if login_required {
-        println!("call pin_fn...");
         let pin = pin_fn().map_err(HardwareIdentityError::UserPinRequired)?;
-        println!("ctx.login()...");
         ctx.login(session_handle, CKU_USER, Some(&pin))?;
     }
     Ok(login_required)

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -125,8 +125,7 @@ impl Identity for HardwareIdentity {
 }
 
 fn get_slot_id(ctx: &Ctx, slot_index: usize) -> Result<CK_SLOT_ID, HardwareIdentityError> {
-    let slots = ctx.get_slot_list(true)?;
-    slots
+    ctx.get_slot_list(true)?
         .get(slot_index)
         .ok_or(HardwareIdentityError::NoSuchSlotIndex(slot_index))
         .map(|x| *x)

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -103,6 +103,24 @@ impl HardwareIdentity {
             public_key,
         })
     }
+
+    // create an ECDSA key to be later used with the new() function.
+    pub fn create_key<P, PinFn>(
+        pkcs11_lib_path: P,
+        slot_id: CK_SLOT_ID,
+        key_id: &str,
+        pin_fn: PinFn,
+    ) -> Result<(), HardwareIdentityError>
+    where
+        P: AsRef<Path>,
+        PinFn: FnOnce() -> Result<String, String>,
+    {
+        let ctx = Ctx::new_and_initialize(pkcs11_lib_path)?;
+        let session_handle = open_session(&ctx, slot_id)?;
+        let logged_in = login_if_required(&ctx, session_handle, pin_fn, slot_id)?;
+        let key_id = str_to_key_id(key_id)?;
+        Ok(())
+    }
 }
 
 impl Identity for HardwareIdentity {

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -64,7 +64,7 @@ pub enum HardwareIdentityError {
     UserPinRequired(String),
 
     #[error("No such slot index ({0}")]
-    NoSuchSlotIndex(usize)
+    NoSuchSlotIndex(usize),
 }
 
 /// An identity based on an HSM
@@ -132,8 +132,10 @@ impl Identity for HardwareIdentity {
 
 fn get_slot_id(ctx: &Ctx, slot_index: usize) -> Result<CK_SLOT_ID, HardwareIdentityError> {
     let slots = ctx.get_slot_list(true)?;
-    slots.get(slot_index).ok_or(HardwareIdentityError::NoSuchSlotIndex(slot_index))
-        .map(|x|x.clone())
+    slots
+        .get(slot_index)
+        .ok_or(HardwareIdentityError::NoSuchSlotIndex(slot_index))
+        .map(|x| x.clone())
 }
 
 // We open a session for the duration of the lifetime of the HardwareIdentity.

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -89,12 +89,17 @@ impl HardwareIdentity {
         P: AsRef<Path>,
         PinFn: FnOnce() -> Result<String, String>,
     {
+        println!("Ctx::new_and_initialize...");
         let ctx = Ctx::new_and_initialize(pkcs11_lib_path)?;
+        println!("open_session...");
         let session_handle = open_session(&ctx, slot_id)?;
+        println!("login_if_required...");
         let logged_in = login_if_required(&ctx, session_handle, pin_fn, slot_id)?;
         let key_id = str_to_key_id(key_id)?;
+        println!("get_der_encoded_public_key...");
         let public_key = get_der_encoded_public_key(&ctx, session_handle, &key_id)?;
 
+        println!("return HardwareIdentity.");
         Ok(HardwareIdentity {
             key_id,
             ctx,
@@ -146,7 +151,9 @@ where
     let login_required = token_info.flags & CKF_LOGIN_REQUIRED != 0;
 
     if login_required {
+        println!("call pin_fn...");
         let pin = pin_fn().map_err(HardwareIdentityError::UserPinRequired)?;
+        println!("ctx.login()...");
         ctx.login(session_handle, CKU_USER, Some(&pin))?;
     }
     Ok(login_required)

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -135,7 +135,7 @@ fn get_slot_id(ctx: &Ctx, slot_index: usize) -> Result<CK_SLOT_ID, HardwareIdent
     slots
         .get(slot_index)
         .ok_or(HardwareIdentityError::NoSuchSlotIndex(slot_index))
-        .map(|x| x.clone())
+        .map(|x| *x)
 }
 
 // We open a session for the duration of the lifetime of the HardwareIdentity.

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 candid = "0.6.12"
 delay = "0.3.0"
 ic-agent = { path = "../ic-agent" }
+ic-identity-hsm = { path = "../ic-identity-hsm" }
 ic-utils = { path = "../ic-utils", features = ["raw"] }
 openssl = "0.10.24"
 ring = "0.16.11"

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -47,7 +47,7 @@ pub async fn create_hsm_identity() -> Result<HardwareIdentity, String> {
     let path = expect_env_var(HSM_PKCS11_LIBRARY_PATH)?;
     let slot_index = expect_env_var(HSM_SLOT_INDEX)?
         .parse::<usize>()
-        .map_err(|e|format!("Unable to parse {} value: {}", HSM_SLOT_INDEX, e))?;
+        .map_err(|e| format!("Unable to parse {} value: {}", HSM_SLOT_INDEX, e))?;
     let key = expect_env_var(HSM_KEY_ID)?;
     HardwareIdentity::new(path, slot_index, &key, get_hsm_pin)
         .map_err(|e| format!("Unable to create hw identity: {}", e))

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -34,7 +34,8 @@ pub async fn create_hsm_identity() -> Result<HardwareIdentity, String> {
     let key =
         std::env::var("HSM_KEY_ID").expect("Need to specify the HSM_KEY_ID environment variable");
     HardwareIdentity::new(path, slot, &key, get_hsm_pin)
-        .map_err(|e| format!("Unable to create hw identity: {}", e))
+        .map_err(|_|"unable to create hw identity".into())
+        //.map_err(|e| format!("Unable to create hw identity: {}", e))
 }
 
 fn get_hsm_pin() -> Result<String, String> {

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -32,7 +32,8 @@ pub async fn create_hsm_identity() -> Result<HardwareIdentity, String> {
         .expect("Need to specify the HSM_PKCS11_LIBRARY_PATH environment variable");
     let slot_index = std::env::var("HSM_SLOT_INDEX")
         .expect("Need to specify the HSM_SLOT_INDEX environment variable");
-    let slot_index = slot_index.parse::<usize>()
+    let slot_index = slot_index
+        .parse::<usize>()
         .expect("Unable to parse HSM_SLOT_INDEX value");
     let key =
         std::env::var("HSM_KEY_ID").expect("Need to specify the HSM_KEY_ID environment variable");

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -34,8 +34,8 @@ pub async fn create_hsm_identity() -> Result<HardwareIdentity, String> {
     let key =
         std::env::var("HSM_KEY_ID").expect("Need to specify the HSM_KEY_ID environment variable");
     HardwareIdentity::new(path, slot, &key, get_hsm_pin)
-        .map_err(|_| "unable to create hw identity".into())
-    //.map_err(|e| format!("Unable to create hw identity: {}", e))
+        //.map_err(|_| "unable to create hw identity".into())
+        .map_err(|e| format!("Unable to create hw identity: {}", e))
 }
 
 fn get_hsm_pin() -> Result<String, String> {

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -32,7 +32,8 @@ pub async fn create_hsm_identity() -> Result<HardwareIdentity, String> {
         .expect("Need to specify the HSM_PKCS11_LIBRARY_PATH environment variable");
     let slot_index = std::env::var("HSM_SLOT_INDEX")
         .expect("Need to specify the HSM_SLOT_INDEX environment variable");
-    let slot_index = slot_index.into();
+    let slot_index = slot_index.parse::<usize>()
+        .expect("Unable to parse HSM_SLOT_INDEX value");
     let key =
         std::env::var("HSM_KEY_ID").expect("Need to specify the HSM_KEY_ID environment variable");
     HardwareIdentity::new(path, slot_index, &key, get_hsm_pin)

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -18,7 +18,7 @@ pub fn create_waiter() -> Delay {
 }
 
 pub async fn create_identity() -> Result<Box<dyn Identity + Send + Sync>, String> {
-    if std::env::var("HSM_PKCS11_LIBRARY_PATHX").is_ok() {
+    if std::env::var("HSM_PKCS11_LIBRARY_PATH").is_ok() {
         let hsm = create_hsm_identity().await?;
         Ok(Box::new(hsm))
     } else {

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -18,12 +18,12 @@ pub fn create_waiter() -> Delay {
 }
 
 pub async fn create_identity() -> Result<Box<dyn Identity + Send + Sync>, String> {
-    if std::env::var("HSM_PKCS11_LIBRARY_PATH").is_ok() {
-        let id = create_hsm_identity().await?;
-        Ok(Box::new(id))
+    if std::env::var("HSM_PKCS11_LIBRARY_PATHX").is_ok() {
+        let hsm = create_hsm_identity().await?;
+        Ok(Box::new(hsm))
     } else {
-        let id = create_basic_identity().await?;
-        Ok(Box::new(id))
+        let basic = create_basic_identity().await?;
+        Ok(Box::new(basic))
     }
 }
 

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -30,10 +30,12 @@ pub async fn create_identity() -> Result<Box<dyn Identity + Send + Sync>, String
 pub async fn create_hsm_identity() -> Result<HardwareIdentity, String> {
     let path = std::env::var("HSM_PKCS11_LIBRARY_PATH")
         .expect("Need to specify the HSM_PKCS11_LIBRARY_PATH environment variable");
-    let slot = 0;
+    let slot_index = std::env::var("HSM_SLOT_INDEX")
+        .expect("Need to specify the HSM_SLOT_INDEX environment variable");
+    let slot_index = slot_index.into();
     let key =
         std::env::var("HSM_KEY_ID").expect("Need to specify the HSM_KEY_ID environment variable");
-    HardwareIdentity::new(path, slot, &key, get_hsm_pin)
+    HardwareIdentity::new(path, slot_index, &key, get_hsm_pin)
         //.map_err(|_| "unable to create hw identity".into())
         .map_err(|e| format!("Unable to create hw identity: {}", e))
 }

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -34,8 +34,8 @@ pub async fn create_hsm_identity() -> Result<HardwareIdentity, String> {
     let key =
         std::env::var("HSM_KEY_ID").expect("Need to specify the HSM_KEY_ID environment variable");
     HardwareIdentity::new(path, slot, &key, get_hsm_pin)
-        .map_err(|_|"unable to create hw identity".into())
-        //.map_err(|e| format!("Unable to create hw identity: {}", e))
+        .map_err(|_| "unable to create hw identity".into())
+    //.map_err(|e| format!("Unable to create hw identity: {}", e))
 }
 
 fn get_hsm_pin() -> Result<String, String> {

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -1,13 +1,14 @@
 use delay::Delay;
 use ic_agent::export::Principal;
 use ic_agent::identity::BasicIdentity;
-use ic_agent::Agent;
+use ic_agent::{Agent, Identity};
 use ic_utils::call::AsyncCall;
 use ic_utils::interfaces::ManagementCanister;
 use ring::signature::Ed25519KeyPair;
 use std::error::Error;
 use std::future::Future;
 use std::path::Path;
+use ic_identity_hsm::HardwareIdentity;
 
 pub fn create_waiter() -> Delay {
     Delay::builder()
@@ -16,7 +17,32 @@ pub fn create_waiter() -> Delay {
         .build()
 }
 
-pub async fn create_identity() -> Result<BasicIdentity, String> {
+pub async fn create_identity() -> Result<Box<dyn Identity + Send + Sync>, String> {
+    if std::env::var("HSM_PKCS11_LIBRARY_PATH").is_ok() {
+        let id = create_hsm_identity().await?;
+        Ok(Box::new(id))
+    } else {
+        let id = create_basic_identity().await?;
+        Ok(Box::new(id))
+    }
+}
+
+pub async fn create_hsm_identity() -> Result<HardwareIdentity, String> {
+    let path = std::env::var("HSM_PKCS11_LIBRARY_PATH")
+        .expect("Need to specify the HSM_PKCS11_LIBRARY_PATH environment variable");
+    let slot = 0;
+    let key = std::env::var("HSM_KEY_ID")
+        .expect("Need to specify the HSM_KEY_ID environment variable");
+    HardwareIdentity::new(path, slot, &key, get_hsm_pin)
+        .map_err(|e|format!("Unable to create hw identity: {}", e))
+}
+
+fn get_hsm_pin() -> Result<String, String> {
+    std::env::var("HSM_PIN")
+        .map_err(|_| "There is no HSM_PIN environment variable.".to_string())
+}
+
+pub async fn create_basic_identity() -> Result<BasicIdentity, String> {
     let rng = ring::rand::SystemRandom::new();
     let key_pair = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng)
         .expect("Could not generate a key pair.");
@@ -26,7 +52,7 @@ pub async fn create_identity() -> Result<BasicIdentity, String> {
     ))
 }
 
-pub async fn create_agent(identity: BasicIdentity) -> Result<Agent, String> {
+pub async fn create_agent(identity: Box<dyn Identity + Send + Sync>) -> Result<Agent, String> {
     let port_env = std::env::var("IC_REF_PORT")
         .expect("Need to specify the IC_REF_PORT environment variable.");
     let port = port_env
@@ -35,7 +61,7 @@ pub async fn create_agent(identity: BasicIdentity) -> Result<Agent, String> {
 
     Agent::builder()
         .with_url(format!("http://127.0.0.1:{}", port))
-        .with_identity(identity)
+        .with_boxed_identity(identity)
         .build()
         .map_err(|e| format!("{:?}", e))
 }

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 const HSM_PKCS11_LIBRARY_PATH: &str = "HSM_PKCS11_LIBRARY_PATH";
 const HSM_SLOT_INDEX: &str = "HSM_SLOT_INDEX";
 const HSM_KEY_ID: &str = "HSM_KEY_ID";
+const HSM_PIN: &str = "HSM_PIN";
 
 pub fn create_waiter() -> Delay {
     Delay::builder()
@@ -46,14 +47,14 @@ pub async fn create_hsm_identity() -> Result<HardwareIdentity, String> {
     let path = expect_env_var(HSM_PKCS11_LIBRARY_PATH)?;
     let slot_index = expect_env_var(HSM_SLOT_INDEX)?
         .parse::<usize>()
-        .expect("Unable to parse HSM_SLOT_INDEX value");
+        .map_err(|e|format!("Unable to parse {} value: {}", HSM_SLOT_INDEX, e))?;
     let key = expect_env_var(HSM_KEY_ID)?;
     HardwareIdentity::new(path, slot_index, &key, get_hsm_pin)
         .map_err(|e| format!("Unable to create hw identity: {}", e))
 }
 
 fn get_hsm_pin() -> Result<String, String> {
-    std::env::var("HSM_PIN").map_err(|_| "There is no HSM_PIN environment variable.".to_string())
+    expect_env_var(HSM_PIN)
 }
 
 pub async fn create_basic_identity() -> Result<BasicIdentity, String> {

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -2,13 +2,13 @@ use delay::Delay;
 use ic_agent::export::Principal;
 use ic_agent::identity::BasicIdentity;
 use ic_agent::{Agent, Identity};
+use ic_identity_hsm::HardwareIdentity;
 use ic_utils::call::AsyncCall;
 use ic_utils::interfaces::ManagementCanister;
 use ring::signature::Ed25519KeyPair;
 use std::error::Error;
 use std::future::Future;
 use std::path::Path;
-use ic_identity_hsm::HardwareIdentity;
 
 pub fn create_waiter() -> Delay {
     Delay::builder()
@@ -31,15 +31,14 @@ pub async fn create_hsm_identity() -> Result<HardwareIdentity, String> {
     let path = std::env::var("HSM_PKCS11_LIBRARY_PATH")
         .expect("Need to specify the HSM_PKCS11_LIBRARY_PATH environment variable");
     let slot = 0;
-    let key = std::env::var("HSM_KEY_ID")
-        .expect("Need to specify the HSM_KEY_ID environment variable");
+    let key =
+        std::env::var("HSM_KEY_ID").expect("Need to specify the HSM_KEY_ID environment variable");
     HardwareIdentity::new(path, slot, &key, get_hsm_pin)
-        .map_err(|e|format!("Unable to create hw identity: {}", e))
+        .map_err(|e| format!("Unable to create hw identity: {}", e))
 }
 
 fn get_hsm_pin() -> Result<String, String> {
-    std::env::var("HSM_PIN")
-        .map_err(|_| "There is no HSM_PIN environment variable.".to_string())
+    std::env::var("HSM_PIN").map_err(|_| "There is no HSM_PIN environment variable.".to_string())
 }
 
 pub async fn create_basic_identity() -> Result<BasicIdentity, String> {

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -38,7 +38,6 @@ fn spec_compliance_claimed() {
 
 mod management_canister {
     use ic_agent::AgentError;
-    use ic_agent::Identity;
     use ic_utils::call::AsyncCall;
     use ic_utils::interfaces::management_canister::{CanisterStatus, InstallMode};
     use ic_utils::interfaces::ManagementCanister;

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -125,7 +125,7 @@ mod management_canister {
                 .await?;
 
             // Each agent has their own identity.
-            let other_agent_identity = create_identity().await?;
+            let other_agent_identity = create_identity(true).await?;
             let other_agent_principal = other_agent_identity.sender()?;
             let other_agent = create_agent(other_agent_identity).await?;
             other_agent.fetch_root_key().await?;
@@ -412,7 +412,7 @@ mod management_canister {
                 .await?;
 
             // Create another agent with different identity.
-            let other_agent_identity = create_identity().await?;
+            let other_agent_identity = create_identity(true).await?;
             let other_agent = create_agent(other_agent_identity).await?;
             other_agent.fetch_root_key().await?;
             let other_ic00 = ManagementCanister::create(&other_agent);

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -42,7 +42,9 @@ mod management_canister {
     use ic_utils::interfaces::management_canister::{CanisterStatus, InstallMode};
     use ic_utils::interfaces::ManagementCanister;
     use openssl::sha::Sha256;
-    use ref_tests::{create_agent, create_identity, create_waiter, with_agent};
+    use ref_tests::{
+        create_agent, create_basic_identity, create_identity, create_waiter, with_agent,
+    };
 
     mod create_canister {
         use super::{create_waiter, with_agent};
@@ -125,7 +127,7 @@ mod management_canister {
                 .await?;
 
             // Each agent has their own identity.
-            let other_agent_identity = create_identity(true).await?;
+            let other_agent_identity = create_basic_identity().await?;
             let other_agent_principal = other_agent_identity.sender()?;
             let other_agent = create_agent(other_agent_identity).await?;
             other_agent.fetch_root_key().await?;
@@ -412,7 +414,7 @@ mod management_canister {
                 .await?;
 
             // Create another agent with different identity.
-            let other_agent_identity = create_identity(true).await?;
+            let other_agent_identity = create_basic_identity().await?;
             let other_agent = create_agent(other_agent_identity).await?;
             other_agent.fetch_root_key().await?;
             let other_ic00 = ManagementCanister::create(&other_agent);

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -13,7 +13,7 @@
 use ref_tests::universal_canister;
 use ref_tests::with_agent;
 
-const EXPECTED_IC_API_VERSION: &str = "0.14.0";
+const EXPECTED_IC_API_VERSION: &str = "0.15.0";
 
 #[ignore]
 #[test]


### PR DESCRIPTION
Adds a test phase that runs the ic-ref tests, but using the SoftHSM library to create identities rather than using basic identities.

This suite runs serially, because the SoftHSM library was panicking.

I also ran into trouble with two tests that create two identities.  The second call to `Ctx::new_and_initialize` panicked, so I made these two tests use a basic identity for the second identity.

This change surfaced an error related to slot ids.  The HSMs that I have used to date had slot index = slot id, but the SoftHSM library assigns different slot IDs.  So now we look up the slot id for the given slot index.

Updated to ic-ref 0.15.0, which added support for ECDSA keys.

Companion sdk PR: [PR-1316](https://github.com/dfinity/sdk/pull/1316)
Fixes https://github.com/dfinity/agent-rs/issues/95
