### PR TITLE
feat: add a ReplicaV1Facade trait to communicate with the replica

### DIFF
--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -19,13 +19,13 @@ base64 = "0.12.3"
 byteorder = "1.3.2"
 delay = "0.3.1"
 hex = "0.4.0"
+http = "0.2.3"
 ic-types = { path = "../ic-types", version = "0.1", features = [ "serde" ] }
 leb128 = "0.2.4"
 mime = "0.3.16"
 num-bigint = "0.3.1"
 openssl = "0.10.32"
 rand = "0.7.2"
-reqwest = { version = "0.11", features = [ "blocking", "json", "rustls-tls" ] }
 rustls = "0.19.0"
 ring = { version = "0.16.11", features = ["std"] }
 serde = { version = "1.0.101", features = ["derive"] }
@@ -35,6 +35,11 @@ simple_asn1 = "0.5.0"
 thiserror = "1.0.20"
 url = "2.1.0"
 webpki-roots = "0.20.0"
+
+[dependencies.reqwest]
+version = "0.11"
+features = [ "blocking", "json", "rustls-tls" ]
+optional = true
 
 [dependencies.pem]
 version = "0.8.1"
@@ -47,6 +52,6 @@ proptest = "0.9.5"
 tokio = { version = "1.2.0", features = ["full"] }
 
 [features]
-default = ["pem"]
+default = ["pem", "reqwest"]
 
 ic_ref_tests = ['default'] # Used to separate integration tests for ic-ref which need a server running.

--- a/ic-agent/src/agent/agent_config.rs
+++ b/ic-agent/src/agent/agent_config.rs
@@ -1,42 +1,23 @@
-use crate::agent::NonceFactory;
+use crate::agent::{NonceFactory, ReplicaV1Facade};
 use crate::identity::anonymous::AnonymousIdentity;
 use crate::identity::Identity;
-
-/// Implemented by the Agent environment to cache and update an HTTP Auth password.
-/// It returns a tuple of `(username, password)`.
-pub trait PasswordManager {
-    /// Retrieve the cached value for a user. If no cache value exists for this URL,
-    /// the manager can return [`None`].
-    fn cached(&self, url: &str) -> Result<Option<(String, String)>, String>;
-
-    /// A call to the replica failed, so in order to succeed a username and password
-    /// is required. If one cannot be provided (for example, there's no terminal),
-    /// this should return an error.
-    /// If the username and password provided by this method does not work (the next
-    /// request still returns UNAUTHORIZED), this will be called and the request will
-    /// be retried in a loop.
-    fn required(&self, url: &str) -> Result<(String, String), String>;
-}
+use std::sync::Arc;
 
 /// A configuration for an agent.
 pub struct AgentConfig {
-    pub url: String,
     pub nonce_factory: NonceFactory,
-    pub identity: Box<dyn Identity + Send + Sync>,
-    pub password_manager: Option<Box<dyn PasswordManager + Send + Sync>>,
+    pub identity: Arc<dyn Identity + Send + Sync>,
     pub ingress_expiry_duration: Option<std::time::Duration>,
+    pub facade: Option<Arc<dyn ReplicaV1Facade + Send + Sync>>,
 }
 
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
-            // Making sure this is invalid so users have to overwrite it before constructing
-            // the agent.
-            url: "-".to_owned(),
             nonce_factory: NonceFactory::random(),
-            identity: Box::new(AnonymousIdentity {}),
-            password_manager: None,
+            identity: Arc::new(AnonymousIdentity {}),
             ingress_expiry_duration: None,
+            facade: None,
         }
     }
 }

--- a/ic-agent/src/agent/agent_config.rs
+++ b/ic-agent/src/agent/agent_config.rs
@@ -1,4 +1,4 @@
-use crate::agent::{NonceFactory, ReplicaV1Facade};
+use crate::agent::{NonceFactory, ReplicaV1Transport};
 use crate::identity::anonymous::AnonymousIdentity;
 use crate::identity::Identity;
 use std::sync::Arc;
@@ -8,7 +8,7 @@ pub struct AgentConfig {
     pub nonce_factory: NonceFactory,
     pub identity: Arc<dyn Identity + Send + Sync>,
     pub ingress_expiry_duration: Option<std::time::Duration>,
-    pub facade: Option<Arc<dyn ReplicaV1Facade + Send + Sync>>,
+    pub transport: Option<Arc<dyn ReplicaV1Transport + Send + Sync>>,
 }
 
 impl Default for AgentConfig {
@@ -17,7 +17,7 @@ impl Default for AgentConfig {
             nonce_factory: NonceFactory::random(),
             identity: Arc::new(AnonymousIdentity {}),
             ingress_expiry_duration: None,
-            facade: None,
+            transport: None,
         }
     }
 }

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -100,11 +100,11 @@ pub enum AgentError {
     #[error("Failed to initialize the BLS library")]
     BlsInitializationFailure(),
 
-    #[error("Missing replica facade in the builder.")]
-    MissingReplicaFacade(),
+    #[error("Missing replica transport in the Agent Builder.")]
+    MissingReplicaTransport(),
 
     #[error("An error happened during communication with the replica: {0}")]
-    ReplicaV1FacadeError(Box<dyn std::error::Error + Send + Sync>),
+    TransportError(Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl PartialEq for AgentError {

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -1,3 +1,6 @@
+// Disable these tests without the reqwest feature.
+#![cfg(feature = "reqwest")]
+
 use crate::agent::replica_api::{CallReply, QueryResponse};
 use crate::agent::Status;
 use crate::export::Principal;

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -1,5 +1,5 @@
 use crate::agent::replica_api::{CallReply, QueryResponse};
-use crate::agent::{AgentConfig, Status};
+use crate::agent::Status;
 use crate::export::Principal;
 use crate::{Agent, AgentError};
 use mockito::mock;
@@ -126,10 +126,7 @@ fn status() -> Result<(), AgentError> {
         .with_body(serde_cbor::to_vec(&response)?)
         .create();
 
-    let agent = Agent::new(AgentConfig {
-        url: mockito::server_url(),
-        ..Default::default()
-    })?;
+    let agent = Agent::builder().with_url(mockito::server_url()).build()?;
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(async { agent.status().await });
 
@@ -152,10 +149,7 @@ fn status_okay() -> Result<(), AgentError> {
         .with_body(serde_cbor::to_vec(&response)?)
         .create();
 
-    let agent = Agent::new(AgentConfig {
-        url: mockito::server_url(),
-        ..Default::default()
-    })?;
+    let agent = Agent::builder().with_url(mockito::server_url()).build()?;
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(agent.status());
 
@@ -176,10 +170,7 @@ fn status_error() -> Result<(), AgentError> {
     // it is called.
     let _read_mock = mock("GET", "/api/v1/status").with_status(500).create();
 
-    let agent = Agent::new(AgentConfig {
-        url: mockito::server_url(),
-        ..Default::default()
-    })?;
+    let agent = Agent::builder().with_url(mockito::server_url()).build()?;
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(async { agent.status().await });
 

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -1,4 +1,3 @@
-use crate::agent::http_facade::ReqwestHttpReplicaV1Facade;
 use crate::agent::{AgentConfig, ReplicaV1Facade};
 use crate::{Agent, AgentError, Identity, NonceFactory};
 use std::sync::Arc;
@@ -25,6 +24,8 @@ impl AgentBuilder {
     #[cfg(feature = "reqwest")]
     #[deprecated(since = "0.3.0", note = "Prefer using with_facade now.")]
     pub fn with_url<S: Into<String>>(self, url: S) -> Self {
+        use crate::agent::http_facade::ReqwestHttpReplicaV1Facade;
+
         self.with_facade(ReqwestHttpReplicaV1Facade::create(url).unwrap())
     }
 

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -1,4 +1,4 @@
-use crate::agent::{AgentConfig, ReplicaV1Facade};
+use crate::agent::{AgentConfig, ReplicaV1Transport};
 use crate::{Agent, AgentError, Identity, NonceFactory};
 use std::sync::Arc;
 
@@ -22,18 +22,21 @@ impl AgentBuilder {
 
     /// Set the URL of the [Agent].
     #[cfg(feature = "reqwest")]
-    #[deprecated(since = "0.3.0", note = "Prefer using with_facade now.")]
+    #[deprecated(since = "0.3.0", note = "Prefer using with_transport().")]
     pub fn with_url<S: Into<String>>(self, url: S) -> Self {
-        use crate::agent::http_facade::ReqwestHttpReplicaV1Facade;
+        use crate::agent::http_transport::ReqwestHttpReplicaV1Transport;
 
-        self.with_facade(ReqwestHttpReplicaV1Facade::create(url).unwrap())
+        self.with_transport(ReqwestHttpReplicaV1Transport::create(url).unwrap())
     }
 
-    /// Set a Replica facade to talk to serve as the replica interface.
-    pub fn with_facade<F: 'static + ReplicaV1Facade + Send + Sync>(self, facade: F) -> Self {
+    /// Set a Replica transport to talk to serve as the replica interface.
+    pub fn with_transport<F: 'static + ReplicaV1Transport + Send + Sync>(
+        self,
+        transport: F,
+    ) -> Self {
         Self {
             config: AgentConfig {
-                facade: Some(Arc::new(facade)),
+                transport: Some(Arc::new(transport)),
                 ..self.config
             },
         }

--- a/ic-agent/src/agent/http_facade.rs
+++ b/ic-agent/src/agent/http_facade.rs
@@ -1,0 +1,208 @@
+//! A [ReplicaFacade] that connects using a reqwest client.
+// #![cfg(feature = "reqwest")]
+
+use crate::agent::agent_error::HttpErrorPayload;
+use crate::AgentError;
+use crate::RequestId;
+use reqwest::Method;
+use std::future::Future;
+use std::pin::Pin;
+
+/// Implemented by the Agent environment to cache and update an HTTP Auth password.
+/// It returns a tuple of `(username, password)`.
+pub trait PasswordManager {
+    /// Retrieve the cached value for a user. If no cache value exists for this URL,
+    /// the manager can return [`None`].
+    fn cached(&self, url: &str) -> Result<Option<(String, String)>, String>;
+
+    /// A call to the replica failed, so in order to succeed a username and password
+    /// is required. If one cannot be provided (for example, there's no terminal),
+    /// this should return an error.
+    /// If the username and password provided by this method does not work (the next
+    /// request still returns UNAUTHORIZED), this will be called and the request will
+    /// be retried in a loop.
+    fn required(&self, url: &str) -> Result<(String, String), String>;
+}
+
+/// A ReplicaV1Facade using Reqwest to make HTTP calls to the internet computer.
+pub struct ReqwestHttpReplicaV1Facade {
+    url: reqwest::Url,
+    client: reqwest::Client,
+    password_manager: Option<Box<dyn PasswordManager + Send + Sync>>,
+}
+
+impl ReqwestHttpReplicaV1Facade {
+    pub fn create<U: Into<String>>(url: U) -> Result<Self, AgentError> {
+        let mut tls_config = rustls::ClientConfig::new();
+
+        // Advertise support for HTTP/2
+        tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+        // Mozilla CA root store
+        tls_config
+            .root_store
+            .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+
+        let url = url.into();
+
+        Ok(Self {
+            url: reqwest::Url::parse(&url)
+                .and_then(|url| url.join("api/v1/"))
+                .map_err(|_| AgentError::InvalidReplicaUrl(url.clone()))?,
+            client: reqwest::Client::builder()
+                .use_preconfigured_tls(tls_config)
+                .build()
+                .expect("Could not create HTTP client."),
+            password_manager: None,
+        })
+    }
+
+    pub fn with_password_manager<P: 'static + PasswordManager + Send + Sync>(
+        self,
+        password_manager: P,
+    ) -> Self {
+        Self {
+            password_manager: Some(Box::new(password_manager)),
+            ..self
+        }
+    }
+
+    fn maybe_add_authorization(
+        &self,
+        http_request: &mut reqwest::Request,
+        cached: bool,
+    ) -> Result<(), AgentError> {
+        if let Some(pm) = &self.password_manager {
+            let maybe_user_pass = if cached {
+                pm.cached(http_request.url().as_str())
+            } else {
+                pm.required(http_request.url().as_str()).map(Some)
+            };
+
+            if let Some((u, p)) = maybe_user_pass.map_err(AgentError::AuthenticationError)? {
+                let auth = base64::encode(&format!("{}:{}", u, p));
+                http_request.headers_mut().insert(
+                    reqwest::header::AUTHORIZATION,
+                    format!("Basic {}", auth).parse().unwrap(),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    async fn request(
+        &self,
+        http_request: reqwest::Request,
+    ) -> Result<(reqwest::StatusCode, reqwest::header::HeaderMap, Vec<u8>), AgentError> {
+        let response = self
+            .client
+            .execute(
+                http_request
+                    .try_clone()
+                    .expect("Could not clone a request."),
+            )
+            .await
+            .map_err(|x| AgentError::ReplicaV1FacadeError(Box::new(x)))?;
+
+        let http_status = response.status();
+        let response_headers = response.headers().clone();
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|x| AgentError::ReplicaV1FacadeError(Box::new(x)))?
+            .to_vec();
+
+        Ok((http_status, response_headers, bytes))
+    }
+
+    async fn execute(
+        &self,
+        method: Method,
+        endpoint: &str,
+        body: Option<Vec<u8>>,
+    ) -> Result<Vec<u8>, AgentError> {
+        let url = self.url.join(endpoint)?;
+        let mut http_request = reqwest::Request::new(method, url);
+        http_request.headers_mut().insert(
+            reqwest::header::CONTENT_TYPE,
+            "application/cbor".parse().unwrap(),
+        );
+
+        self.maybe_add_authorization(&mut http_request, true)?;
+
+        *http_request.body_mut() = body.map(reqwest::Body::from);
+
+        let mut status;
+        let mut headers;
+        let mut body;
+        loop {
+            let request_result = self.request(http_request.try_clone().unwrap()).await?;
+            status = request_result.0;
+            headers = request_result.1;
+            body = request_result.2;
+
+            // If the server returned UNAUTHORIZED, and it is the first time we replay the call,
+            // check if we can get the username/password for the HTTP Auth.
+            if status == reqwest::StatusCode::UNAUTHORIZED {
+                if self.url.scheme() == "https" || self.url.host_str() == Some("localhost") {
+                    // If there is a password manager, get the username and password from it.
+                    self.maybe_add_authorization(&mut http_request, false)?;
+                } else {
+                    return Err(AgentError::CannotUseAuthenticationOnNonSecureUrl());
+                }
+            } else {
+                break;
+            }
+        }
+
+        if status.is_client_error() || status.is_server_error() {
+            Err(AgentError::HttpError(HttpErrorPayload {
+                status: status.into(),
+                content_type: headers
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|value| value.to_str().ok())
+                    .map(|x| x.to_string()),
+                content: body,
+            }))
+        } else {
+            Ok(body)
+        }
+    }
+}
+
+impl super::ReplicaV1Facade for ReqwestHttpReplicaV1Facade {
+    fn read<'a>(
+        &'a self,
+        envelope: Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>> {
+        async fn run(
+            s: &ReqwestHttpReplicaV1Facade,
+            envelope: Vec<u8>,
+        ) -> Result<Vec<u8>, AgentError> {
+            s.execute(Method::POST, "read", Some(envelope)).await
+        }
+
+        Box::pin(run(self, envelope))
+    }
+
+    fn submit<'a>(
+        &'a self,
+        envelope: Vec<u8>,
+        _request_id: RequestId,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AgentError>> + Send + 'a>> {
+        async fn run(s: &ReqwestHttpReplicaV1Facade, envelope: Vec<u8>) -> Result<(), AgentError> {
+            s.execute(Method::POST, "submit", Some(envelope)).await?;
+            Ok(())
+        }
+        Box::pin(run(self, envelope))
+    }
+
+    fn status<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>> {
+        async fn run(s: &ReqwestHttpReplicaV1Facade) -> Result<Vec<u8>, AgentError> {
+            s.execute(Method::GET, "status", None).await
+        }
+
+        Box::pin(run(self))
+    }
+}

--- a/ic-agent/src/agent/http_facade.rs
+++ b/ic-agent/src/agent/http_facade.rs
@@ -1,5 +1,5 @@
 //! A [ReplicaFacade] that connects using a reqwest client.
-// #![cfg(feature = "reqwest")]
+#![cfg(feature = "reqwest")]
 
 use crate::agent::agent_error::HttpErrorPayload;
 use crate::AgentError;

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -254,9 +254,7 @@ impl Agent {
         serializer.self_describe()?;
         envelope.serialize(&mut serializer)?;
 
-        self.facade
-            .submit(serialized_bytes, request_id.clone())
-            .await?;
+        self.facade.submit(serialized_bytes, request_id).await?;
         Ok(request_id)
     }
 

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1,21 +1,22 @@
 //! The main Agent module. Contains the [Agent] type and all associated structures.
 pub(crate) mod agent_config;
-pub(crate) mod agent_error;
+pub mod agent_error;
 pub(crate) mod builder;
+pub mod http_facade;
 pub(crate) mod nonce;
 pub(crate) mod replica_api;
 pub(crate) mod response;
+mod response_authentication;
 
 pub mod status;
-pub use agent_config::{AgentConfig, PasswordManager};
-pub use agent_error::{AgentError, HttpErrorPayload};
+pub use agent_config::AgentConfig;
+pub use agent_error::AgentError;
 pub use builder::AgentBuilder;
 pub use nonce::NonceFactory;
 pub use response::{Replied, RequestStatusResponse};
 
 #[cfg(test)]
 mod agent_test;
-mod response_authentication;
 
 use crate::agent::replica_api::{
     AsyncContent, Certificate, Delegation, Envelope, ReadStateResponse, SyncContent,
@@ -25,7 +26,6 @@ use crate::hash_tree::Label;
 use crate::identity::Identity;
 use crate::{to_request_id, RequestId};
 use delay::Waiter;
-use reqwest::Method;
 use serde::Serialize;
 use status::Status;
 
@@ -34,11 +34,45 @@ use crate::agent::response_authentication::{
 };
 use crate::bls::bls12381::bls;
 use std::convert::TryFrom;
-use std::sync::RwLock;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 const IC_REQUEST_DOMAIN_SEPARATOR: &[u8; 11] = b"\x0Aic-request";
 const IC_STATE_ROOT_DOMAIN_SEPARATOR: &[u8; 14] = b"\x0Dic-state-root";
+
+/// A facade that connects to the Replica and does requests. These requests can be of any type
+/// (does not have to be HTTP).
+///
+/// Any error returned by these methods will bubble up to the code that called the [Agent].
+pub trait ReplicaV1Facade {
+    /// Sends a synchronous request to a Replica. This call includes the body of the request message
+    /// itself (envelope).
+    ///
+    /// This normally corresponds to the `/api/v1/read` endpoint.
+    fn read<'a>(
+        &'a self,
+        envelope: Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>>;
+
+    /// Sends an asynchronous request to a Replica. The Request ID is non-mutable and
+    /// depends on the content of the envelope.
+    ///
+    /// This normally corresponds to the `/api/v1/read` endpoint.
+    fn submit<'a>(
+        &'a self,
+        envelope: Vec<u8>,
+        request_id: RequestId,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AgentError>> + Send + 'a>>;
+
+    /// Sends a status request to the Replica, returning whatever the replica returns.
+    /// In the current spec v1, this is a CBOR encoded status message, but we are not
+    /// making this API attach semantics to the response.
+    fn status<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>>;
+}
 
 /// A low level Agent to make calls to a Replica endpoint.
 ///
@@ -101,14 +135,13 @@ const IC_STATE_ROOT_DOMAIN_SEPARATOR: &[u8; 14] = b"\x0Dic-state-root";
 /// ```
 ///
 /// This agent does not understand Candid, and only acts on byte buffers.
+#[derive(Clone)]
 pub struct Agent {
-    url: reqwest::Url,
     nonce_factory: NonceFactory,
-    client: reqwest::Client,
-    identity: Box<dyn Identity + Send + Sync>,
-    password_manager: Option<Box<dyn PasswordManager + Send + Sync>>,
+    identity: Arc<dyn Identity + Send + Sync>,
     ingress_expiry_duration: Duration,
-    root_key: RwLock<Option<Vec<u8>>>,
+    root_key: Arc<RwLock<Option<Vec<u8>>>>,
+    facade: Arc<dyn ReplicaV1Facade + Send + Sync>,
 }
 
 impl Agent {
@@ -122,31 +155,14 @@ impl Agent {
     pub fn new(config: AgentConfig) -> Result<Agent, AgentError> {
         initialize_bls()?;
 
-        let url = config.url;
-        let mut tls_config = rustls::ClientConfig::new();
-
-        // Advertise support for HTTP/2
-        tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-        // Mozilla CA root store
-        tls_config
-            .root_store
-            .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-
         Ok(Agent {
-            url: reqwest::Url::parse(&url)
-                .and_then(|url| url.join("api/v1/"))
-                .map_err(|_| AgentError::InvalidReplicaUrl(url.clone()))?,
-            client: reqwest::Client::builder()
-                .use_preconfigured_tls(tls_config)
-                .build()
-                .expect("Could not create HTTP client."),
             nonce_factory: config.nonce_factory,
             identity: config.identity,
-            password_manager: config.password_manager,
             ingress_expiry_duration: config
                 .ingress_expiry_duration
                 .unwrap_or_else(|| Duration::from_secs(300)),
-            root_key: RwLock::new(None),
+            root_key: Arc::new(RwLock::new(None)),
+            facade: config.facade.ok_or_else(AgentError::MissingReplicaFacade)?,
         })
     }
 
@@ -199,115 +215,6 @@ impl Agent {
         buf
     }
 
-    async fn request(
-        &self,
-        http_request: reqwest::Request,
-    ) -> Result<(reqwest::StatusCode, reqwest::header::HeaderMap, Vec<u8>), AgentError> {
-        let response = self
-            .client
-            .execute(
-                http_request
-                    .try_clone()
-                    .expect("Could not clone a request."),
-            )
-            .await
-            .map_err(AgentError::from)?;
-
-        let http_status = response.status();
-        let response_headers = response.headers().clone();
-        let bytes = response.bytes().await?.to_vec();
-
-        Ok((http_status, response_headers, bytes))
-    }
-
-    fn maybe_add_authorization(
-        &self,
-        http_request: &mut reqwest::Request,
-        cached: bool,
-    ) -> Result<(), AgentError> {
-        if let Some(pm) = &self.password_manager {
-            let maybe_user_pass = if cached {
-                pm.cached(http_request.url().as_str())
-            } else {
-                pm.required(http_request.url().as_str()).map(Some)
-            };
-
-            if let Some((u, p)) = maybe_user_pass.map_err(AgentError::AuthenticationError)? {
-                let auth = base64::encode(&format!("{}:{}", u, p));
-                http_request.headers_mut().insert(
-                    reqwest::header::AUTHORIZATION,
-                    format!("Basic {}", auth).parse().unwrap(),
-                );
-            }
-        }
-        Ok(())
-    }
-
-    async fn execute<T: std::fmt::Debug + serde::Serialize>(
-        &self,
-        method: Method,
-        endpoint: &str,
-        envelope: Option<Envelope<T>>,
-    ) -> Result<Vec<u8>, AgentError> {
-        let mut body = None;
-        if let Some(e) = envelope {
-            let mut serialized_bytes = Vec::new();
-
-            let mut serializer = serde_cbor::Serializer::new(&mut serialized_bytes);
-            serializer.self_describe()?;
-            e.serialize(&mut serializer)?;
-
-            body = Some(serialized_bytes);
-        }
-
-        let url = self.url.join(endpoint)?;
-        let mut http_request = reqwest::Request::new(method, url);
-        http_request.headers_mut().insert(
-            reqwest::header::CONTENT_TYPE,
-            "application/cbor".parse().unwrap(),
-        );
-
-        self.maybe_add_authorization(&mut http_request, true)?;
-
-        *http_request.body_mut() = body.map(reqwest::Body::from);
-
-        let mut status;
-        let mut headers;
-        let mut body;
-        loop {
-            let request_result = self.request(http_request.try_clone().unwrap()).await?;
-            status = request_result.0;
-            headers = request_result.1;
-            body = request_result.2;
-
-            // If the server returned UNAUTHORIZED, and it is the first time we replay the call,
-            // check if we can get the username/password for the HTTP Auth.
-            if status == reqwest::StatusCode::UNAUTHORIZED {
-                if self.url.scheme() == "https" || self.url.host_str() == Some("localhost") {
-                    // If there is a password manager, get the username and password from it.
-                    self.maybe_add_authorization(&mut http_request, false)?;
-                } else {
-                    return Err(AgentError::CannotUseAuthenticationOnNonSecureUrl());
-                }
-            } else {
-                break;
-            }
-        }
-
-        if status.is_client_error() || status.is_server_error() {
-            Err(AgentError::HttpError(HttpErrorPayload {
-                status: status.into(),
-                content_type: headers
-                    .get(reqwest::header::CONTENT_TYPE)
-                    .and_then(|value| value.to_str().ok())
-                    .map(|x| x.to_string()),
-                content: body,
-            }))
-        } else {
-            Ok(body)
-        }
-    }
-
     async fn read_endpoint<A>(&self, request: SyncContent) -> Result<A, AgentError>
     where
         A: serde::de::DeserializeOwned,
@@ -315,18 +222,19 @@ impl Agent {
         let request_id = to_request_id(&request)?;
         let msg = self.construct_message(&request_id);
         let signature = self.identity.sign(&msg).map_err(AgentError::SigningError)?;
-        let bytes = self
-            .execute(
-                Method::POST,
-                "read",
-                Some(Envelope {
-                    content: request,
-                    sender_pubkey: signature.public_key,
-                    sender_sig: signature.signature,
-                }),
-            )
-            .await?;
 
+        let envelope = Envelope {
+            content: request,
+            sender_pubkey: signature.public_key,
+            sender_sig: signature.signature,
+        };
+
+        let mut serialized_bytes = Vec::new();
+        let mut serializer = serde_cbor::Serializer::new(&mut serialized_bytes);
+        serializer.self_describe()?;
+        envelope.serialize(&mut serializer)?;
+
+        let bytes = self.facade.read(serialized_bytes).await?;
         serde_cbor::from_slice(&bytes).map_err(AgentError::InvalidCborData)
     }
 
@@ -334,18 +242,21 @@ impl Agent {
         let request_id = to_request_id(&request)?;
         let msg = self.construct_message(&request_id);
         let signature = self.identity.sign(&msg).map_err(AgentError::SigningError)?;
-        let _ = self
-            .execute(
-                Method::POST,
-                "submit",
-                Some(Envelope {
-                    content: request,
-                    sender_pubkey: signature.public_key,
-                    sender_sig: signature.signature,
-                }),
-            )
-            .await?;
 
+        let envelope = Envelope {
+            content: request,
+            sender_pubkey: signature.public_key,
+            sender_sig: signature.signature,
+        };
+
+        let mut serialized_bytes = Vec::new();
+        let mut serializer = serde_cbor::Serializer::new(&mut serialized_bytes);
+        serializer.self_describe()?;
+        envelope.serialize(&mut serializer)?;
+
+        self.facade
+            .submit(serialized_bytes, request_id.clone())
+            .await?;
         Ok(request_id)
     }
 
@@ -473,7 +384,7 @@ impl Agent {
 
     /// Calls and returns the information returned by the status endpoint of a replica.
     pub async fn status(&self) -> Result<Status, AgentError> {
-        let bytes = self.execute::<()>(Method::GET, "status", None).await?;
+        let bytes = self.facade.status().await?;
 
         let cbor: serde_cbor::Value =
             serde_cbor::from_slice(&bytes).map_err(AgentError::InvalidCborData)?;

--- a/ic-agent/src/agent/nonce.rs
+++ b/ic-agent/src/agent/nonce.rs
@@ -1,16 +1,17 @@
 use rand::rngs::OsRng;
 use rand::Rng;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 /// A Factory for nonce blobs.
+#[derive(Clone)]
 pub struct NonceFactory {
-    inner: Mutex<Box<dyn Iterator<Item = Vec<u8>> + Send>>,
+    inner: Arc<Mutex<Box<dyn Iterator<Item = Vec<u8>> + Send>>>,
 }
 
 impl NonceFactory {
     pub fn from_iterator(iter: Box<dyn Iterator<Item = Vec<u8>> + Send>) -> Self {
         Self {
-            inner: Mutex::new(iter),
+            inner: Arc::new(Mutex::new(iter)),
         }
     }
 

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -107,10 +107,7 @@ pub mod export;
 pub mod identity;
 pub mod request_id;
 
-pub use agent::{
-    agent_error::AgentError, agent_error::HttpErrorPayload, nonce::NonceFactory, Agent,
-    PasswordManager,
-};
+pub use agent::{agent_error, agent_error::AgentError, nonce::NonceFactory, Agent};
 pub use identity::{Identity, Signature};
 pub use request_id::{to_request_id, RequestId, RequestIdError};
 

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -16,6 +16,7 @@ ic-agent = { path = "../ic-agent" }
 ic-types = { path = "../ic-types" }
 pem = "0.8.1"
 ring = "0.16.11"
-tokio = { version = "0.2.22", features = ["full"] }
 serde = "1.0.115"
 serde_json = "1.0.57"
+tokio = { version = "1.2.0", features = ["full"] }
+thiserror = "1.0.24"

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -423,7 +423,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     input.pop_front().unwrap(); // empty line.
                     line = input.pop_front().unwrap(); // envelope
                     let envelope = hex::decode(line)?;
-                    facade.submit(envelope, request_id.clone()).await?;
+                    facade.submit(envelope, request_id).await?;
                     eprint!("Request ID: ");
                     println!("0x{}", hex::encode(request_id.as_slice()));
                 }

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -2,14 +2,21 @@ use candid::parser::value::IDLValue;
 use candid::types::{Function, Type};
 use candid::{check_prog, IDLArgs, IDLProg, TypeEnv};
 use clap::{crate_authors, crate_version, AppSettings, Clap};
-use ic_agent::agent::AgentConfig;
+use ic_agent::agent::agent_error::HttpErrorPayload;
+use ic_agent::agent::http_facade::ReqwestHttpReplicaV1Facade;
+use ic_agent::agent::ReplicaV1Facade;
 use ic_agent::export::Principal;
 use ic_agent::identity::BasicIdentity;
-use ic_agent::{Agent, AgentError, HttpErrorPayload, Identity};
+use ic_agent::{agent, Agent, AgentError, Identity, RequestId};
 use ring::signature::Ed25519KeyPair;
+use std::collections::VecDeque;
 use std::convert::TryFrom;
-use std::error::Error;
+use std::future::Future;
+use std::io::BufRead;
 use std::path::PathBuf;
+use std::pin::Pin;
+use std::str::FromStr;
+use thiserror::Error;
 
 #[derive(Clap)]
 #[clap(
@@ -48,6 +55,9 @@ enum SubCommand {
     /// Checks the `status` endpoints of the replica.
     Status,
 
+    /// Send a serialized request, taking from STDIN.
+    Send,
+
     /// Transform Principal from hex to new text.
     PrincipalConvert(PrincipalConvertOpts),
 }
@@ -58,6 +68,10 @@ struct CallOpts {
     /// The Canister ID to call.
     #[clap(parse(try_from_str), required = true)]
     canister_id: Principal,
+
+    /// Output the serialization of a message to STDOUT.
+    #[clap(long)]
+    serialize: bool,
 
     /// Path to a candid file to analyze the argument. Otherwise candid will parse the
     /// argument without type hint.
@@ -219,14 +233,80 @@ fn create_identity(maybe_pem: Option<PathBuf>) -> impl Identity {
     }
 }
 
+#[derive(Error, Debug)]
+enum SerializeError {
+    #[error("")]
+    Success,
+}
+
+struct SerializingFacade;
+
+impl agent::ReplicaV1Facade for SerializingFacade {
+    fn read<'a>(
+        &'a self,
+        envelope: Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>> {
+        async fn run(_: &SerializingFacade, envelope: Vec<u8>) -> Result<Vec<u8>, AgentError> {
+            print!("read\n\n{}", hex::encode(envelope));
+            Err(AgentError::ReplicaV1FacadeError(
+                SerializeError::Success.into(),
+            ))
+        }
+
+        Box::pin(run(self, envelope))
+    }
+
+    fn submit<'a>(
+        &'a self,
+        envelope: Vec<u8>,
+        request_id: RequestId,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AgentError>> + Send + 'a>> {
+        async fn run(
+            _: &SerializingFacade,
+            envelope: Vec<u8>,
+            request_id: RequestId,
+        ) -> Result<(), AgentError> {
+            print!(
+                "submit\n{}\n\n{}",
+                hex::encode(request_id.as_slice()),
+                hex::encode(envelope)
+            );
+            Err(AgentError::MessageError(String::new()))
+        }
+
+        Box::pin(run(self, envelope, request_id))
+    }
+
+    fn status<'a>(
+        &'a self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>> {
+        async fn run(_: &SerializingFacade) -> Result<Vec<u8>, AgentError> {
+            Err(AgentError::MessageError(
+                "status calls not supported".to_string(),
+            ))
+        }
+
+        Box::pin(run(self))
+    }
+}
+
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opts: Opts = Opts::parse();
-    let agent = Agent::new(AgentConfig {
-        url: opts.replica,
-        identity: Box::new(create_identity(opts.pem)),
-        ..AgentConfig::default()
-    })?;
+
+    let agent = match &opts.subcommand {
+        SubCommand::Query(CallOpts {
+            serialize: true, ..
+        })
+        | SubCommand::Update(CallOpts {
+            serialize: true, ..
+        }) => Agent::builder().with_facade(SerializingFacade),
+        _ => Agent::builder().with_facade(agent::http_facade::ReqwestHttpReplicaV1Facade::create(
+            opts.replica.clone(),
+        )?),
+    }
+    .with_boxed_identity(Box::new(create_identity(opts.pem)))
+    .build()?;
 
     // You can handle information about subcommands by requesting their matches by name
     // (as below), requesting just the name used, or both at the same time
@@ -283,6 +363,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     print_idl_blob(&blob, &t.output, &method_type)
                         .map_err(|e| format!("Invalid IDL blob: {}", e))?;
                 }
+                Err(AgentError::ReplicaV1FacadeError(_)) => return Ok(()),
                 Err(AgentError::HttpError(HttpErrorPayload {
                     status,
                     content_type,
@@ -314,6 +395,44 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 let p = Principal::from_text(txt.as_str())
                     .expect("Could not transform into a Principal: {}");
                 eprintln!("Hexadecimal: {}", hex::encode(p.as_slice()));
+            }
+        }
+        SubCommand::Send => {
+            let mut input: VecDeque<String> = std::io::stdin()
+                .lock()
+                .lines()
+                .collect::<Result<VecDeque<String>, std::io::Error>>()?;
+            let mut line = input.pop_front().unwrap();
+            while line == "" {
+                line = input.pop_front().unwrap();
+            }
+
+            let facade = ReqwestHttpReplicaV1Facade::create(opts.replica)?;
+            match line.as_str() {
+                "read" => {
+                    input.pop_front().unwrap(); // empty line.
+                    line = input.pop_front().unwrap(); // envelope
+                    let envelope = hex::decode(line)?;
+                    let result = facade.read(envelope).await?;
+                    eprint!("Result: ");
+                    println!("{}", hex::encode(result));
+                }
+                "submit" => {
+                    line = input.pop_front().unwrap(); // request id.
+                    let request_id = RequestId::from_str(&line)?;
+                    input.pop_front().unwrap(); // empty line.
+                    line = input.pop_front().unwrap(); // envelope
+                    let envelope = hex::decode(line)?;
+                    facade.submit(envelope, request_id.clone()).await?;
+                    eprint!("Request ID: ");
+                    println!("0x{}", hex::encode(request_id.as_slice()));
+                }
+                other => {
+                    eprintln!(
+                        r#"Error: Invalid STDIN format. Unexpected line: "{}""#,
+                        other
+                    );
+                }
             }
         }
     }

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -2,8 +2,9 @@
 //!
 //! Contrary to ic-ref.rs, these tests are not meant to match any other tests. They're
 //! integration tests with a running IC-Ref.
+use ic_agent::agent::agent_error::HttpErrorPayload;
 use ic_agent::export::Principal;
-use ic_agent::{AgentError, HttpErrorPayload};
+use ic_agent::AgentError;
 use ic_utils::call::AsyncCall;
 use ic_utils::call::SyncCall;
 use ic_utils::interfaces::management_canister::InstallMode;


### PR DESCRIPTION


# BREAKING CHANGE

This whole PR is a breaking change if you're using the previous API. The best you can do is use the `reqwest` feature and ignore the deprecation warning for `with_url`.