### PR TITLE
feat: add Send and Sync so CanisterBuilderError can be shared between threads safely

### DIFF
--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum CanisterBuilderError {
     #[error("Getting the Canister ID returned an error: {0}")]
-    PrincipalError(#[from] Box<dyn std::error::Error>),
+    PrincipalError(#[from] Box<dyn std::error::Error + std::marker::Send + std::marker::Sync>),
 
     #[error("Must specify an Agent")]
     MustSpecifyAnAgent(),
@@ -32,7 +32,7 @@ impl<'agent, T> CanisterBuilder<'agent, T> {
     /// Attach a canister ID to this canister.
     pub fn with_canister_id<E, P>(self, canister_id: P) -> Self
     where
-        E: 'static + std::error::Error,
+        E: 'static + std::error::Error + std::marker::Send + std::marker::Sync,
         P: TryInto<Principal, Error = E>,
     {
         Self {


### PR DESCRIPTION
Fixes build errors of form:
```
error[E0277]: `(dyn std::error::Error + 'static)` cannot be shared between threads safely
   --> src/dfx/src/commands/canister/call.rs:278:32
    |
278 |                   let canister = Canister::builder()
    |  ________________________________^
279 | |                     .with_agent(agent)
280 | |                     .with_canister_id(canister_id)
281 | |                     .build()
282 | |                     .map_err(DfxError::from)?;
    | |____________________________________________^ `(dyn std::error::Error + 'static)` cannot be shared between threads safely
```

Required by https://github.com/dfinity/sdk/pull/1719