### PR TITLE
fix: icx-proxy should only consult query string and referrer when run locally

### DIFF
--- a/icx-proxy/src/main.rs
+++ b/icx-proxy/src/main.rs
@@ -81,6 +81,10 @@ pub(crate) struct Opts {
     /// is used as the Principal, if it parses as a Principal.
     #[clap(long, default_value = "localhost")]
     dns_suffix: Vec<String>,
+
+    /// If true, check the URI and the referer when determining canister id.
+    #[clap(long)]
+    check_uri_and_referer_for_canister_id: bool,
 }
 
 fn resolve_canister_id_from_hostname(
@@ -461,9 +465,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let counter = AtomicUsize::new(0);
     let debug = opts.debug;
-
-    /// For local/development, check the URI (query string) and the referer for a canister id.
-    let check_uri_and_referer_for_canister_id = opts.address.ip().is_loopback();
+    let check_uri_and_referer_for_canister_id = opts.check_uri_and_referer_for_canister_id;
 
     let service = make_service_fn(|socket: &hyper::server::conn::AddrStream| {
         let ip_addr = socket.remote_addr();

--- a/icx-proxy/src/main.rs
+++ b/icx-proxy/src/main.rs
@@ -82,9 +82,9 @@ pub(crate) struct Opts {
     #[clap(long, default_value = "localhost")]
     dns_suffix: Vec<String>,
 
-    /// If true, check the URI and the referer when determining canister id.
+    /// For local development, check the URI and the referer when determining canister id.
     #[clap(long)]
-    check_uri_and_referer_for_canister_id: bool,
+    local: bool,
 }
 
 fn resolve_canister_id_from_hostname(
@@ -465,7 +465,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let counter = AtomicUsize::new(0);
     let debug = opts.debug;
-    let check_uri_and_referer_for_canister_id = opts.check_uri_and_referer_for_canister_id;
+    let check_uri_and_referer_for_canister_id = opts.local;
 
     let service = make_service_fn(|socket: &hyper::server::conn::AddrStream| {
         let ip_addr = socket.remote_addr();

--- a/icx-proxy/src/main.rs
+++ b/icx-proxy/src/main.rs
@@ -160,7 +160,11 @@ async fn forward_request(
     check_uri_and_referer_for_canister_id: bool,
     logger: slog::Logger,
 ) -> Result<Response<Body>, Box<dyn Error>> {
-    let canister_id = match resolve_canister_id(&request, dns_canister_config, check_uri_and_referer_for_canister_id) {
+    let canister_id = match resolve_canister_id(
+        &request,
+        dns_canister_config,
+        check_uri_and_referer_for_canister_id,
+    ) {
         None => {
             return Ok(Response::builder()
                 .status(StatusCode::BAD_REQUEST)
@@ -424,7 +428,14 @@ async fn handle_request(
                 .expect("Could not create agent..."),
         );
 
-        forward_request(request, agent, dns_canister_config.as_ref(), check_uri_and_referer_for_canister_id, logger.clone()).await
+        forward_request(
+            request,
+            agent,
+            dns_canister_config.as_ref(),
+            check_uri_and_referer_for_canister_id,
+            logger.clone(),
+        )
+        .await
     } {
         Err(err) => {
             slog::warn!(logger, "Internal Error during request:\n{:#?}", err);

--- a/icx-proxy/src/main.rs
+++ b/icx-proxy/src/main.rs
@@ -81,10 +81,6 @@ pub(crate) struct Opts {
     /// is used as the Principal, if it parses as a Principal.
     #[clap(long, default_value = "localhost")]
     dns_suffix: Vec<String>,
-
-    /// If true, check the URI and the referer when determining canister id.
-    #[clap(long)]
-    check_uri_and_referer_for_canister_id: bool,
 }
 
 fn resolve_canister_id_from_hostname(
@@ -465,7 +461,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let counter = AtomicUsize::new(0);
     let debug = opts.debug;
-    let check_uri_and_referer_for_canister_id = opts.check_uri_and_referer_for_canister_id;
+
+    /// For local/development, check the URI (query string) and the referer for a canister id.
+    let check_uri_and_referer_for_canister_id = opts.address.ip().is_loopback();
 
     let service = make_service_fn(|socket: &hyper::server::conn::AddrStream| {
         let ip_addr = socket.remote_addr();


### PR DESCRIPTION
Only check the URI (query string) and `referer` header when `icx-proxy` is run for local development, determined by a new `--local` command-line argument.