### PR TITLE
chore: re-remove `BigUint` and `OID` imports

### DIFF
--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -30,7 +30,7 @@ ring = { version = "0.16.11", features = ["std"] }
 serde = { version = "1.0.101", features = ["derive"] }
 serde_bytes = "0.11.2"
 serde_cbor = "0.11.1"
-simple_asn1 = "0.5.0"
+simple_asn1 = "0.5.4"
 thiserror = "1.0.20"
 url = "2.1.0"
 webpki-roots = "0.20.0"

--- a/ic-agent/src/agent/agent_config.rs
+++ b/ic-agent/src/agent/agent_config.rs
@@ -1,6 +1,7 @@
-use crate::agent::{NonceFactory, ReplicaV2Transport};
-use crate::identity::anonymous::AnonymousIdentity;
-use crate::identity::Identity;
+use crate::{
+    agent::{NonceFactory, ReplicaV2Transport},
+    identity::{anonymous::AnonymousIdentity, Identity},
+};
 use std::sync::Arc;
 
 /// A configuration for an agent.

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -1,9 +1,9 @@
-use crate::agent::status::Status;
-use crate::hash_tree::Label;
-use crate::RequestIdError;
+use crate::{agent::status::Status, hash_tree::Label, RequestIdError};
 use leb128::read;
-use std::fmt::{Debug, Display, Formatter};
-use std::str::Utf8Error;
+use std::{
+    fmt::{Debug, Display, Formatter},
+    str::Utf8Error,
+};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -1,10 +1,14 @@
 // Disable these tests without the reqwest feature.
 #![cfg(feature = "reqwest")]
 
-use crate::agent::replica_api::{CallReply, QueryResponse};
-use crate::agent::Status;
-use crate::export::Principal;
-use crate::{Agent, AgentError};
+use crate::{
+    agent::{
+        replica_api::{CallReply, QueryResponse},
+        Status,
+    },
+    export::Principal,
+    Agent, AgentError,
+};
 use mockito::mock;
 use std::collections::BTreeMap;
 

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -1,5 +1,7 @@
-use crate::agent::{AgentConfig, ReplicaV2Transport};
-use crate::{Agent, AgentError, Identity, NonceFactory};
+use crate::{
+    agent::{AgentConfig, ReplicaV2Transport},
+    Agent, AgentError, Identity, NonceFactory,
+};
 use std::sync::Arc;
 
 pub struct AgentBuilder {

--- a/ic-agent/src/agent/http_transport.rs
+++ b/ic-agent/src/agent/http_transport.rs
@@ -1,13 +1,9 @@
 //! A [ReplicaV2Transport] that connects using a reqwest client.
 #![cfg(feature = "reqwest")]
 
-use crate::agent::agent_error::HttpErrorPayload;
-use crate::ic_types::Principal;
-use crate::AgentError;
-use crate::RequestId;
+use crate::{agent::agent_error::HttpErrorPayload, ic_types::Principal, AgentError, RequestId};
 use reqwest::Method;
-use std::future::Future;
-use std::pin::Pin;
+use std::{future::Future, pin::Pin};
 
 /// Implemented by the Agent environment to cache and update an HTTP Auth password.
 /// It returns a tuple of `(username, password)`.

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -19,28 +19,34 @@ pub use response::{Replied, RequestStatusResponse};
 #[cfg(test)]
 mod agent_test;
 
-use crate::agent::replica_api::{
-    CallRequestContent, Certificate, Delegation, Envelope, QueryContent, ReadStateContent,
-    ReadStateResponse,
+use crate::{
+    agent::replica_api::{
+        CallRequestContent, Certificate, Delegation, Envelope, QueryContent, ReadStateContent,
+        ReadStateResponse,
+    },
+    export::Principal,
+    hash_tree::Label,
+    identity::Identity,
+    to_request_id, RequestId,
 };
-use crate::export::Principal;
-use crate::hash_tree::Label;
-use crate::identity::Identity;
-use crate::{to_request_id, RequestId};
 use garcon::Waiter;
 use serde::Serialize;
 use status::Status;
 
-use crate::agent::response_authentication::{
-    extract_der, initialize_bls, lookup_canister_info, lookup_request_status, lookup_value,
+use crate::{
+    agent::response_authentication::{
+        extract_der, initialize_bls, lookup_canister_info, lookup_request_status, lookup_value,
+    },
+    bls::bls12381::bls,
 };
-use crate::bls::bls12381::bls;
-use std::convert::TryFrom;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::{Arc, RwLock};
-use std::task::{Context, Poll};
-use std::time::Duration;
+use std::{
+    convert::TryFrom,
+    future::Future,
+    pin::Pin,
+    sync::{Arc, RwLock},
+    task::{Context, Poll},
+    time::Duration,
+};
 
 const IC_REQUEST_DOMAIN_SEPARATOR: &[u8; 11] = b"\x0Aic-request";
 const IC_STATE_ROOT_DOMAIN_SEPARATOR: &[u8; 14] = b"\x0Dic-state-root";

--- a/ic-agent/src/agent/nonce.rs
+++ b/ic-agent/src/agent/nonce.rs
@@ -1,5 +1,4 @@
-use rand::rngs::OsRng;
-use rand::Rng;
+use rand::{rngs::OsRng, Rng};
 use std::sync::{Arc, Mutex};
 
 /// A Factory for nonce blobs.

--- a/ic-agent/src/agent/replica_api.rs
+++ b/ic-agent/src/agent/replica_api.rs
@@ -1,5 +1,7 @@
-use crate::export::Principal;
-use crate::hash_tree::{HashTree, Label};
+use crate::{
+    export::Principal,
+    hash_tree::{HashTree, Label},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -1,11 +1,11 @@
 use crate::{ic_types::Principal, AgentError, RequestId};
 
-use crate::agent::replica_api::Certificate;
-use crate::agent::{Replied, RequestStatusResponse};
-use crate::bls::bls12381::bls;
-use crate::hash_tree::{Label, LookupResult};
-use std::str::from_utf8;
-use std::sync::Once;
+use crate::{
+    agent::{replica_api::Certificate, Replied, RequestStatusResponse},
+    bls::bls12381::bls,
+    hash_tree::{Label, LookupResult},
+};
+use std::{str::from_utf8, sync::Once};
 
 const DER_PREFIX: &[u8; 37] = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x01\x02\x01\x06\x0c\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x02\x01\x03\x61\x00";
 const KEY_LENGTH: usize = 96;

--- a/ic-agent/src/agent/signed.rs
+++ b/ic-agent/src/agent/signed.rs
@@ -1,5 +1,4 @@
-use crate::export::Principal;
-use crate::RequestId;
+use crate::{export::Principal, RequestId};
 
 use serde::{Deserialize, Serialize};
 

--- a/ic-agent/src/agent/status.rs
+++ b/ic-agent/src/agent/status.rs
@@ -1,5 +1,4 @@
-use std::collections::BTreeMap;
-use std::fmt::Debug;
+use std::{collections::BTreeMap, fmt::Debug};
 
 /// Value returned by the status endpoint of a replica. This is a loose mapping to CBOR values.
 /// Because the agent should not return [`serde_cbor::Value`] directly across API boundaries,

--- a/ic-agent/src/bls/bls12381/big.rs
+++ b/ic-agent/src/bls/bls12381/big.rs
@@ -17,13 +17,11 @@
  * limitations under the License.
  */
 
-use crate::bls::arch;
-use crate::bls::arch::Chunk;
+use crate::bls::{arch, arch::Chunk};
 
 use crate::bls::arch::DChunk;
 
-use crate::bls::bls12381::dbig::DBIG;
-use crate::bls::rand::RAND;
+use crate::bls::{bls12381::dbig::DBIG, rand::RAND};
 
 pub const MODBYTES: usize = 48;
 pub const BASEBITS: usize = 58;

--- a/ic-agent/src/bls/bls12381/bls.rs
+++ b/ic-agent/src/bls/bls12381/bls.rs
@@ -16,17 +16,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use crate::bls::bls12381::big;
-use crate::bls::bls12381::big::BIG;
-use crate::bls::bls12381::dbig::DBIG;
-use crate::bls::bls12381::ecp;
-use crate::bls::bls12381::ecp::ECP;
-use crate::bls::bls12381::ecp2::ECP2;
-use crate::bls::bls12381::fp::FP;
-use crate::bls::bls12381::fp4::FP4;
-use crate::bls::bls12381::pair;
-use crate::bls::bls12381::rom;
-use crate::bls::hmac;
+use crate::bls::{
+    bls12381::{big, big::BIG, dbig::DBIG, ecp, ecp::ECP, ecp2::ECP2, fp::FP, fp4::FP4, pair, rom},
+    hmac,
+};
 
 /* Boneh-Lynn-Shacham signature 128-bit API Functions */
 

--- a/ic-agent/src/bls/bls12381/dbig.rs
+++ b/ic-agent/src/bls/bls12381/dbig.rs
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
 
-use crate::bls::arch;
-use crate::bls::arch::Chunk;
-use crate::bls::bls12381::big;
-use crate::bls::bls12381::big::BIG;
+use crate::bls::{
+    arch,
+    arch::Chunk,
+    bls12381::{big, big::BIG},
+};
 
 pub struct DBIG {
     pub w: [Chunk; big::DNLEN],

--- a/ic-agent/src/bls/bls12381/ecp.rs
+++ b/ic-agent/src/bls/bls12381/ecp.rs
@@ -17,12 +17,7 @@
  * limitations under the License.
  */
 
-use crate::bls::bls12381::big;
-use crate::bls::bls12381::big::BIG;
-use crate::bls::bls12381::dbig::DBIG;
-use crate::bls::bls12381::fp;
-use crate::bls::bls12381::fp::FP;
-use crate::bls::bls12381::rom;
+use crate::bls::bls12381::{big, big::BIG, dbig::DBIG, fp, fp::FP, rom};
 
 #[derive(Clone)]
 pub struct ECP {

--- a/ic-agent/src/bls/bls12381/ecp2.rs
+++ b/ic-agent/src/bls/bls12381/ecp2.rs
@@ -17,14 +17,7 @@
  * limitations under the License.
  */
 
-use crate::bls::bls12381::big;
-use crate::bls::bls12381::big::BIG;
-use crate::bls::bls12381::dbig::DBIG;
-use crate::bls::bls12381::ecp;
-use crate::bls::bls12381::fp;
-use crate::bls::bls12381::fp::FP;
-use crate::bls::bls12381::fp2::FP2;
-use crate::bls::bls12381::rom;
+use crate::bls::bls12381::{big, big::BIG, dbig::DBIG, ecp, fp, fp::FP, fp2::FP2, rom};
 
 #[derive(Clone)]
 pub struct ECP2 {

--- a/ic-agent/src/bls/bls12381/fp.rs
+++ b/ic-agent/src/bls/bls12381/fp.rs
@@ -17,12 +17,11 @@
  * limitations under the License.
  */
 
-use crate::bls::arch;
-use crate::bls::arch::Chunk;
-use crate::bls::bls12381::big;
-use crate::bls::bls12381::big::BIG;
-use crate::bls::bls12381::dbig::DBIG;
-use crate::bls::bls12381::rom;
+use crate::bls::{
+    arch,
+    arch::Chunk,
+    bls12381::{big, big::BIG, dbig::DBIG, rom},
+};
 
 use crate::bls::rand::RAND;
 

--- a/ic-agent/src/bls/bls12381/fp12.rs
+++ b/ic-agent/src/bls/bls12381/fp12.rs
@@ -17,13 +17,7 @@
  * limitations under the License.
  */
 
-use crate::bls::bls12381::big;
-use crate::bls::bls12381::big::BIG;
-use crate::bls::bls12381::ecp;
-use crate::bls::bls12381::fp::FP;
-use crate::bls::bls12381::fp2::FP2;
-use crate::bls::bls12381::fp4::FP4;
-use crate::bls::bls12381::rom;
+use crate::bls::bls12381::{big, big::BIG, ecp, fp::FP, fp2::FP2, fp4::FP4, rom};
 
 pub const ZERO: usize = 0;
 pub const ONE: usize = 1;

--- a/ic-agent/src/bls/bls12381/fp2.rs
+++ b/ic-agent/src/bls/bls12381/fp2.rs
@@ -17,12 +17,7 @@
  * limitations under the License.
  */
 
-use crate::bls::bls12381::big;
-use crate::bls::bls12381::big::BIG;
-use crate::bls::bls12381::dbig::DBIG;
-use crate::bls::bls12381::fp;
-use crate::bls::bls12381::fp::FP;
-use crate::bls::bls12381::rom;
+use crate::bls::bls12381::{big, big::BIG, dbig::DBIG, fp, fp::FP, rom};
 
 use crate::bls::rand::RAND;
 

--- a/ic-agent/src/bls/bls12381/fp4.rs
+++ b/ic-agent/src/bls/bls12381/fp4.rs
@@ -17,14 +17,12 @@
  * limitations under the License.
  */
 
-use crate::bls::bls12381::big;
-use crate::bls::bls12381::big::BIG;
-use crate::bls::bls12381::fp;
-use crate::bls::bls12381::fp::FP;
-use crate::bls::bls12381::fp2::FP2;
 #[allow(unused_imports)]
 use crate::bls::bls12381::rom;
-use crate::bls::rand::RAND;
+use crate::bls::{
+    bls12381::{big, big::BIG, fp, fp::FP, fp2::FP2},
+    rand::RAND,
+};
 
 #[derive(Copy, Clone)]
 pub struct FP4 {

--- a/ic-agent/src/bls/bls12381/mpin.rs
+++ b/ic-agent/src/bls/bls12381/mpin.rs
@@ -17,19 +17,11 @@
  * limitations under the License.
  */
 
-use crate::bls::bls12381::big;
-use crate::bls::bls12381::big::BIG;
-use crate::bls::bls12381::dbig::DBIG;
-use crate::bls::bls12381::ecp;
-use crate::bls::bls12381::ecp::ECP;
-use crate::bls::bls12381::ecp2::ECP2;
-use crate::bls::bls12381::fp::FP;
-use crate::bls::bls12381::fp12::FP12;
-use crate::bls::bls12381::pair;
-use crate::bls::bls12381::rom;
+use crate::bls::bls12381::{
+    big, big::BIG, dbig::DBIG, ecp, ecp::ECP, ecp2::ECP2, fp::FP, fp12::FP12, pair, rom,
+};
 
-use crate::bls::hmac;
-use crate::bls::rand::RAND;
+use crate::bls::{hmac, rand::RAND};
 
 /* MPIN 128-bit API Functions */
 

--- a/ic-agent/src/bls/bls12381/pair.rs
+++ b/ic-agent/src/bls/bls12381/pair.rs
@@ -17,16 +17,9 @@
  * limitations under the License.
  */
 
-use crate::bls::bls12381::big::BIG;
-use crate::bls::bls12381::ecp;
-use crate::bls::bls12381::ecp::ECP;
-use crate::bls::bls12381::ecp2::ECP2;
-use crate::bls::bls12381::fp::FP;
-use crate::bls::bls12381::fp12;
-use crate::bls::bls12381::fp12::FP12;
-use crate::bls::bls12381::fp2::FP2;
-use crate::bls::bls12381::fp4::FP4;
-use crate::bls::bls12381::rom;
+use crate::bls::bls12381::{
+    big::BIG, ecp, ecp::ECP, ecp2::ECP2, fp::FP, fp12, fp12::FP12, fp2::FP2, fp4::FP4, rom,
+};
 
 #[allow(unused_imports)]
 use crate::bls::bls12381::dbig::DBIG;

--- a/ic-agent/src/bls/bls12381/rom.rs
+++ b/ic-agent/src/bls/bls12381/rom.rs
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-use crate::bls::arch::Chunk;
-use crate::bls::bls12381::big::NLEN;
+use crate::bls::{arch::Chunk, bls12381::big::NLEN};
 
 // Base Bits= 58
 // bls12381 Modulus

--- a/ic-agent/src/bls/gcm.rs
+++ b/ic-agent/src/bls/gcm.rs
@@ -25,8 +25,7 @@ const GCM_FINISHED: usize = 3;
 //const GCM_ENCRYPTING: usize = 0;
 //const GCM_DECRYPTING: usize = 1;
 
-use crate::bls::aes;
-use crate::bls::aes::AES;
+use crate::bls::{aes, aes::AES};
 
 pub struct GCM {
     table: [[u32; 4]; 128],

--- a/ic-agent/src/bls/hmac.rs
+++ b/ic-agent/src/bls/hmac.rs
@@ -17,11 +17,7 @@
  * limitations under the License.
  */
 
-use crate::bls::hash256::HASH256;
-use crate::bls::hash384::HASH384;
-use crate::bls::hash512::HASH512;
-use crate::bls::rand::RAND;
-use crate::bls::sha3::SHA3;
+use crate::bls::{hash256::HASH256, hash384::HASH384, hash512::HASH512, rand::RAND, sha3::SHA3};
 
 pub const MC_SHA2: usize = 2;
 pub const MC_SHA3: usize = 3;

--- a/ic-agent/src/bls/nhs.rs
+++ b/ic-agent/src/bls/nhs.rs
@@ -19,9 +19,7 @@
 
 /* NewHope Simple API high-level functions  */
 
-use crate::bls::rand::RAND;
-use crate::bls::sha3;
-use crate::bls::sha3::SHA3;
+use crate::bls::{rand::RAND, sha3, sha3::SHA3};
 
 const PRIME: i32 = 0x3001; // q in Hex
 const LGN: usize = 10; // Degree n=2^LGN

--- a/ic-agent/src/identity/anonymous.rs
+++ b/ic-agent/src/identity/anonymous.rs
@@ -1,6 +1,4 @@
-use crate::export::Principal;
-use crate::identity::Identity;
-use crate::Signature;
+use crate::{export::Principal, identity::Identity, Signature};
 
 pub struct AnonymousIdentity;
 

--- a/ic-agent/src/identity/basic.rs
+++ b/ic-agent/src/identity/basic.rs
@@ -6,7 +6,7 @@ use crate::identity::error::PemError;
 
 use ring::signature::{Ed25519KeyPair, KeyPair};
 use simple_asn1::ASN1Block::{BitString, ObjectIdentifier, Sequence};
-use simple_asn1::{oid, to_der, BigUint, OID};
+use simple_asn1::{oid, to_der};
 
 /// A Basic Identity which sign using an ED25519 key pair.
 pub struct BasicIdentity {

--- a/ic-agent/src/identity/basic.rs
+++ b/ic-agent/src/identity/basic.rs
@@ -1,12 +1,13 @@
-use crate::export::Principal;
-use crate::{Identity, Signature};
+use crate::{export::Principal, Identity, Signature};
 
 #[cfg(feature = "pem")]
 use crate::identity::error::PemError;
 
 use ring::signature::{Ed25519KeyPair, KeyPair};
-use simple_asn1::ASN1Block::{BitString, ObjectIdentifier, Sequence};
-use simple_asn1::{oid, to_der};
+use simple_asn1::{
+    oid, to_der,
+    ASN1Block::{BitString, ObjectIdentifier, Sequence},
+};
 
 /// A Basic Identity which sign using an ED25519 key pair.
 pub struct BasicIdentity {

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -1,18 +1,20 @@
-use crate::export::Principal;
-use crate::{Identity, Signature};
+use crate::{export::Principal, Identity, Signature};
 
 #[cfg(feature = "pem")]
 use crate::identity::error::PemError;
 
-use openssl::bn::BigNumContext;
-use openssl::ec::{EcKey, PointConversionForm};
-use openssl::ecdsa::EcdsaSig;
-use openssl::error::ErrorStack;
-use openssl::pkey::{Private, Public};
-use openssl::sha::sha256;
-use simple_asn1::ASN1Block;
-use simple_asn1::ASN1Block::{BitString, ObjectIdentifier, Sequence};
-use simple_asn1::{oid, to_der};
+use openssl::{
+    bn::BigNumContext,
+    ec::{EcKey, PointConversionForm},
+    ecdsa::EcdsaSig,
+    error::ErrorStack,
+    pkey::{Private, Public},
+    sha::sha256,
+};
+use simple_asn1::{
+    oid, to_der, ASN1Block,
+    ASN1Block::{BitString, ObjectIdentifier, Sequence},
+};
 
 #[derive(Clone, Debug)]
 pub struct Secp256k1Identity {

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -12,7 +12,7 @@ use openssl::pkey::{Private, Public};
 use openssl::sha::sha256;
 use simple_asn1::ASN1Block;
 use simple_asn1::ASN1Block::{BitString, ObjectIdentifier, Sequence};
-use simple_asn1::{oid, to_der, BigUint, OID};
+use simple_asn1::{oid, to_der};
 
 #[derive(Clone, Debug)]
 pub struct Secp256k1Identity {

--- a/ic-agent/src/request_id/mod.rs
+++ b/ic-agent/src/request_id/mod.rs
@@ -9,9 +9,7 @@
 use error::RequestIdFromStringError;
 use openssl::sha::Sha256;
 use serde::{ser, Deserialize, Serialize};
-use std::collections::BTreeMap;
-use std::iter::Extend;
-use std::str::FromStr;
+use std::{collections::BTreeMap, iter::Extend, str::FromStr};
 
 pub mod error;
 pub use error::RequestIdError;

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -18,5 +18,5 @@ ic-agent = { path = "../ic-agent", version = "0.5", features = [ "pem" ] }
 num-bigint = "0.3.1"
 openssl = "0.10.30"
 pkcs11 = "0.5.0"
-simple_asn1 = "0.5.0"
+simple_asn1 = "0.5.4"
 thiserror = "1.0.20"

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -1,17 +1,21 @@
 use ic_agent::{ic_types::Principal, Identity, Signature};
 
 use openssl::sha::Sha256;
-use pkcs11::types::{
-    CKA_CLASS, CKA_EC_PARAMS, CKA_EC_POINT, CKA_ID, CKA_KEY_TYPE, CKF_LOGIN_REQUIRED,
-    CKF_SERIAL_SESSION, CKK_ECDSA, CKM_ECDSA, CKO_PRIVATE_KEY, CKO_PUBLIC_KEY, CKU_USER,
-    CK_ATTRIBUTE, CK_ATTRIBUTE_TYPE, CK_KEY_TYPE, CK_MECHANISM, CK_OBJECT_CLASS, CK_OBJECT_HANDLE,
-    CK_SESSION_HANDLE, CK_SLOT_ID,
+use pkcs11::{
+    types::{
+        CKA_CLASS, CKA_EC_PARAMS, CKA_EC_POINT, CKA_ID, CKA_KEY_TYPE, CKF_LOGIN_REQUIRED,
+        CKF_SERIAL_SESSION, CKK_ECDSA, CKM_ECDSA, CKO_PRIVATE_KEY, CKO_PUBLIC_KEY, CKU_USER,
+        CK_ATTRIBUTE, CK_ATTRIBUTE_TYPE, CK_KEY_TYPE, CK_MECHANISM, CK_OBJECT_CLASS,
+        CK_OBJECT_HANDLE, CK_SESSION_HANDLE, CK_SLOT_ID,
+    },
+    Ctx,
 };
-use pkcs11::Ctx;
-use simple_asn1::ASN1Block::{BitString, ObjectIdentifier, OctetString, Sequence};
-use simple_asn1::{from_der, oid, to_der, ASN1DecodeErr, ASN1EncodeErr};
-use std::path::Path;
-use std::ptr;
+use simple_asn1::{
+    from_der, oid, to_der,
+    ASN1Block::{BitString, ObjectIdentifier, OctetString, Sequence},
+    ASN1DecodeErr, ASN1EncodeErr,
+};
+use std::{path::Path, ptr};
 use thiserror::Error;
 
 type KeyIdVec = Vec<u8>;

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -9,7 +9,7 @@ use pkcs11::types::{
 };
 use pkcs11::Ctx;
 use simple_asn1::ASN1Block::{BitString, ObjectIdentifier, OctetString, Sequence};
-use simple_asn1::{from_der, oid, to_der, ASN1DecodeErr, ASN1EncodeErr, BigUint, OID};
+use simple_asn1::{from_der, oid, to_der, ASN1DecodeErr, ASN1EncodeErr};
 use std::path::Path;
 use std::ptr;
 use thiserror::Error;

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -1,10 +1,7 @@
 use async_trait::async_trait;
-use candid::utils::ArgumentDecoder;
-use candid::{decode_args, decode_one, CandidType};
+use candid::{decode_args, decode_one, utils::ArgumentDecoder, CandidType};
 use garcon::Waiter;
-use ic_agent::agent::UpdateBuilder;
-use ic_agent::export::Principal;
-use ic_agent::{Agent, AgentError, RequestId};
+use ic_agent::{agent::UpdateBuilder, export::Principal, Agent, AgentError, RequestId};
 use serde::de::DeserializeOwned;
 use std::future::Future;
 

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -1,8 +1,5 @@
 use crate::call::{AsyncCaller, SyncCaller};
-use candid::parser::value::IDLValue;
-use candid::ser::IDLBuilder;
-use candid::utils::ArgumentDecoder;
-use candid::CandidType;
+use candid::{parser::value::IDLValue, ser::IDLBuilder, utils::ArgumentDecoder, CandidType};
 use ic_agent::{ic_types::Principal, Agent, AgentError};
 use std::convert::TryInto;
 use thiserror::Error;

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -1,10 +1,6 @@
-use crate::call::SyncCall;
-use crate::canister::CanisterBuilder;
-use crate::Canister;
-use candid::parser::value::IDLValue;
-use candid::{CandidType, Deserialize};
-use ic_agent::export::Principal;
-use ic_agent::Agent;
+use crate::{call::SyncCall, canister::CanisterBuilder, Canister};
+use candid::{parser::value::IDLValue, CandidType, Deserialize};
+use ic_agent::{export::Principal, Agent};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -1,11 +1,7 @@
-use crate::call::AsyncCall;
-use crate::canister::CanisterBuilder;
-use crate::Canister;
+use crate::{call::AsyncCall, canister::CanisterBuilder, Canister};
 use candid::{CandidType, Deserialize};
-use ic_agent::export::Principal;
-use ic_agent::Agent;
-use std::convert::AsRef;
-use std::fmt::Debug;
+use ic_agent::{export::Principal, Agent};
+use std::{convert::AsRef, fmt::Debug};
 use strum_macros::{AsRefStr, EnumString};
 
 pub mod attributes;

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -1,19 +1,14 @@
-use crate::call::AsyncCall;
-use crate::canister::Argument;
-use crate::interfaces::management_canister::MgmtMethod;
-use crate::Canister;
+use crate::{
+    call::AsyncCall, canister::Argument, interfaces::management_canister::MgmtMethod, Canister,
+};
 use async_trait::async_trait;
 use candid::{CandidType, Deserialize};
 use garcon::Waiter;
-use ic_agent::export::Principal;
-use ic_agent::{AgentError, RequestId};
+use ic_agent::{export::Principal, AgentError, RequestId};
 use std::str::FromStr;
 
-pub use super::attributes::ComputeAllocation;
-pub use super::attributes::FreezingThreshold;
-pub use super::attributes::MemoryAllocation;
-use std::convert::From;
-use std::convert::TryInto;
+pub use super::attributes::{ComputeAllocation, FreezingThreshold, MemoryAllocation};
+use std::convert::{From, TryInto};
 
 #[derive(CandidType, Deserialize)]
 pub struct CanisterSettings {

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -1,17 +1,16 @@
-use crate::call::{AsyncCall, AsyncCaller, SyncCall};
-use crate::canister::{Argument, CanisterBuilder};
-use crate::interfaces::management_canister::attributes::{
-    ComputeAllocation, FreezingThreshold, MemoryAllocation,
+use crate::{
+    call::{AsyncCall, AsyncCaller, SyncCall},
+    canister::{Argument, CanisterBuilder},
+    interfaces::management_canister::{
+        attributes::{ComputeAllocation, FreezingThreshold, MemoryAllocation},
+        builders::CanisterSettings,
+    },
+    Canister,
 };
-use crate::interfaces::management_canister::builders::CanisterSettings;
-use crate::Canister;
 use async_trait::async_trait;
-use candid::utils::ArgumentDecoder;
-use candid::{decode_args, CandidType, Deserialize};
+use candid::{decode_args, utils::ArgumentDecoder, CandidType, Deserialize};
 use garcon::Waiter;
-use ic_agent::agent::UpdateBuilder;
-use ic_agent::export::Principal;
-use ic_agent::{Agent, AgentError, RequestId};
+use ic_agent::{agent::UpdateBuilder, export::Principal, Agent, AgentError, RequestId};
 
 pub struct CallForwarder<'agent, 'canister: 'agent, Out>
 where

--- a/icx-proxy/src/logging.rs
+++ b/icx-proxy/src/logging.rs
@@ -1,7 +1,6 @@
 use crate::Opts;
 use slog::{Drain, Level, LevelFilter, Logger};
-use std::fs::File;
-use std::path::PathBuf;
+use std::{fs::File, path::PathBuf};
 
 /// The logging mode to use.
 enum LoggingMode {

--- a/icx-proxy/src/main.rs
+++ b/icx-proxy/src/main.rs
@@ -1,25 +1,34 @@
 use crate::config::dns_canister_config::DnsCanisterConfig;
 use candid::parser::value::IDLValue;
 use clap::{crate_authors, crate_version, AppSettings, Clap};
-use hyper::body::Bytes;
-use hyper::http::uri::Parts;
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{body, Body, Client, Request, Response, Server, StatusCode, Uri};
-use ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport;
-use ic_agent::export::Principal;
-use ic_agent::{Agent, AgentError};
-use ic_utils::call::SyncCall;
-use ic_utils::interfaces::http_request::{
-    HeaderField, HttpRequestCanister, StreamingCallbackHttpResponse, StreamingStrategy,
+use hyper::{
+    body,
+    body::Bytes,
+    http::uri::Parts,
+    service::{make_service_fn, service_fn},
+    Body, Client, Request, Response, Server, StatusCode, Uri,
+};
+use ic_agent::{
+    agent::http_transport::ReqwestHttpReplicaV2Transport, export::Principal, Agent, AgentError,
+};
+use ic_utils::{
+    call::SyncCall,
+    interfaces::http_request::{
+        HeaderField, HttpRequestCanister, StreamingCallbackHttpResponse, StreamingStrategy,
+    },
 };
 use slog::Drain;
-use std::convert::Infallible;
-use std::error::Error;
-use std::net::{IpAddr, SocketAddr};
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::{
+    convert::Infallible,
+    error::Error,
+    net::{IpAddr, SocketAddr},
+    path::PathBuf,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+};
 
 mod config;
 mod logging;

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -1,24 +1,29 @@
-use candid::parser::value::IDLValue;
-use candid::types::{Function, Type};
-use candid::{check_prog, IDLArgs, IDLProg, TypeEnv};
-use candid::{CandidType, Decode, Deserialize};
+use candid::{
+    check_prog,
+    parser::value::IDLValue,
+    types::{Function, Type},
+    CandidType, Decode, Deserialize, IDLArgs, IDLProg, TypeEnv,
+};
 use clap::{crate_authors, crate_version, AppSettings, Clap};
-use ic_agent::agent::agent_error::HttpErrorPayload;
-use ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport;
-use ic_agent::agent::ReplicaV2Transport;
-use ic_agent::export::Principal;
-use ic_agent::identity::BasicIdentity;
-use ic_agent::{agent, Agent, AgentError, Identity, RequestId};
-use ic_utils::interfaces::management_canister::builders::{CanisterInstall, CanisterSettings};
-use ic_utils::interfaces::management_canister::MgmtMethod;
+use ic_agent::{
+    agent,
+    agent::{
+        agent_error::HttpErrorPayload, http_transport::ReqwestHttpReplicaV2Transport,
+        ReplicaV2Transport,
+    },
+    export::Principal,
+    identity::BasicIdentity,
+    Agent, AgentError, Identity, RequestId,
+};
+use ic_utils::interfaces::management_canister::{
+    builders::{CanisterInstall, CanisterSettings},
+    MgmtMethod,
+};
 use ring::signature::Ed25519KeyPair;
-use std::collections::VecDeque;
-use std::convert::TryFrom;
-use std::future::Future;
-use std::io::BufRead;
-use std::path::PathBuf;
-use std::pin::Pin;
-use std::str::FromStr;
+use std::{
+    collections::VecDeque, convert::TryFrom, future::Future, io::BufRead, path::PathBuf, pin::Pin,
+    str::FromStr,
+};
 use thiserror::Error;
 
 #[derive(Clap)]

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -1,15 +1,9 @@
 use garcon::Delay;
-use ic_agent::export::Principal;
-use ic_agent::identity::BasicIdentity;
-use ic_agent::{Agent, Identity};
+use ic_agent::{export::Principal, identity::BasicIdentity, Agent, Identity};
 use ic_identity_hsm::HardwareIdentity;
-use ic_utils::interfaces::management_canister::builders::MemoryAllocation;
-use ic_utils::interfaces::ManagementCanister;
+use ic_utils::interfaces::{management_canister::builders::MemoryAllocation, ManagementCanister};
 use ring::signature::Ed25519KeyPair;
-use std::convert::TryFrom;
-use std::error::Error;
-use std::future::Future;
-use std::path::Path;
+use std::{convert::TryFrom, error::Error, future::Future, path::Path};
 
 const HSM_PKCS11_LIBRARY_PATH: &str = "HSM_PKCS11_LIBRARY_PATH";
 const HSM_SLOT_INDEX: &str = "HSM_SLOT_INDEX";

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -10,8 +10,7 @@
 //! tests (like invalid CBOR or special Headers) might not be translatable, in
 //! which case they should still be added here but do nothing (just keep the
 //! use case being tested).
-use ref_tests::universal_canister;
-use ref_tests::with_agent;
+use ref_tests::{universal_canister, with_agent};
 
 const EXPECTED_IC_API_VERSION: &str = "0.17.0";
 
@@ -37,14 +36,19 @@ fn spec_compliance_claimed() {
 }
 
 mod management_canister {
-    use ic_agent::export::Principal;
-    use ic_agent::AgentError;
-    use ic_utils::call::AsyncCall;
-    use ic_utils::interfaces::management_canister::builders::{CanisterSettings, InstallMode};
-    use ic_utils::interfaces::management_canister::{CanisterStatus, StatusCallResult};
-    use ic_utils::interfaces::wallet::CreateResult;
-    use ic_utils::interfaces::{ManagementCanister, Wallet};
-    use ic_utils::{Argument, Canister};
+    use ic_agent::{export::Principal, AgentError};
+    use ic_utils::{
+        call::AsyncCall,
+        interfaces::{
+            management_canister::{
+                builders::{CanisterSettings, InstallMode},
+                CanisterStatus, StatusCallResult,
+            },
+            wallet::CreateResult,
+            ManagementCanister, Wallet,
+        },
+        Argument, Canister,
+    };
     use openssl::sha::Sha256;
     use ref_tests::{
         create_agent, create_basic_identity, create_waiter, with_agent, with_wallet_canister,
@@ -52,8 +56,7 @@ mod management_canister {
 
     mod create_canister {
         use super::{create_waiter, with_agent};
-        use ic_agent::export::Principal;
-        use ic_agent::AgentError;
+        use ic_agent::{export::Principal, AgentError};
         use ic_utils::interfaces::ManagementCanister;
         use std::str::FromStr;
 
@@ -666,9 +669,10 @@ mod simple_calls {
 }
 
 mod extras {
-    use ic_utils::call::AsyncCall;
-    use ic_utils::interfaces::management_canister::builders::ComputeAllocation;
-    use ic_utils::interfaces::ManagementCanister;
+    use ic_utils::{
+        call::AsyncCall,
+        interfaces::{management_canister::builders::ComputeAllocation, ManagementCanister},
+    };
     use ref_tests::{create_waiter, with_agent};
 
     #[ignore]

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -2,19 +2,19 @@
 //!
 //! Contrary to ic-ref.rs, these tests are not meant to match any other tests. They're
 //! integration tests with a running IC-Ref.
-use ic_agent::agent::agent_error::HttpErrorPayload;
-use ic_agent::export::Principal;
-use ic_agent::AgentError;
-use ic_utils::call::AsyncCall;
-use ic_utils::call::SyncCall;
-use ic_utils::interfaces::management_canister::builders::{CanisterSettings, InstallMode};
-use ic_utils::interfaces::Wallet;
-use ic_utils::{Argument, Canister};
-use ref_tests::universal_canister::payload;
+use ic_agent::{agent::agent_error::HttpErrorPayload, export::Principal, AgentError};
+use ic_utils::{
+    call::{AsyncCall, SyncCall},
+    interfaces::{
+        management_canister::builders::{CanisterSettings, InstallMode},
+        Wallet,
+    },
+    Argument, Canister,
+};
 use ref_tests::{
     create_agent, create_basic_identity, create_universal_canister, create_waiter,
-    create_wallet_canister, get_wallet_wasm_from_env, with_universal_canister,
-    with_wallet_canister,
+    create_wallet_canister, get_wallet_wasm_from_env, universal_canister::payload,
+    with_universal_canister, with_wallet_canister,
 };
 
 #[ignore]
@@ -468,13 +468,14 @@ fn wallet_helper_functions() {
 }
 
 mod sign_send {
-    use ic_agent::agent::{
-        signed_query_inspect, signed_request_status_inspect, signed_update_inspect,
+    use ic_agent::{
+        agent::{
+            signed_query_inspect, signed_request_status_inspect, signed_update_inspect, Replied,
+            RequestStatusResponse,
+        },
+        AgentError,
     };
-    use ic_agent::agent::{Replied, RequestStatusResponse};
-    use ic_agent::AgentError;
-    use ref_tests::universal_canister::payload;
-    use ref_tests::with_universal_canister;
+    use ref_tests::{universal_canister::payload, with_universal_canister};
     use std::{thread, time};
 
     #[ignore]

--- a/zzz-release/src/main.rs
+++ b/zzz-release/src/main.rs
@@ -2,10 +2,12 @@ use anyhow::{anyhow, Result};
 use cargo_metadata::{Package, Version};
 use clap::Clap;
 use git2::{Commit, DescribeFormatOptions, Repository, RepositoryState};
-use std::collections::HashMap;
-use std::ops::Range;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
+use std::{
+    collections::HashMap,
+    ops::Range,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 use toml_parse::{walk, SyntaxNode, SyntaxToken, TomlKind};
 
 #[derive(Clap, Debug)]


### PR DESCRIPTION
But this time bump `simple_asn1` to the patch that forces this to work (older versions don't use the `$crate::` idiom which enable this to work).
Also cleanup imports via `cargo fmt -- --config imports_granularity="Crate"`