### PR TITLE
chore: upgrade to tokio 1.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,9 +2512,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.7.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -47,7 +47,7 @@ optional = true
 [dev-dependencies]
 mockito = "0.27.0"
 proptest = "0.9.5"
-tokio = { version = "1.2.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 [features]
 default = ["pem", "reqwest"]

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0.20"
 
 [dev-dependencies]
 ring = "0.16.11"
-tokio = { version = "1.2.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 [features]
 raw = []

--- a/icx-proxy/Cargo.toml
+++ b/icx-proxy/Cargo.toml
@@ -26,7 +26,7 @@ hyper = { version = "0.14.4", features = ["full"] }
 hyper-tls = "0.5.0"
 ic-agent = { path = "../ic-agent", version = "0.5" }
 ic-utils = { path = "../ic-utils", version = "0.3" }
-tokio = { version = "1.2.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 serde = "1.0.115"
 serde_json = "1.0.57"
 slog = { version = "2.7.0", features = ["max_level_trace"] }

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -28,5 +28,5 @@ pem = "0.8.1"
 ring = "0.16.11"
 serde = "1.0.115"
 serde_json = "1.0.57"
-tokio = { version = "1.2.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 thiserror = "1.0.24"

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -14,7 +14,7 @@ ic-utils = { path = "../ic-utils", features = ["raw"] }
 openssl = "0.10.24"
 ring = "0.16.11"
 serde = { version = "1.0.101", features = ["derive"] }
-tokio = { version = "1.2.0", features = ["full"] }
+tokio = { version = "1.8.1", features = ["full"] }
 
 [dev-dependencies]
 serde_cbor = "0.11.1"


### PR DESCRIPTION
See https://dfinity.atlassian.net/browse/SDK-57

Due to security vulnerability
```
ID:       RUSTSEC-2021-0072
Crate:    tokio
Version:  1.4.0
Date:     2021-07-07
URL:      https://rustsec.org/advisories/RUSTSEC-2021-0072
Title:    Task dropped in wrong thread when aborting `LocalSet` task
Solution:  upgrade to >= 1.5.1, < 1.6.0 OR >= 1.6.3, < 1.7.0 OR >= 1.7.2, < 1.8.0 OR >= 1.8.1
Dependency tree:
tokio 1.4.0
```
