### PR TITLE
fix: enable serde feature "derive" for non-dev

### DIFF
--- a/ic-types/Cargo.toml
+++ b/ic-types/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1.0.57"
 
 [dependencies.serde]
 version = "1.0.115"
+features = ["derive"]
 optional = true
 
 [dependencies.serde_bytes]


### PR DESCRIPTION
This fixes at least the following case:

1. Clone agent-rs into `~/agent-rs`
2. Create a new project `~/ic-types-test`
3. Add a dependency on `../agent-rs/ic-types`
4. `~/ic-types-test` fails to build
5. Apply the change from this PR in `~/agent-rs`
6. `~/ic-types-test` builds

Fixes https://github.com/dfinity/agent-rs/issues/208