### PR TITLE
chore: release of ic-agent

### DIFF
--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-agent"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Agent library to communicate with the Internet Computer, following the Public Specification."

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-identity-hsm"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Identity implementation for HSM for the ic-agent package."
 homepage = "https://docs.rs/ic-identity-hsm"

--- a/ic-types/Cargo.toml
+++ b/ic-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-types"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Types related to the Internet Computer Public Specification."

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-utils"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Collection of utilities for Rust, on top of ic-agent, to communicate with the Internet Computer, following the Public Specification."

--- a/icx-proxy/Cargo.toml
+++ b/icx-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-proxy"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to create an HTTP proxy to the Internet Computer."

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to call canisters on the Internet Computer."


### PR DESCRIPTION
icx: 0.2.1 => 0.2.2
ic-agent: 0.5.0 => 0.5.1
icx-proxy: 0.3.0 => 0.3.1
ic-identity-hsm: 0.3.1 => 0.3.2
ic-utils: 0.3.1 => 0.3.2
ic-types: 0.1.3 => 0.1.4