### PR TITLE
build: add a shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+let
+  # Pinned nixpkgs, deterministic. Last updated: 2/12/21.
+  frameworks = pkgs.darwin.apple_sdk.frameworks;
+  pkgs = import (fetchTarball
+    ("https://github.com/NixOS/nixpkgs/archive/a58a0b5098f0c2a389ee70eb69422a052982d990.tar.gz"))
+    { };
+  # Rolling updates, not deterministic.
+  # pkgs = import (fetchTarball("channel:nixpkgs-unstable")) {};
+in pkgs.mkShell {
+  buildInputs =
+    [ pkgs.cargo pkgs.rustc pkgs.openssl.dev pkgs.openssl pkgs.pkgconfig pkgs.libiconv ]
+    ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin [
+      frameworks.Security
+      frameworks.CoreServices
+      frameworks.CoreFoundation
+      frameworks.Foundation
+      frameworks.AppKit
+    ]);
+}


### PR DESCRIPTION
debugging this build error on macos catalina 10.15.7

```
  = note: Undefined symbols for architecture x86_64:
            "_SecTrustEvaluateWithError", referenced from:
                security_framework::trust::SecTrust::evaluate_with_error::h78626442bc8f59e7 in libsecurity_framework-0a3f1f26f69824df.rlib(security_framework-0a3f1f26f69824df.security_framework.6ha9kg5d-cgu.4.rcgu.o)
          ld: symbol(s) not found for architecture x86_64
          clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
```
