### PR TITLE
feat: Make `AnonymousIdentity` public

### DIFF
--- a/ic-agent/src/identity/anonymous.rs
+++ b/ic-agent/src/identity/anonymous.rs
@@ -2,7 +2,7 @@ use crate::export::Principal;
 use crate::identity::Identity;
 use crate::Signature;
 
-pub(crate) struct AnonymousIdentity {}
+pub struct AnonymousIdentity;
 
 impl Identity for AnonymousIdentity {
     fn sender(&self) -> Result<Principal, String> {

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -3,6 +3,7 @@ use crate::export::Principal;
 
 pub(crate) mod anonymous;
 pub(crate) mod basic;
+pub use anonymous::AnonymousIdentity;
 pub use basic::{BasicIdentity, PemError};
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
As of https://github.com/dfinity-lab/dfinity/pull/8248, we've started using `agent-rs`
for our system tests. One of our tests needs the `AnonymousIdentity`.
Making it public here to allow for that usage.