### PR TITLE
chore: update ic-types to 0.1.3 (should be 0.2.0) and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base32",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "hex",
  "ic-agent",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "ic-types"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base32",
  "crc32fast",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "candid",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "candid",
  "clap",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "icx-proxy"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "candid",

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-agent"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Agent library to communicate with the Internet Computer, following the Public Specification."

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-identity-hsm"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Identity implementation for HSM for the ic-agent package."
 homepage = "https://docs.rs/ic-identity-hsm"
@@ -14,7 +14,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 hex = "0.4.2"
-ic-agent = { path = "../ic-agent", version = "0.4", features = [ "pem" ] }
+ic-agent = { path = "../ic-agent", version = "0.5", features = [ "pem" ] }
 ic-types = { path = "../ic-types", version = "0.1", features = [ "serde" ] }
 num-bigint = "0.3.1"
 openssl = "0.10.30"

--- a/ic-types/Cargo.toml
+++ b/ic-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-types"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Types related to the Internet Computer Public Specification."

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-utils"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Collection of utilities for Rust, on top of ic-agent, to communicate with the Internet Computer, following the Public Specification."
@@ -18,8 +18,8 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 async-trait = "0.1.40"
 candid = "0.6.17"
 garcon = { version = "0.2", features = ["async"] }
-ic-agent = { path = "../ic-agent", version = "0.4" }
-ic-types = { path = "../ic-types", version = "0.1.2" }
+ic-agent = { path = "../ic-agent", version = "0.5" }
+ic-types = { path = "../ic-types", version = "0.1" }
 serde = "1.0.115"
 serde_bytes = "0.11"
 strum = "0.20"

--- a/icx-proxy/Cargo.toml
+++ b/icx-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-proxy"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to create an HTTP proxy to the Internet Computer."
@@ -24,8 +24,8 @@ garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.3"
 hyper = { version = "0.14.4", features = ["full"] }
 hyper-tls = "0.5.0"
-ic-agent = { path = "../ic-agent", version = "0.4" }
-ic-types = { path = "../ic-types", version = "0.1.2" }
+ic-agent = { path = "../ic-agent", version = "0.5" }
+ic-types = { path = "../ic-types", version = "0.1" }
 ic-utils = { path = "../ic-utils", version = "0.3" }
 tokio = { version = "1.2.0", features = ["full"] }
 serde = "1.0.115"

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to call canisters on the Internet Computer."
@@ -22,7 +22,7 @@ clap = "3.0.0-beta.1"
 garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.2"
 humantime = "2.0.1"
-ic-agent = { path = "../ic-agent", version = "0.4" }
+ic-agent = { path = "../ic-agent", version = "0.5" }
 ic-types = { path = "../ic-types", version = "0.1" }
 ic-utils = { path = "../ic-utils", version = "0.3" }
 pem = "0.8.1"


### PR DESCRIPTION
ic-types to 0.1.3 but this is actually a breaking change.
It would be 0.2.0 but there is a circular dependency with candid -> ic-types 0.1.2 and cannot be built.