### PR TITLE
feat: display request::Error message in AgentError

### DIFF
--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -27,7 +27,7 @@ pub enum AgentError {
     #[error("Cannot calculate a RequestID: {0}")]
     CannotCalculateRequestId(#[from] RequestIdError),
 
-    #[error("Could not reach the server")]
+    #[error("Could not reach the server: {0}")]
     ReqwestError(#[from] reqwest::Error),
 
     #[error("Candid returned an error: {0}")]


### PR DESCRIPTION
The fixed message (`Could not reach the server`) may be hiding different underlying problems.  For example, I am seeing Clients (and therefore Agents) get stuck in a state where every request returns "channel closed"