### PR TITLE
feat: add icx-cert tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "base32",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex",
  "ic-agent",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "ic-types"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base32",
  "crc32fast",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "candid",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "candid",
  "clap",
@@ -906,8 +906,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "icx-cert"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.12.3",
+ "clap",
+ "hex",
+ "ic-types",
+ "reqwest",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "sha2",
+]
+
+[[package]]
 name = "icx-proxy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "candid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,9 +911,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.12.3",
+ "chrono",
  "clap",
  "hex",
  "ic-types",
+ "leb128",
  "reqwest",
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "ic-agent",
+    "icx-cert",
     "ic-identity-hsm",
     "ic-types",
     "ic-utils",

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -10,8 +10,10 @@ edition = "2018"
 anyhow = "1.0"
 base64 = "0.12"
 clap = "3.0.0-beta.2"
+chrono = "0.4.19"
 hex = "0.4.2"
 ic-types = { path = "../ic-types", version = "0.1", features = [ "serde" ] }
+leb128 = "0.2.4"
 reqwest = { version = "0.11",features = [ "blocking", "rustls-tls" ] }
 sha2 = "0.9.1"
 serde = { version = "1.0.115", features = ["derive"] }

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "icx-cert"
+version = "0.1.0"
+authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0"
+base64 = "0.12"
+clap = "3.0.0-beta.2"
+hex = "0.4.2"
+ic-types = { path = "../ic-types", version = "0.1", features = [ "serde" ] }
+reqwest = { version = "0.11",features = [ "blocking", "rustls-tls" ] }
+sha2 = "0.9.1"
+serde = { version = "1.0.115", features = ["derive"] }
+serde_bytes = "0.11"
+serde_cbor = "0.11"

--- a/icx-cert/src/main.rs
+++ b/icx-cert/src/main.rs
@@ -10,7 +10,7 @@ mod pprint;
 )]
 enum Command {
     /// Fetches the specified URL and pretty-prints the certificate.
-    #[clap(name = "pprint")]
+    #[clap(name = "print")]
     PPrint { url: String },
 }
 

--- a/icx-cert/src/main.rs
+++ b/icx-cert/src/main.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use clap::{crate_authors, crate_version, Clap};
+
+mod pprint;
+
+#[derive(Clap)]
+#[clap(
+    version = crate_version!(),
+    author = crate_authors!(),
+)]
+enum Command {
+    /// Fetches the specified URL and pretty-prints the certificate.
+    #[clap(name = "pprint")]
+    PPrint { url: String },
+}
+
+fn main() -> Result<()> {
+    match Command::parse() {
+        Command::PPrint { url } => pprint::pprint(url),
+    }
+}

--- a/icx-cert/src/pprint.rs
+++ b/icx-cert/src/pprint.rs
@@ -1,0 +1,102 @@
+use anyhow::{anyhow, Context, Result};
+use ic_types::HashTree;
+use serde::{de::DeserializeOwned, Deserialize};
+use sha2::Digest;
+
+/// Structured contents of the IC-Certificate header.
+struct StructuredCertHeader<'a> {
+    certificate: &'a str,
+    tree: &'a str,
+}
+
+/// A fully parsed replica certificate.
+#[derive(Deserialize)]
+struct ReplicaCertificate {
+    tree: HashTree<'static>,
+    signature: serde_bytes::ByteBuf,
+}
+
+/// Parses the value of IC-Certificate header.
+fn parse_structured_cert_header(value: &str) -> Result<StructuredCertHeader<'_>> {
+    fn extract_field<'a>(value: &'a str, field_name: &'a str, prefix: &'a str) -> Result<&'a str> {
+        let start = value.find(prefix).ok_or_else(|| {
+            anyhow!(
+                "Certificate header doesn't have '{}' field: {}",
+                field_name,
+                value,
+            )
+        })? + prefix.len();
+        let len = value[start..].find(':').ok_or_else(|| {
+            anyhow!(
+                "malformed '{}' field: no ending colon found: {}",
+                prefix,
+                value
+            )
+        })?;
+        Ok(&value[start..(start + len)])
+    }
+
+    Ok(StructuredCertHeader {
+        certificate: extract_field(value, "certificate", "certificate=:")?,
+        tree: extract_field(value, "tree", "tree=:")?,
+    })
+}
+
+/// Decodes base64-encoded CBOR value.
+fn parse_base64_cbor<T: DeserializeOwned>(s: &str) -> Result<T> {
+    let bytes = base64::decode(s).with_context(|| {
+        format!(
+            "failed to parse {}: invalid base64 {}",
+            std::any::type_name::<T>(),
+            s
+        )
+    })?;
+    serde_cbor::from_slice(&bytes[..]).with_context(|| {
+        format!(
+            "failed to parse {}: malformed CBOR",
+            std::any::type_name::<T>()
+        )
+    })
+}
+
+/// Downloads the asset with the specified URL and pretty-print certificate contents.
+pub fn pprint(url: String) -> Result<()> {
+    let response = reqwest::blocking::get(url).with_context(|| "failed to fetch the document")?;
+    let status = response.status().as_u16();
+    let certificate_header = response
+        .headers()
+        .get("IC-Certificate")
+        .ok_or_else(|| anyhow!("IC-Certificate header not found: {:?}", response.headers()))?
+        .to_owned();
+    let data = response
+        .bytes()
+        .with_context(|| "failed to get response body")?;
+    let certificate_str = certificate_header.to_str().with_context(|| {
+        format!(
+            "failed to convert certificate header {:?} to string",
+            certificate_header
+        )
+    })?;
+    let structured_header = parse_structured_cert_header(&certificate_str[..])?;
+    let tree: HashTree = parse_base64_cbor(structured_header.tree)?;
+    let cert: ReplicaCertificate = parse_base64_cbor(structured_header.certificate)?;
+
+    println!("STATUS: {}", status);
+    println!("ROOT HASH: {}", hex::encode(&cert.tree.digest()));
+    println!(
+        "DATA HASH: {}",
+        hex::encode(&sha2::Sha256::digest(data.as_ref()))
+    );
+    println!("TREE HASH: {}", hex::encode(&tree.digest()));
+    println!("SIGNATURE: {}", hex::encode(cert.signature.as_ref()));
+    println!("CERTIFICATE TREE: {:#?}", cert.tree);
+    println!("TREE:             {:#?}", tree);
+    Ok(())
+}
+
+#[test]
+fn test_parse_structured_header() {
+    let header = parse_structured_cert_header("certificate=:abcdef:, tree=:010203:").unwrap();
+    assert_eq!(header.certificate, "abcdef");
+    assert_eq!(header.tree, "010203");
+}


### PR DESCRIPTION
This change introduces a new command-line tool for debugging certified
HTTP responses.  The tool downloads the document with the specified
URL and pretty-prints the contents of the IC-Certificate header.