### PR TITLE
fix: revert garcon and remove unused bigint

### DIFF
--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -23,7 +23,6 @@ http = "0.2.3"
 ic-types = { path = "../ic-types", version = "0.1", features = [ "serde" ] }
 leb128 = "0.2.4"
 mime = "0.3.16"
-num-bigint = "0.3.1"
 openssl = "0.10.32"
 rand = "0.7.2"
 rustls = "0.19.0"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = "0.1.35"
 base32 = "0.4.0"
 base64 = "0.12.3"
 byteorder = "1.3.2"
-garcon = { version = "0.2.2", features = [ "async" ] }
+delay = "0.3.1"
 hex = "0.4.0"
 http = "0.2.3"
 ic-types = { path = "../ic-types", version = "0.1", features = [ "serde" ] }

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -26,7 +26,7 @@ use crate::export::Principal;
 use crate::hash_tree::Label;
 use crate::identity::Identity;
 use crate::{to_request_id, RequestId};
-use garcon::Waiter;
+use delay::Waiter;
 use serde::Serialize;
 use status::Status;
 
@@ -133,7 +133,7 @@ pub trait ReplicaV2Transport {
 ///   agent.fetch_root_key().await?;
 ///   let management_canister_id = Principal::from_text("aaaaa-aa")?;
 ///
-///   let waiter = garcon::Delay::builder()
+///   let waiter = delay::Delay::builder()
 ///     .throttle(std::time::Duration::from_millis(500))
 ///     .timeout(std::time::Duration::from_secs(60 * 5))
 ///     .build();
@@ -698,8 +698,7 @@ impl<'agent> UpdateBuilder<'agent> {
             };
 
             waiter
-                .async_wait()
-                .await
+                .wait()
                 .map_err(|_| AgentError::TimeoutWaitingForResponse())?;
         }
     }

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -65,7 +65,7 @@
 //!   agent.fetch_root_key().await?;
 //!   let management_canister_id = Principal::from_text("aaaaa-aa")?;
 //!
-//!   let waiter = garcon::Delay::builder()
+//!   let waiter = delay::Delay::builder()
 //!     .throttle(std::time::Duration::from_millis(500))
 //!     .timeout(std::time::Duration::from_secs(60 * 5))
 //!     .build();

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -17,7 +17,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 [dependencies]
 async-trait = "0.1.40"
 candid = "0.6.17"
-garcon = { version = "0.2.2", features = [ "async" ] }
+delay = "0.3.1"
 ic-agent = { path = "../ic-agent", version = "0.3" }
 ic-types = { path = "../ic-types", version = "0.1.2" }
 serde = "1.0.115"

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use candid::de::ArgumentDecoder;
 use candid::{decode_args, decode_one};
-use garcon::Waiter;
+use delay::Waiter;
 use ic_agent::agent::UpdateBuilder;
 use ic_agent::export::Principal;
 use ic_agent::{Agent, AgentError, RequestId};
@@ -92,7 +92,7 @@ where
     ///     .with_interface(interfaces::ManagementCanister)
     ///     .build()?;
     ///
-    ///   let waiter = garcon::Delay::builder()
+    ///   let waiter = delay::Delay::builder()
     ///     .throttle(std::time::Duration::from_millis(500))
     ///     .timeout(std::time::Duration::from_secs(60 * 5))
     ///     .build();

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -406,7 +406,7 @@ mod tests {
     #[tokio::test]
     async fn simple() {
         use super::Canister;
-        use garcon::Delay;
+        use delay::Delay;
 
         let rng = ring::rand::SystemRandom::new();
         let key_pair = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng)

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -3,7 +3,7 @@ use crate::canister::{Argument, CanisterBuilder};
 use crate::Canister;
 use async_trait::async_trait;
 use candid::{CandidType, Deserialize};
-use garcon::Waiter;
+use delay::Waiter;
 use ic_agent::export::Principal;
 use ic_agent::{Agent, AgentError, RequestId};
 use std::convert::AsRef;

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -4,7 +4,7 @@ use crate::Canister;
 use async_trait::async_trait;
 use candid::de::ArgumentDecoder;
 use candid::{decode_args, CandidType, Deserialize};
-use garcon::Waiter;
+use delay::Waiter;
 use ic_agent::agent::UpdateBuilder;
 use ic_agent::export::Principal;
 use ic_agent::{Agent, AgentError, RequestId};

--- a/icx-proxy/Cargo.toml
+++ b/icx-proxy/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 anyhow = "1.0.34"
 candid = "0.6.15"
 clap = "3.0.0-beta.2"
-garcon = { version = "0.2.2", features = [ "async" ] }
+delay = "0.3.1"
 hex = "0.4.3"
 hyper = { version = "0.14.4", features = ["full"] }
 hyper-tls = "0.5.0"

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 candid = "0.6.17"
 clap = "3.0.0-beta.1"
-garcon = { version = "0.2.2", features = [ "async" ] }
+delay = "0.3.1"
 hex = "0.4.2"
 humantime = "2.0.1"
 ic-agent = { path = "../ic-agent", version = "0.3" }

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -430,7 +430,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .with_arg(arg)
                         .with_effective_canister_id(effective_canister_id)
                         .call_and_wait(
-                            garcon::Delay::builder()
+                            delay::Delay::builder()
                                 .exponential_backoff(std::time::Duration::from_secs(1), 1.1)
                                 .side_effect(|| {
                                     eprint!(".");

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 candid = "0.6.17"
-garcon = { version = "0.2.2", features = [ "async" ] }
+delay = "0.3.1"
 ic-agent = { path = "../ic-agent" }
 ic-identity-hsm = { path = "../ic-identity-hsm" }
 ic-utils = { path = "../ic-utils", features = ["raw"] }

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -1,4 +1,4 @@
-use garcon::Delay;
+use delay::Delay;
 use ic_agent::export::Principal;
 use ic_agent::identity::BasicIdentity;
 use ic_agent::{Agent, Identity};


### PR DESCRIPTION
* Revert #154, as it causes update call to wait forever.
* Remove unused crate `num-bigint`. It causes problems with simple_asn1.

When using `ic-agent` from my project, I get a compiler error

```
error[E0308]: mismatched types
  --> /Users/chenyan/.cargo/registry/src/github.com-1ecc6299db9ec823/ic-agent-0.3.0/src/identity/secp256k1.rs:86:48
   |
86 |     let ec_public_key_id = ObjectIdentifier(0, oid!(1, 2, 840, 10045, 2, 1));
   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `simple_asn1::BigUint`, found struct `num_bigint::BigUint`
   |
   = note: expected struct `Vec<simple_asn1::BigUint>`
              found struct `Vec<num_bigint::BigUint>`
   = note: perhaps two different versions of crate `num_bigint` are being used?
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

Removing `num-bigint` from `ic-agent` fixes the problem. We are not using this crate anyway.