### PR TITLE
refactor: move HashTree to use Cows instead of owning the values

### DIFF
--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -408,7 +408,7 @@ impl Agent {
         &self,
         paths: Vec<Vec<Label>>,
         effective_canister_id: Principal,
-    ) -> Result<Certificate, AgentError> {
+    ) -> Result<Certificate<'_>, AgentError> {
         let read_state_response: ReadStateResponse = self
             .read_state_endpoint(
                 effective_canister_id,

--- a/ic-agent/src/agent/replica_api.rs
+++ b/ic-agent/src/agent/replica_api.rs
@@ -104,8 +104,8 @@ pub struct ReadStateResponse {
 
 /// A `Certificate` as defined in https://docs.dfinity.systems/public/#_certificate
 #[derive(Deserialize)]
-pub(crate) struct Certificate {
-    pub tree: HashTree,
+pub(crate) struct Certificate<'a> {
+    pub tree: HashTree<'a>,
 
     #[serde(with = "serde_bytes")]
     pub signature: Vec<u8>,

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -101,7 +101,7 @@ pub(crate) fn lookup_reject_code(
         request_id.to_vec().into(),
         "reject_code".into(),
     ];
-    let code = lookup_value(&certificate, path)?;
+    let code = lookup_value(certificate, path)?;
     let mut readable = &code[..];
     Ok(leb128::read::unsigned(&mut readable)?)
 }
@@ -133,10 +133,10 @@ pub(crate) fn lookup_reply(
     Ok(RequestStatusResponse::Replied { reply })
 }
 
-pub(crate) fn lookup_value(
-    certificate: &Certificate,
+pub(crate) fn lookup_value<'a>(
+    certificate: &'a Certificate<'a>,
     path: Vec<Label>,
-) -> Result<&[u8], AgentError> {
+) -> Result<&'a [u8], AgentError> {
     match certificate.tree.lookup_path(&path) {
         LookupResult::Absent => Err(AgentError::LookupPathAbsent(path)),
         LookupResult::Unknown => Err(AgentError::LookupPathUnknown(path)),


### PR DESCRIPTION
This allows us to reduce memory and processing time. This is yak shaving for
publishing this data structure in ic_types and making it WASM (and canister)
friendly, with the hope we can move the certified asset canister to using this
(and hopefully more people).