### PR TITLE
feat: add an http-request interface and icx-http-server bin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ members = [
     "ic-identity-hsm/",
     "ic-types/",
     "ic-utils/",
-    "icx",
+    "icx/",
+    "icx-http-server/",
     "ref-tests/",
 ]
 

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -44,7 +44,7 @@ optional = true
 candid = "0.6.15"
 mockito = "0.27.0"
 proptest = "0.9.5"
-tokio = "0.2.22"
+tokio = "1.2.0"
 
 [features]
 default = ["pem"]

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -44,7 +44,7 @@ optional = true
 candid = "0.6.15"
 mockito = "0.27.0"
 proptest = "0.9.5"
-tokio = "1.2.0"
+tokio = { version = "1.2.0", features = ["full"] }
 
 [features]
 default = ["pem"]

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -25,8 +25,8 @@ mime = "0.3.16"
 num-bigint = "0.3.1"
 openssl = "0.10.32"
 rand = "0.7.2"
-reqwest = { version = "0.10.4", features = [ "blocking", "json", "rustls-tls" ] }
-rustls = "0.18.0"
+reqwest = { version = "0.11", features = [ "blocking", "json", "rustls-tls" ] }
+rustls = "0.19.0"
 ring = { version = "0.16.11", features = ["std"] }
 serde = { version = "1.0.101", features = ["derive"] }
 serde_bytes = "0.11.2"

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -19,7 +19,7 @@ fn query() -> Result<(), AgentError> {
         .create();
 
     let agent = Agent::builder().with_url(&mockito::server_url()).build()?;
-    let mut runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
+    let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(async {
         agent
             .query_raw(&Principal::management_canister(), "main", &[], None)
@@ -37,7 +37,7 @@ fn query() -> Result<(), AgentError> {
 fn query_error() -> Result<(), AgentError> {
     let read_mock = mock("POST", "/api/v1/read").with_status(500).create();
     let agent = Agent::builder().with_url(&mockito::server_url()).build()?;
-    let mut runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
+    let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
 
     let result = runtime.block_on(async {
         agent
@@ -66,7 +66,7 @@ fn query_rejected() -> Result<(), AgentError> {
         .create();
 
     let agent = Agent::builder().with_url(&mockito::server_url()).build()?;
-    let mut runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
+    let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
 
     let result = runtime.block_on(async {
         agent
@@ -96,7 +96,7 @@ fn call_error() -> Result<(), AgentError> {
 
     let agent = Agent::builder().with_url(&mockito::server_url()).build()?;
 
-    let mut runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
+    let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(async {
         agent
             .update(&Principal::management_canister(), "greet")
@@ -130,7 +130,7 @@ fn status() -> Result<(), AgentError> {
         url: mockito::server_url(),
         ..Default::default()
     })?;
-    let mut runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
+    let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(async { agent.status().await });
 
     read_mock.assert();
@@ -156,7 +156,7 @@ fn status_okay() -> Result<(), AgentError> {
         url: mockito::server_url(),
         ..Default::default()
     })?;
-    let mut runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
+    let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(agent.status());
 
     read_mock.assert();
@@ -180,7 +180,7 @@ fn status_error() -> Result<(), AgentError> {
         url: mockito::server_url(),
         ..Default::default()
     })?;
-    let mut runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
+    let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(async { agent.status().await });
 
     assert!(result.is_err());

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -87,8 +87,6 @@ fn public_key_to_asn1_block(public_key: EcKey<Public>) -> Result<ASN1Block, Erro
 
 #[cfg(feature = "pem")]
 mod test {
-    use super::*;
-
     #[test]
     fn test_from_pem() {
         // IDENTITY_FILE was generated from the the following commands:

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -86,7 +86,10 @@ fn public_key_to_asn1_block(public_key: EcKey<Public>) -> Result<ASN1Block, Erro
 }
 
 #[cfg(feature = "pem")]
+#[cfg(test)]
 mod test {
+    use super::*;
+
     #[test]
     fn test_from_pem() {
         // IDENTITY_FILE was generated from the the following commands:

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0.20"
 
 [dev-dependencies]
 ring = "0.16.11"
-tokio = { version = "0.2.22", features = ["macros"] }
+tokio = { version = "1.2.0", features = ["full"] }
 
 [features]
 raw = []

--- a/ic-utils/src/interfaces.rs
+++ b/ic-utils/src/interfaces.rs
@@ -1,5 +1,7 @@
+pub mod http_request;
 pub mod management_canister;
 pub mod wallet;
 
+pub use http_request::HttpRequestCanister;
 pub use management_canister::ManagementCanister;
 pub use wallet::Wallet;

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -1,0 +1,68 @@
+use crate::call::SyncCall;
+use crate::canister::CanisterBuilder;
+use crate::Canister;
+use candid::{CandidType, Deserialize};
+use ic_agent::export::Principal;
+use ic_agent::Agent;
+use std::fmt::Debug;
+
+#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
+pub struct HttpRequestCanister;
+
+#[derive(CandidType, Deserialize)]
+pub struct HeaderField(pub String, pub String);
+
+#[derive(CandidType)]
+pub struct HttpRequest<'body> {
+    pub method: String,
+    pub url: String,
+    pub headers: Vec<HeaderField>,
+    pub body: &'body [u8],
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct HttpResponse {
+    pub status_code: u16,
+    pub headers: Vec<HeaderField>,
+    pub body: Vec<u8>,
+}
+
+impl HttpRequestCanister {
+    /// Create an instance of a [Canister] implementing the [HttpRequestCanister] interface
+    /// and pointing to the right Canister ID.
+    pub fn create(agent: &Agent, canister_id: Principal) -> Canister<HttpRequestCanister> {
+        Canister::builder()
+            .with_agent(agent)
+            .with_canister_id(canister_id)
+            .with_interface(HttpRequestCanister)
+            .build()
+            .unwrap()
+    }
+
+    /// Creating a CanisterBuilder with the right interface and Canister Id. This can
+    /// be useful, for example, for providing additional Builder information.
+    pub fn with_agent(agent: &Agent) -> CanisterBuilder<HttpRequestCanister> {
+        Canister::builder()
+            .with_agent(agent)
+            .with_interface(HttpRequestCanister)
+    }
+}
+
+impl<'agent> Canister<'agent, HttpRequestCanister> {
+    pub fn http_request<'canister: 'agent, M: Into<String>, U: Into<String>, B: AsRef<[u8]>>(
+        &'canister self,
+        method: M,
+        url: U,
+        headers: Vec<HeaderField>,
+        body: B,
+    ) -> impl 'agent + SyncCall<(HttpResponse,)> {
+        self.query_("http_request")
+            .with_arg(HttpRequest {
+                method: method.into(),
+                url: url.into(),
+                headers,
+                body: body.as_ref(),
+            })
+            .build()
+    }
+}

--- a/icx-http-server/Cargo.toml
+++ b/icx-http-server/Cargo.toml
@@ -14,7 +14,7 @@ hyper = { version = "0.14.4", features = ["full"] }
 ic-agent = { path = "../ic-agent" }
 ic-types = { path = "../ic-types" }
 ic-utils = { path = "../ic-utils" }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.2.0", features = ["full"] }
 serde = "1.0.115"
 serde_json = "1.0.57"
 url = "2.2.1"

--- a/icx-http-server/Cargo.toml
+++ b/icx-http-server/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "icx-http-server"
+version = "0.1.0"
+authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+candid = "0.6.15"
+clap = "3.0.0-beta.2"
+delay = "0.3.1"
+hyper = { version = "0.14.4", features = ["full"] }
+ic-agent = { path = "../ic-agent" }
+ic-types = { path = "../ic-types" }
+ic-utils = { path = "../ic-utils" }
+tokio = { version = "1", features = ["full"] }
+serde = "1.0.115"
+serde_json = "1.0.57"
+url = "2.2.1"

--- a/icx-http-server/README.md
+++ b/icx-http-server/README.md
@@ -1,0 +1,14 @@
+# `icx-http-server`
+A command line tool to use the `ic-agent` crate directly. It allows simple communication with
+the Internet Computer.
+
+## Installing `icx`
+To install `icx` you will have to build it locally, using `cargo`. Make a clone of this repository,
+then in it simply run `cargo build`:
+
+```sh
+git clone https://github.com/dfinity/agent-rust.git
+cd agent-rust
+cargo build
+```
+

--- a/icx-http-server/src/main.rs
+++ b/icx-http-server/src/main.rs
@@ -1,0 +1,272 @@
+use clap::{crate_authors, crate_version, AppSettings, Clap};
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{body, Body, Client, Request, Response, Server, StatusCode, Uri};
+use ic_agent::export::Principal;
+use ic_agent::Agent;
+use ic_utils::call::SyncCall;
+use ic_utils::interfaces::http_request::HeaderField;
+use ic_utils::interfaces::HttpRequestCanister;
+use std::convert::Infallible;
+use std::error::Error;
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clap)]
+#[clap(
+    version = crate_version!(),
+    author = crate_authors!(),
+    global_setting = AppSettings::GlobalVersion,
+    global_setting = AppSettings::ColoredHelp
+)]
+struct Opts {
+    /// The address to bind to.
+    #[clap(default_value = "127.0.0.1:3000")]
+    address: SocketAddr,
+
+    /// Some input. Because this isn't an Option<T> it's required to be used
+    #[clap(default_value = "http://localhost:8000/")]
+    replica: Vec<String>,
+
+    /// Whether or not this is run in a debug context (e.g. errors returned in responses
+    /// should show full stack and error details).
+    #[clap(long)]
+    debug: bool,
+}
+
+fn resolve_canister_id_from_hostname(hostname: &str) -> Option<Principal> {
+    let url = Uri::from_str(hostname).ok()?;
+
+    // Check if it's localhost or ic0.
+    match url.host()?.split('.').collect::<Vec<&str>>().as_slice() {
+        [.., maybe_canister_id, "localhost"] | [.., maybe_canister_id, "ic0", "app"] => {
+            match Principal::from_text(maybe_canister_id) {
+                Ok(canister_id) => return Some(canister_id),
+                _ => {}
+            }
+        }
+        _ => {}
+    };
+
+    None
+}
+
+fn resolve_canister_id_from_query(url: &hyper::Uri) -> Option<Principal> {
+    let (_, canister_id) = url::form_urlencoded::parse(url.query()?.as_bytes())
+        .find(|(name, _)| name == "canisterId")?;
+    Principal::from_text(canister_id.as_ref()).ok()
+}
+
+fn resolve_canister_id(request: &Request<Body>) -> Option<Principal> {
+    // Look for subdomains if there's a host header.
+    if let Some(host_header) = request.headers().get("Host") {
+        if let Ok(host) = host_header.to_str() {
+            if let Some(canister_id) = resolve_canister_id_from_hostname(host) {
+                return Some(canister_id);
+            }
+        }
+    }
+
+    // Look into the URI.
+    if let Some(canister_id) = resolve_canister_id_from_query(request.uri()) {
+        return Some(canister_id);
+    }
+
+    // Look into the request by header.
+    if let Some(referer_header) = request.headers().get("referer") {
+        if let Ok(referer) = referer_header.to_str() {
+            if let Ok(referer_uri) = hyper::Uri::from_str(referer) {
+                if let Some(canister_id) = resolve_canister_id_from_query(&referer_uri) {
+                    return Some(canister_id);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+async fn forward_request(
+    request: Request<Body>,
+    agent: Arc<Agent>,
+) -> Result<Response<Body>, Box<dyn Error>> {
+    let canister_id = match resolve_canister_id(&request) {
+        None => {
+            return Ok(Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body("Could not find a canister id to forward to.".into())
+                .unwrap())
+        }
+        Some(x) => x,
+    };
+
+    let method = request.method().to_string();
+    let uri = request.uri().clone();
+    let headers = request
+        .headers()
+        .into_iter()
+        .filter_map(|(name, value)| {
+            Some(HeaderField(
+                name.to_string(),
+                value.to_str().ok()?.to_string(),
+            ))
+        })
+        .collect();
+
+    let entire_body = body::to_bytes(request.into_body()).await?.to_vec();
+
+    HttpRequestCanister::create(agent.as_ref(), canister_id)
+        .http_request(method, uri.to_string(), headers, &entire_body)
+        .call()
+        .await
+        .map_err(Into::<Box<dyn Error>>::into)
+        .and_then(|(http_response,)| {
+            let mut builder =
+                Response::builder().status(StatusCode::from_u16(http_response.status_code)?);
+            for HeaderField(name, value) in http_response.headers {
+                builder = builder.header(&name, value);
+            }
+            Ok(builder.body(http_response.body.into())?)
+        })
+}
+
+fn is_hop_header(name: &str) -> bool {
+    name.to_ascii_lowercase() == "connection"
+        || name.to_ascii_lowercase() == "keep-alive"
+        || name.to_ascii_lowercase() == "proxy-authenticate"
+        || name.to_ascii_lowercase() == "proxy-authorization"
+        || name.to_ascii_lowercase() == "te"
+        || name.to_ascii_lowercase() == "trailers"
+        || name.to_ascii_lowercase() == "transfer-encoding"
+        || name.to_ascii_lowercase() == "upgrade"
+}
+
+/// Returns a clone of the headers without the [hop-by-hop headers].
+///
+/// [hop-by-hop headers]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+fn remove_hop_headers(
+    headers: &hyper::header::HeaderMap<hyper::header::HeaderValue>,
+) -> hyper::header::HeaderMap<hyper::header::HeaderValue> {
+    let mut result = hyper::HeaderMap::new();
+    for (k, v) in headers.iter() {
+        if !is_hop_header(k.as_str()) {
+            result.insert(k.clone(), v.clone());
+        }
+    }
+    result
+}
+use hyper::http::uri::Parts;
+
+fn forward_uri<B>(forward_url: &str, req: &Request<B>) -> Result<Uri, Box<dyn Error>> {
+    let uri = Uri::from_str(forward_url)?;
+    let mut parts = Parts::from(uri);
+    parts.path_and_query = req.uri().path_and_query().cloned();
+
+    Ok(Uri::from_parts(parts)?)
+}
+
+fn create_proxied_request<B>(
+    client_ip: &IpAddr,
+    forward_url: &str,
+    mut request: Request<B>,
+) -> Result<Request<B>, Box<dyn Error>> {
+    *request.headers_mut() = remove_hop_headers(request.headers());
+    *request.uri_mut() = forward_uri(forward_url, &request)?;
+
+    let x_forwarded_for_header_name = "x-forwarded-for";
+
+    // Add forwarding information in the headers
+    match request.headers_mut().entry(x_forwarded_for_header_name) {
+        hyper::header::Entry::Vacant(entry) => {
+            entry.insert(client_ip.to_string().parse()?);
+        }
+
+        hyper::header::Entry::Occupied(mut entry) => {
+            let addr = format!("{}, {}", entry.get().to_str()?, client_ip);
+            entry.insert(addr.parse()?);
+        }
+    }
+
+    Ok(request)
+}
+
+async fn forward_api(
+    ip_addr: &IpAddr,
+    request: Request<Body>,
+    replica_url: &str,
+) -> Result<Response<Body>, Box<dyn Error>> {
+    let proxied_request = create_proxied_request(ip_addr, &replica_url, request)?;
+
+    let client = Client::new();
+    let response = client.request(proxied_request).await?;
+    Ok(response)
+}
+
+async fn handle_request(
+    ip_addr: IpAddr,
+    request: Request<Body>,
+    replica_url: String,
+    debug: bool,
+) -> Result<Response<Body>, Infallible> {
+    match if request.uri().path().starts_with("/api/") {
+        forward_api(&ip_addr, request, &replica_url).await
+    } else {
+        let agent = Arc::new(
+            ic_agent::Agent::builder()
+                .with_url(replica_url)
+                .build()
+                .expect("Could not create agent..."),
+        );
+
+        forward_request(request, agent).await
+    } {
+        Err(err) => Ok(Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(if debug {
+                format!("Internal Error: {:?}", err).into()
+            } else {
+                "Internal Server Error".into()
+            })
+            .unwrap()),
+        Ok(x) => Ok::<_, Infallible>(x),
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let opts: Opts = Opts::parse();
+
+    // Prepare a list of agents for each backend replicas.
+    let replicas = Mutex::new(opts.replica.clone());
+
+    let counter = AtomicUsize::new(0);
+    let debug = opts.debug;
+
+    let service = make_service_fn(|socket: &hyper::server::conn::AddrStream| {
+        let ip_addr = socket.remote_addr();
+        let ip_addr = ip_addr.ip().clone();
+
+        // Select an agent.
+        let replica_url_array = replicas.lock().unwrap();
+        let count = counter.fetch_add(1, Ordering::SeqCst);
+        let replica_url = replica_url_array
+            .get(count % replica_url_array.len())
+            .unwrap_or_else(|| unreachable!());
+        let replica_url = replica_url.clone();
+
+        async move {
+            Ok::<_, Infallible>(service_fn(move |req| {
+                handle_request(ip_addr, req, replica_url.clone(), debug)
+            }))
+        }
+    });
+
+    eprintln!("Starting server. Listening on http://{}/", opts.address);
+
+    let runtime = tokio::runtime::Runtime::new()?;
+    runtime.block_on(async {
+        let server = Server::bind(&opts.address).serve(service);
+        server.await?;
+        Ok(())
+    })
+}

--- a/icx-http-server/src/main.rs
+++ b/icx-http-server/src/main.rs
@@ -23,11 +23,11 @@ use std::sync::{Arc, Mutex};
 )]
 struct Opts {
     /// The address to bind to.
-    #[clap(default_value = "127.0.0.1:3000")]
+    #[clap(long, default_value = "127.0.0.1:3000")]
     address: SocketAddr,
 
     /// Some input. Because this isn't an Option<T> it's required to be used
-    #[clap(default_value = "http://localhost:8000/")]
+    #[clap(long, default_value = "http://localhost:8000/")]
     replica: Vec<String>,
 
     /// Whether or not this is run in a debug context (e.g. errors returned in responses

--- a/icx-http-server/src/main.rs
+++ b/icx-http-server/src/main.rs
@@ -42,9 +42,8 @@ fn resolve_canister_id_from_hostname(hostname: &str) -> Option<Principal> {
     // Check if it's localhost or ic0.
     match url.host()?.split('.').collect::<Vec<&str>>().as_slice() {
         [.., maybe_canister_id, "localhost"] | [.., maybe_canister_id, "ic0", "app"] => {
-            match Principal::from_text(maybe_canister_id) {
-                Ok(canister_id) => return Some(canister_id),
-                _ => {}
+            if let Ok(canister_id) = Principal::from_text(maybe_canister_id) {
+                return Some(canister_id);
             }
         }
         _ => {}
@@ -244,7 +243,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let service = make_service_fn(|socket: &hyper::server::conn::AddrStream| {
         let ip_addr = socket.remote_addr();
-        let ip_addr = ip_addr.ip().clone();
+        let ip_addr = ip_addr.ip();
 
         // Select an agent.
         let replica_url_array = replicas.lock().unwrap();

--- a/icx-http-server/src/main.rs
+++ b/icx-http-server/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{crate_authors, crate_version, AppSettings, Clap};
+use hyper::http::uri::Parts;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{body, Body, Client, Request, Response, Server, StatusCode, Uri};
 use ic_agent::export::Principal;
@@ -156,7 +157,6 @@ fn remove_hop_headers(
     }
     result
 }
-use hyper::http::uri::Parts;
 
 fn forward_uri<B>(forward_url: &str, req: &Request<B>) -> Result<Uri, Box<dyn Error>> {
     let uri = Uri::from_str(forward_url)?;

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -14,7 +14,7 @@ ic-utils = { path = "../ic-utils", features = ["raw"] }
 openssl = "0.10.24"
 ring = "0.16.11"
 serde = { version = "1.0.101", features = ["derive"] }
-tokio = "0.2.22"
+tokio = { version = "1.2.0", features = ["full"] }
 
 [dev-dependencies]
 serde_cbor = "0.11.1"


### PR DESCRIPTION
The icx-http-server is used to create a HTTP server which redirects every
requests to /api to the replica directly, and every other requests to an
http_request query call on the canister itself.

For the moment the design doc is private but will be added in this repo soon.