### PR TITLE
feat: add icx-asset command-line tool

### DIFF
--- a/.github/workflows/icx_asset.yml
+++ b/.github/workflows/icx_asset.yml
@@ -24,8 +24,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-16.04
-          - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-latest
 

--- a/.github/workflows/icx_asset.yml
+++ b/.github/workflows/icx_asset.yml
@@ -9,11 +9,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - macos-10.15
-          - macos-latest
+        os: [ macos-latest ]
+        rust: [ '1.52.1' ]
+
     steps:
       - uses: actions/checkout@v1
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+      - name: Install Rust
+        run: |
+          rustup update ${{ matrix.rust }} --no-self-update
+          rustup default ${{ matrix.rust }}
+          rustup component add rustfmt
+
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: 'Test icx-asset'
@@ -23,12 +37,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-20.04
-          - ubuntu-latest
+        rust: [ '1.52.1' ]
+        os: [ ubuntu-latest ]
 
     steps:
       - uses: actions/checkout@v1
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
+      - name: Install Rust
+        run: |
+          rustup update ${{ matrix.rust }} --no-self-update
+          rustup default ${{ matrix.rust }}
+          rustup component add rustfmt
+
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: 'Test icx-asset'

--- a/.github/workflows/icx_asset.yml
+++ b/.github/workflows/icx_asset.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: 'Test icx-asset'
-        run: bats e2e/bash/test.bats
+        run: bats e2e/bash/icx-asset.bash
 
   icx-asset-linux:
     runs-on: ${{ matrix.os }}
@@ -34,4 +34,4 @@ jobs:
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: 'Test icx-asset'
-        run: bats e2e/bash/test.bats
+        run: bats e2e/bash/icx-asset.bash

--- a/.github/workflows/icx_asset.yml
+++ b/.github/workflows/icx_asset.yml
@@ -1,0 +1,37 @@
+name: test-icx-asset
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  icx-asset-darwin:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-10.15
+          - macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Provision Darwin
+        run: bash .github/workflows/provision-darwin.sh
+      - name: 'Test icx-asset'
+        run: bats e2e/bash/test.bats
+
+  icx-asset-linux:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-16.04
+          - ubuntu-18.04
+          - ubuntu-20.04
+          - ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
+      - name: 'Test icx-asset'
+        run: bats e2e/bash/test.bats

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -ex
+
+# Enter temporary directory.
+pushd /tmp
+
+# Install Homebrew
+curl --location --output install-brew.sh "https://raw.githubusercontent.com/Homebrew/install/master/install.sh"
+bash install-brew.sh
+rm install-brew.sh
+
+# Install Node.
+version=14.15.4
+curl --location --output node.pkg "https://nodejs.org/dist/v$version/node-v$version.pkg"
+sudo installer -pkg node.pkg -store -target /
+rm node.pkg
+
+# Install DFINITY SDK.
+version=0.7.2
+curl --location --output install-dfx.sh "https://sdk.dfinity.org/install.sh"
+DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
+rm install-dfx.sh
+
+# Exit temporary directory.
+popd

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -33,6 +33,9 @@ curl --location --output install-dfx.sh "https://sdk.dfinity.org/install.sh"
 DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
 
+# Build icx-asset
+cargo build -p icx-asset
+
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"
 echo "BATS_SUPPORT=${BATS_SUPPORT}" >> ${GITHUB_ENV}

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -42,4 +42,7 @@ popd
 
 # Build icx-asset
 cargo build -p icx-asset
+echo "ICX_ASSET=$(pwd)/target/debug/icx-asset" >> $GITHUB_ENV
+echo $PATH
+$ICX_ASSET help
 

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -33,12 +33,13 @@ curl --location --output install-dfx.sh "https://sdk.dfinity.org/install.sh"
 DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
 
-# Build icx-asset
-cargo build -p icx-asset
-
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"
 echo "BATS_SUPPORT=${BATS_SUPPORT}" >> ${GITHUB_ENV}
 
 # Exit temporary directory.
 popd
+
+# Build icx-asset
+cargo build -p icx-asset
+

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -42,7 +42,8 @@ popd
 
 # Build icx-asset
 cargo build -p icx-asset
-echo "ICX_ASSET=$(pwd)/target/debug/icx-asset" >> $GITHUB_ENV
+ICX_ASSET="$(pwd)/target/debug/icx-asset"
+echo "ICX_ASSET=$ICX_ASSET" >> $GITHUB_ENV
 echo $PATH
 $ICX_ASSET help
 

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -16,11 +16,25 @@ curl --location --output node.pkg "https://nodejs.org/dist/v$version/node-v$vers
 sudo installer -pkg node.pkg -store -target /
 rm node.pkg
 
+# Install Bats.
+brew unlink bats
+brew install bats-core
+
+# Install Bats support.
+version=0.3.0
+curl --location --output bats-support.tar.gz https://github.com/ztombol/bats-support/archive/v$version.tar.gz
+mkdir /usr/local/lib/bats-support
+tar --directory /usr/local/lib/bats-support --extract --file bats-support.tar.gz --strip-components 1
+rm bats-support.tar.gz
+
 # Install DFINITY SDK.
 version=0.7.2
 curl --location --output install-dfx.sh "https://sdk.dfinity.org/install.sh"
 DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
+
+# Set environment variables.
+echo "::set-env name=BATSLIB::/usr/local/lib/bats-support"
 
 # Exit temporary directory.
 popd

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -34,7 +34,8 @@ DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
 
 # Set environment variables.
-echo "::set-env name=BATSLIB::/usr/local/lib/bats-support"
+BATS_SUPPORT="/usr/local/lib/bats-support"
+echo "BATS_SUPPORT=${BATS_SUPPORT}" >> ${GITHUB_ENV}
 
 # Exit temporary directory.
 popd

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -35,7 +35,7 @@ rm install-dfx.sh
 
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"
-echo "BATS_SUPPORT=${BATS_SUPPORT}" >> ${GITHUB_ENV}
+echo "BATS_SUPPORT=${BATS_SUPPORT}" >> "$GITHUB_ENV"
 
 # Exit temporary directory.
 popd
@@ -43,7 +43,5 @@ popd
 # Build icx-asset
 cargo build -p icx-asset
 ICX_ASSET="$(pwd)/target/debug/icx-asset"
-echo "ICX_ASSET=$ICX_ASSET" >> $GITHUB_ENV
-echo $PATH
-$ICX_ASSET help
+echo "ICX_ASSET=$ICX_ASSET" >> "$GITHUB_ENV"
 

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -1,0 +1,25 @@
+
+#!/bin/bash
+
+set -ex
+
+# Enter temporary directory.
+pushd /tmp
+
+# Install Node.
+wget --output-document install-node.sh "https://deb.nodesource.com/setup_14.x"
+sudo bash install-node.sh
+sudo apt-get install --yes nodejs
+rm install-node.sh
+
+# Install DFINITY SDK.
+version=0.7.2
+wget --output-document install-dfx.sh "https://sdk.dfinity.org/install.sh"
+DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
+rm install-dfx.sh
+
+# Set environment variables.
+echo "$HOME/bin" >> $GITHUB_PATH
+
+# Exit temporary directory.
+popd

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -29,8 +29,8 @@ rm install-dfx.sh
 
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"
-echo "BATS_SUPPORT=${BATS_SUPPORT}" >> ${GITHUB_ENV}
-echo "$HOME/bin" >> $GITHUB_PATH
+echo "BATS_SUPPORT=${BATS_SUPPORT}" >> "$GITHUB_ENV"
+echo "$HOME/bin" >> "$GITHUB_PATH"
 
 # Exit temporary directory.
 popd
@@ -38,7 +38,5 @@ popd
 # Build icx-asset
 cargo build -p icx-asset
 ICX_ASSET="$(pwd)/target/debug/icx-asset"
-echo "ICX_ASSET=$ICX_ASSET" >> $GITHUB_ENV
-echo $PATH
-$ICX_ASSET help
+echo "ICX_ASSET=$ICX_ASSET" >> "$GITHUB_ENV"
 

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -6,8 +6,6 @@ set -ex
 # Enter temporary directory.
 pushd /tmp
 
-sudo apt-get install --yes glibc_2
-
 # Install Node.
 wget --output-document install-node.sh "https://deb.nodesource.com/setup_14.x"
 sudo bash install-node.sh

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -6,6 +6,8 @@ set -ex
 # Enter temporary directory.
 pushd /tmp
 
+sudo apt-get install --yes glibc_2.25 glibc_2.29
+
 # Install Node.
 wget --output-document install-node.sh "https://deb.nodesource.com/setup_14.x"
 sudo bash install-node.sh

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 set -ex
@@ -28,9 +27,6 @@ wget --output-document install-dfx.sh "https://sdk.dfinity.org/install.sh"
 DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
 
-# Build icx-asset
-cargo build -p icx-asset
-
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"
 echo "BATS_SUPPORT=${BATS_SUPPORT}" >> ${GITHUB_ENV}
@@ -38,3 +34,6 @@ echo "$HOME/bin" >> $GITHUB_PATH
 
 # Exit temporary directory.
 popd
+
+# Build icx-asset
+cargo build -p icx-asset

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -6,7 +6,7 @@ set -ex
 # Enter temporary directory.
 pushd /tmp
 
-sudo apt-get install --yes glibc_2.25 glibc_2.29
+sudo apt-get install --yes glibc_2
 
 # Install Node.
 wget --output-document install-node.sh "https://deb.nodesource.com/setup_14.x"

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -12,6 +12,16 @@ sudo bash install-node.sh
 sudo apt-get install --yes nodejs
 rm install-node.sh
 
+# Install Bats.
+sudo apt-get install --yes bats
+
+# Install Bats support.
+version=0.3.0
+wget https://github.com/ztombol/bats-support/archive/v$version.tar.gz
+sudo mkdir /usr/local/lib/bats-support
+sudo tar --directory /usr/local/lib/bats-support --extract --file v$version.tar.gz --strip-components 1
+rm v$version.tar.gz
+
 # Install DFINITY SDK.
 version=0.7.2
 wget --output-document install-dfx.sh "https://sdk.dfinity.org/install.sh"
@@ -19,6 +29,8 @@ DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
 
 # Set environment variables.
+echo "::set-env name=BATSLIB::/usr/local/lib/bats-support"
+echo "::add-path::/home/runner/bin"
 echo "$HOME/bin" >> $GITHUB_PATH
 
 # Exit temporary directory.

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -37,7 +37,8 @@ popd
 
 # Build icx-asset
 cargo build -p icx-asset
-echo "ICX_ASSET=$(pwd)/target/debug/icx-asset" >> $GITHUB_ENV
+ICX_ASSET="$(pwd)/target/debug/icx-asset"
+echo "ICX_ASSET=$ICX_ASSET" >> $GITHUB_ENV
 echo $PATH
 $ICX_ASSET help
 

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -29,8 +29,8 @@ DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
 
 # Set environment variables.
-echo "::set-env name=BATSLIB::/usr/local/lib/bats-support"
-echo "::add-path::/home/runner/bin"
+BATS_SUPPORT="/usr/local/lib/bats-support"
+echo "BATS_SUPPORT=${BATS_SUPPORT}" >> ${GITHUB_ENV}
 echo "$HOME/bin" >> $GITHUB_PATH
 
 # Exit temporary directory.

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -37,3 +37,7 @@ popd
 
 # Build icx-asset
 cargo build -p icx-asset
+echo "ICX_ASSET=$(pwd)/target/debug/icx-asset" >> $GITHUB_ENV
+echo $PATH
+$ICX_ASSET help
+

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -28,6 +28,9 @@ wget --output-document install-dfx.sh "https://sdk.dfinity.org/install.sh"
 DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
 
+# Build icx-asset
+cargo build -p icx-asset
+
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"
 echo "BATS_SUPPORT=${BATS_SUPPORT}" >> ${GITHUB_ENV}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,30 @@
+name: Check shell scripts
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - 'e2e/**'
+      - '.github/**'
+  push:
+    branches:
+      - master
+
+jobs:
+  check_macos:
+    # ubuntu-latest has shellcheck 0.4.6, while macos-latest has 0.7.1
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install shellcheck
+        run: |
+          mkdir $HOME/bin
+          cd $HOME/bin
+          curl -L https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.darwin.x86_64.tar.xz \
+            | xz -d | tar x
+      - name: Check e2e scripts
+        run: $HOME/bin/shellcheck-v0.7.1/shellcheck e2e/bash/*.bash
+      - name: Check workflow scripts
+        run: $HOME/bin/shellcheck-v0.7.1/shellcheck .github/workflows/*.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -25,6 +25,6 @@ jobs:
           curl -L https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.darwin.x86_64.tar.xz \
             | xz -d | tar x
       - name: Check e2e scripts
-        run: $HOME/bin/shellcheck-v0.7.1/shellcheck e2e/bash/*.bash
+        run: $HOME/bin/shellcheck-v0.7.1/shellcheck e2e/bash/*.bash e2e/bash/util/*.bash
       - name: Check workflow scripts
         run: $HOME/bin/shellcheck-v0.7.1/shellcheck .github/workflows/*.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
  "candid_derive",
  "codespan-reporting",
  "hex",
- "ic-types 0.2.0",
+ "ic-types",
  "lalrpop",
  "lalrpop-util",
  "leb128",
@@ -919,7 +919,7 @@ dependencies = [
  "garcon",
  "hex",
  "ic-agent",
- "ic-types 0.2.0",
+ "ic-types",
  "mime",
  "mime_guess",
  "mockito",
@@ -940,21 +940,6 @@ dependencies = [
  "openssl",
  "pkcs11",
  "simple_asn1",
- "thiserror",
-]
-
-[[package]]
-name = "ic-types"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94dd8ec75019bc7159efe6ca2de5392e14a8e82c02ec6dae6d1b32af5337acd1"
-dependencies = [
- "base32",
- "crc32fast",
- "hex",
- "serde",
- "serde_bytes",
- "sha2",
  "thiserror",
 ]
 
@@ -1020,7 +1005,7 @@ dependencies = [
  "garcon",
  "ic-agent",
  "ic-asset",
- "ic-types 0.1.5",
+ "ic-types",
  "ic-utils",
  "libflate",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,7 @@ dependencies = [
  "clap",
  "delay",
  "garcon",
+ "humantime",
  "ic-agent",
  "ic-asset",
  "ic-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base32",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "ic-asset"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hex",
  "ic-agent",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "candid",
  "clap",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.12.3",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "icx-proxy"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "candid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,7 +202,7 @@ dependencies = [
  "candid_derive",
  "codespan-reporting",
  "hex",
- "ic-types",
+ "ic-types 0.2.0",
  "lalrpop",
  "lalrpop-util",
  "leb128",
@@ -395,6 +401,12 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "delay"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8546bb2c80129c9c85cd2b44e160b917f34a8b7ce9f3af675502cf9960e33d62"
 
 [[package]]
 name = "derivative"
@@ -907,7 +919,7 @@ dependencies = [
  "garcon",
  "hex",
  "ic-agent",
- "ic-types",
+ "ic-types 0.2.0",
  "mime",
  "mime_guess",
  "mockito",
@@ -928,6 +940,21 @@ dependencies = [
  "openssl",
  "pkcs11",
  "simple_asn1",
+ "thiserror",
+]
+
+[[package]]
+name = "ic-types"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94dd8ec75019bc7159efe6ca2de5392e14a8e82c02ec6dae6d1b32af5337acd1"
+dependencies = [
+ "base32",
+ "crc32fast",
+ "hex",
+ "serde",
+ "serde_bytes",
+ "sha2",
  "thiserror",
 ]
 
@@ -980,6 +1007,30 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "icx-asset"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "chrono",
+ "clap",
+ "delay",
+ "garcon",
+ "ic-agent",
+ "ic-asset",
+ "ic-types 0.1.5",
+ "ic-utils",
+ "libflate",
+ "num-traits",
+ "pem",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "walkdir",
 ]
 
 [[package]]
@@ -1140,6 +1191,26 @@ name = "libc"
 version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+
+[[package]]
+name = "libflate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d87eae36b3f680f7f01645121b782798b56ef33c53f83d1c66ba3a22b60bfe3"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
+dependencies = [
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -2025,6 +2096,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rowan"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "ic-identity-hsm",
     "ic-utils",
     "icx",
+    "icx-asset",
     "icx-proxy",
     "ref-tests",
     "zzz-release",

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -7,10 +7,15 @@ source $BATS_SUPPORT/load.bash
 
 setup() {
     cd $(mktemp -d -t icx-asset-e2e-XXXXXXXX)
+    dfx new e2e_project
+    cd e2e_project
+    dfx start --background
+    dfx deploy
 }
 
 teardown() {
     echo teardown
+    dfx stop
 }
 
 @test "no-nop test" {

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -1,13 +1,13 @@
 #!/usr/bin/env bats
 
-source $BATS_SUPPORT/load.bash
+#source "$BATS_SUPPORT"/load.bash
 
 load util/assertions
 
 setup() {
-    cd $(mktemp -d -t icx-asset-e2e-XXXXXXXX)
+    cd "$(mktemp -d -t icx-asset-e2e-XXXXXXXX)" || exit 1
     dfx new --no-frontend e2e_project
-    cd e2e_project
+    cd e2e_project || exit 1
     dfx start --background
     dfx deploy
 }
@@ -19,7 +19,7 @@ teardown() {
 
 icx_asset_sync() {
   CANISTER_ID=$(dfx canister id e2e_project_assets)
-  assert_command $ICX_ASSET --pem $HOME/.config/dfx/identity/default/identity.pem sync $CANISTER_ID src/e2e_project_assets/assets
+  assert_command "$ICX_ASSET" --pem "$HOME"/.config/dfx/identity/default/identity.pem sync "$CANISTER_ID" src/e2e_project_assets/assets
 }
 
 @test "creates new files" {

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -7,7 +7,7 @@ source $BATS_SUPPORT/load.bash
 
 setup() {
     cd $(mktemp -d -t icx-asset-e2e-XXXXXXXX)
-    dfx new e2e_project
+    dfx new --no-frontend e2e_project
     cd e2e_project
     dfx start --background
     dfx deploy

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -2,8 +2,7 @@
 
 source $BATS_SUPPORT/load.bash
 
-#load util/_
-#load util/assert
+load util/assertions
 
 setup() {
     cd $(mktemp -d -t icx-asset-e2e-XXXXXXXX)
@@ -18,6 +17,39 @@ teardown() {
     dfx stop
 }
 
+icx_asset_sync() {
+  CANISTER_ID=$(dfx canister id e2e_project_assets)
+  $ICX_ASSET --pem $HOME/.config/dfx/identity/default/identity.pem $CANISTER_ID src/e2e_project_assets/assets
+}
+
 @test "no-nop test" {
     echo pass
+}
+
+@test "creates new files" {
+  echo "new file content" >src/e2e_project_assets/assets/new-asset.txt
+  icx_asset_sync
+
+  dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/new-asset.txt";accept_encodings=vec{"identity"}})'
+}
+
+@test "updates existing files" {
+  echo pass
+}
+
+@test "deletes removed files" {
+  echo pass
+}
+
+@test "unsets asset encodings that are removed from project" {
+
+    dfx canister --no-wallet call --update e2e_project_assets store '(record{key="/sample-asset.txt"; content_type="text/plain"; content_encoding="arbitrary"; content=blob "content encoded in another way!"})'
+
+    dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"identity"}})'
+    dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"arbitrary"}})'
+
+    icx_asset_sync
+
+    dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"identity"}})'
+    assert_command_fail dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"arbitrary"}})'
 }

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
-#source "$BATS_SUPPORT"/load.bash
+# shellcheck disable=SC1090
+source "$BATS_SUPPORT"/load.bash
 
 load util/assertions
 

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+source $BATS_SUPPORT/load.bash
+
+#load util/_
+#load util/assert
+
+setup() {
+    cd $(mktemp -d -t icx-asset-e2e-XXXXXXXX)
+}
+
+teardown() {
+    echo teardown
+}
+
+@test "no-nop test" {
+    echo pass
+}

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -19,7 +19,7 @@ teardown() {
 
 icx_asset_sync() {
   CANISTER_ID=$(dfx canister id e2e_project_assets)
-  $ICX_ASSET --pem $HOME/.config/dfx/identity/default/identity.pem $CANISTER_ID src/e2e_project_assets/assets
+  assert_command $ICX_ASSET --pem $HOME/.config/dfx/identity/default/identity.pem sync $CANISTER_ID src/e2e_project_assets/assets
 }
 
 @test "no-nop test" {
@@ -30,7 +30,7 @@ icx_asset_sync() {
   echo "new file content" >src/e2e_project_assets/assets/new-asset.txt
   icx_asset_sync
 
-  dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/new-asset.txt";accept_encodings=vec{"identity"}})'
+  assert_command dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/new-asset.txt";accept_encodings=vec{"identity"}})'
 }
 
 @test "updates existing files" {
@@ -43,13 +43,13 @@ icx_asset_sync() {
 
 @test "unsets asset encodings that are removed from project" {
 
-    dfx canister --no-wallet call --update e2e_project_assets store '(record{key="/sample-asset.txt"; content_type="text/plain"; content_encoding="arbitrary"; content=blob "content encoded in another way!"})'
+    assert_command dfx canister --no-wallet call --update e2e_project_assets store '(record{key="/sample-asset.txt"; content_type="text/plain"; content_encoding="arbitrary"; content=blob "content encoded in another way!"})'
 
-    dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"identity"}})'
-    dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"arbitrary"}})'
+    assert_command dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"identity"}})'
+    assert_command dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"arbitrary"}})'
 
     icx_asset_sync
 
-    dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"identity"}})'
+    assert_command dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"identity"}})'
     assert_command_fail dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"arbitrary"}})'
 }

--- a/e2e/bash/util/assertions.bash
+++ b/e2e/bash/util/assertions.bash
@@ -7,17 +7,21 @@
 # Returns:
 #   none
 assert_command() {
-    local stderrf="$(mktemp)"
-    local stdoutf="$(mktemp)"
-    local statusf="$(mktemp)"
+    x="$(mktemp)"
+    local stderrf="$x"
+    x="$(mktemp)"
+    local stdoutf="$x"
+    x="$(mktemp)"
+    local statusf="$x"
     ( set +e; "$@" 2>"$stderrf" >"$stdoutf"; echo -n "$?" > "$statusf" )
-    status="$(<$statusf)"; rm "$statusf"
+    status="$(<"$statusf")"; rm "$statusf"
 
-    stderr="$(cat $stderrf)"; rm "$stderrf"
-    stdout="$(cat $stdoutf)"; rm "$stdoutf"
+    stderr="$(cat "$stderrf")"; rm "$stderrf"
+    stdout="$(cat "$stdoutf")"; rm "$stdoutf"
+    # shellcheck disable=SC2015
     output="$( \
-        [ "$stderr" ] && echo $stderr || true; \
-        [ "$stdout" ] && echo $stdout || true; \
+        [ "$stderr" ] && echo "$stderr" || true; \
+        [ "$stdout" ] && echo "$stdout" || true; \
     )"
 
     [[ $status == 0 ]] || \
@@ -33,17 +37,21 @@ assert_command() {
 # Returns:
 #   none
 assert_command_fail() {
-    local stderrf="$(mktemp)"
-    local stdoutf="$(mktemp)"
-    local statusf="$(mktemp)"
+    x="$(mktemp)"
+    local stderrf="$x"
+    x="$(mktemp)"
+    local stdoutf="$x"
+    x="$(mktemp)"
+    local statusf="$x"
     ( set +e; "$@" 2>"$stderrf" >"$stdoutf"; echo -n "$?" >"$statusf" )
-    status="$(<$statusf)"; rm "$statusf"
+    status="$(<"$statusf")"; rm "$statusf"
 
-    stderr="$(cat $stderrf)"; rm "$stderrf"
-    stdout="$(cat $stdoutf)"; rm "$stdoutf"
+    stderr="$(cat "$stderrf")"; rm "$stderrf"
+    stdout="$(cat "$stdoutf")"; rm "$stdoutf"
+    # shellcheck disable=SC2015
     output="$(
-        [ "$stderr" ] && echo $stderr || true;
-        [ "$stdout" ] && echo $stdout || true;
+        [ "$stderr" ] && echo "$stderr" || true;
+        [ "$stdout" ] && echo "$stdout" || true;
     )"
 
     [[ $status != 0 ]] || \
@@ -59,7 +67,7 @@ assert_command_fail() {
 #         $output.
 assert_match() {
     regex="$1"
-    if [[ $# < 2 ]]; then
+    if [[ $# -lt 2 ]]; then
         text="$output"
     else
         text="$2"
@@ -77,7 +85,7 @@ assert_match() {
 #         $output.
 assert_not_match() {
     regex="$1"
-    if [[ $# < 2 ]]; then
+    if [[ $# -lt 2 ]]; then
         text="$output"
     else
         text="$2"
@@ -101,7 +109,7 @@ assert_not_match() {
 #    $2 - The actual value.
 assert_eq() {
     expected="$1"
-    if [[ $# < 2 ]]; then
+    if [[ $# -lt 2 ]]; then
         actual="$output"
     else
         actual="$2"
@@ -119,7 +127,7 @@ assert_eq() {
 #    $2 - The actual value.
 assert_neq() {
     expected="$1"
-    if [[ $# < 2 ]]; then
+    if [[ $# -lt 2 ]]; then
         actual="$output"
     else
         actual="$2"
@@ -140,7 +148,7 @@ assert_process_exits() {
     pid="$1"
     timeout="$2"
 
-    timeout $timeout sh -c \
+    timeout "$timeout" sh -c \
       "while kill -0 $pid; do echo waiting for process $pid to exit; sleep 1; done" \
       || (echo "process $pid did not exit" && ps aux && exit 1)
 
@@ -150,7 +158,7 @@ assert_file_eventually_exists() {
     filename="$1"
     timeout="$2"
 
-    timeout $timeout sh -c \
+    timeout "$timeout" sh -c \
       "until [ -f $filename ]; do echo waiting for $filename; sleep 1; done" \
       || (echo "file $filename was never created" && ls && exit 1)
 }

--- a/e2e/bash/util/assertions.bash
+++ b/e2e/bash/util/assertions.bash
@@ -1,0 +1,156 @@
+#!
+
+# Asserts that a command line succeeds. Still sets $output to the stdout and stderr
+# of the command.
+# Arguments:
+#   $@ - The command to run.
+# Returns:
+#   none
+assert_command() {
+    local stderrf="$(mktemp)"
+    local stdoutf="$(mktemp)"
+    local statusf="$(mktemp)"
+    ( set +e; "$@" 2>"$stderrf" >"$stdoutf"; echo -n "$?" > "$statusf" )
+    status="$(<$statusf)"; rm "$statusf"
+
+    stderr="$(cat $stderrf)"; rm "$stderrf"
+    stdout="$(cat $stdoutf)"; rm "$stdoutf"
+    output="$( \
+        [ "$stderr" ] && echo $stderr || true; \
+        [ "$stdout" ] && echo $stdout || true; \
+    )"
+
+    [[ $status == 0 ]] || \
+        (  (echo "$*"; echo "status: $status"; echo "$output" | batslib_decorate "Output") \
+         | batslib_decorate "Command failed" \
+         | fail)
+}
+
+# Asserts that a command line fails. Still sets $output to the stdout and stderr
+# of the command.
+# Arguments:
+#   $@ - The command to run.
+# Returns:
+#   none
+assert_command_fail() {
+    local stderrf="$(mktemp)"
+    local stdoutf="$(mktemp)"
+    local statusf="$(mktemp)"
+    ( set +e; "$@" 2>"$stderrf" >"$stdoutf"; echo -n "$?" >"$statusf" )
+    status="$(<$statusf)"; rm "$statusf"
+
+    stderr="$(cat $stderrf)"; rm "$stderrf"
+    stdout="$(cat $stdoutf)"; rm "$stdoutf"
+    output="$(
+        [ "$stderr" ] && echo $stderr || true;
+        [ "$stdout" ] && echo $stdout || true;
+    )"
+
+    [[ $status != 0 ]] || \
+        (  (echo "$*"; echo "$output" | batslib_decorate "Output") \
+         | batslib_decorate "Command succeeded (should have failed)" \
+         | fail)
+}
+
+# Asserts that a string contains another string, using regexp.
+# Arguments:
+#    $1 - The regex to use to match.
+#    $2 - The string to match against (output). By default it will use
+#         $output.
+assert_match() {
+    regex="$1"
+    if [[ $# < 2 ]]; then
+        text="$output"
+    else
+        text="$2"
+    fi
+    [[ "$text" =~ $regex ]] || \
+        (batslib_print_kv_single_or_multi 10 "regex" "$regex" "actual" "$text" \
+         | batslib_decorate "output does not match" \
+         | fail)
+}
+
+# Asserts that a string does not contain another string, using regexp.
+# Arguments:
+#    $1 - The regex to use to match.
+#    $2 - The string to match against (output). By default it will use
+#         $output.
+assert_not_match() {
+    regex="$1"
+    if [[ $# < 2 ]]; then
+        text="$output"
+    else
+        text="$2"
+    fi
+    if [[ "$text" =~ $regex ]]; then
+        (batslib_print_kv_single_or_multi 10 "regex" "$regex" "actual" "$text" \
+         | batslib_decorate "output matches but is expected not to" \
+         | fail)
+    fi
+}
+
+# Asserts a command will timeout. This assertion will fail if the command finishes before
+# the timeout period. If the command fails, it will also fail.
+# Arguments:
+#   $1 - The amount of time (in seconds) to wait for.
+#   $@ - The command to run.
+
+# Asserts that two values are equal.
+# Arguments:
+#    $1 - The expected value.
+#    $2 - The actual value.
+assert_eq() {
+    expected="$1"
+    if [[ $# < 2 ]]; then
+        actual="$output"
+    else
+        actual="$2"
+    fi
+
+    [[ "$actual" == "$expected" ]] || \
+        (batslib_print_kv_single_or_multi 10 "expected" "$expected" "actual" "$actual" \
+         | batslib_decorate "output does not match" \
+         | fail)
+}
+
+# Asserts that two values are not equal.
+# Arguments:
+#    $1 - The expected value.
+#    $2 - The actual value.
+assert_neq() {
+    expected="$1"
+    if [[ $# < 2 ]]; then
+        actual="$output"
+    else
+        actual="$2"
+    fi
+
+    [[ "$actual" != "$expected" ]] || \
+        (batslib_print_kv_single_or_multi 10 "expected" "$expected" "actual" "$actual" \
+         | batslib_decorate "output does not match" \
+         | fail)
+}
+
+
+# Asserts that a process exits within a timeframe
+# Arguments:
+#    $1 - the PID
+#    $2 - the timeout
+assert_process_exits() {
+    pid="$1"
+    timeout="$2"
+
+    timeout $timeout sh -c \
+      "while kill -0 $pid; do echo waiting for process $pid to exit; sleep 1; done" \
+      || (echo "process $pid did not exit" && ps aux && exit 1)
+
+}
+
+assert_file_eventually_exists() {
+    filename="$1"
+    timeout="$2"
+
+    timeout $timeout sh -c \
+      "until [ -f $filename ]; do echo waiting for $filename; sleep 1; done" \
+      || (echo "file $filename was never created" && ls && exit 1)
+}

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -14,7 +14,7 @@ delay = "0.3.1"
 garcon = "0.2.2"
 ic-agent = { path = "../ic-agent", version = "0.5" }
 ic-asset = { path = "../ic-asset", version = "0.0" }
-ic-types = { version = "0.1" }
+ic-types = { version = "0.2" }
 ic-utils = { path = "../ic-utils", version = "0.3" }
 libflate = "1.1.0"
 num-traits = "0.2"

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "icx-asset"
+version = "0.1.0"
+authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+candid = "0.7.1"
+chrono = "0.4.19"
+clap = "3.0.0-beta.2"
+delay = "0.3.1"
+garcon = "0.2.2"
+ic-agent = { path = "../ic-agent", version = "0.5" }
+ic-asset = { path = "../ic-asset", version = "0.0" }
+ic-types = { version = "0.1" }
+ic-utils = { path = "../ic-utils", version = "0.3" }
+libflate = "1.1.0"
+num-traits = "0.2"
+pem = "0.8.1"
+serde = "1.0.115"
+serde_bytes = "0.11.5"
+serde_json = "1.0.57"
+tokio = { version = "1.2.0", features = ["full", "rt"] }
+thiserror = "1.0.24"
+walkdir = "2.3.1"

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -13,10 +13,10 @@ clap = "3.0.0-beta.2"
 delay = "0.3.1"
 garcon = "0.2.2"
 humantime = "2.0.1"
-ic-agent = { path = "../ic-agent", version = "0.5" }
-ic-asset = { path = "../ic-asset", version = "0.0" }
+ic-agent = { path = "../ic-agent", version = "0.6" }
+ic-asset = { path = "../ic-asset", version = "0.1" }
 ic-types = { version = "0.2" }
-ic-utils = { path = "../ic-utils", version = "0.3" }
+ic-utils = { path = "../ic-utils", version = "0.4" }
 libflate = "1.1.0"
 num-traits = "0.2"
 pem = "0.8.1"

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -12,6 +12,7 @@ chrono = "0.4.19"
 clap = "3.0.0-beta.2"
 delay = "0.3.1"
 garcon = "0.2.2"
+humantime = "2.0.1"
 ic-agent = { path = "../ic-agent", version = "0.5" }
 ic-asset = { path = "../ic-asset", version = "0.0" }
 ic-types = { version = "0.2" }

--- a/icx-asset/README.md
+++ b/icx-asset/README.md
@@ -1,0 +1,2 @@
+# `icx-asset`
+A command line tool to manage an asset storage canister.

--- a/icx-asset/src/main.rs
+++ b/icx-asset/src/main.rs
@@ -1,0 +1,93 @@
+use clap::{crate_authors, crate_version, AppSettings, Clap};
+use ic_agent::identity::{AnonymousIdentity, BasicIdentity};
+use ic_agent::{agent, Agent, Identity};
+use candid::Principal;
+use candid::Principal as CanisterId;
+use std::path::PathBuf;
+use std::time::Duration;
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Clap)]
+#[clap(
+version = crate_version!(),
+author = crate_authors!(),
+global_setting = AppSettings::GlobalVersion,
+global_setting = AppSettings::ColoredHelp
+)]
+struct Opts {
+    /// Some input. Because this isn't an Option<T> it's required to be used
+    #[clap(long, default_value = "http://localhost:8000/")]
+    replica: String,
+
+    /// Set for non-IC networks: fetch the root key.  If not passed, use real hardcoded key.
+    #[clap(long)]
+    fetch_root_key: bool,
+
+    /// An optional PEM file to read the identity from. If none is passed,
+    /// a random identity will be created.
+    #[clap(long)]
+    pem: Option<PathBuf>,
+
+    #[clap(subcommand)]
+    subcommand: SubCommand,
+}
+
+#[derive(Clap)]
+enum SubCommand {
+    /// Synchronize a directory to the asset canister
+    Sync(SyncOpts),
+}
+
+#[derive(Clap)]
+struct SyncOpts {
+    /// The canister ID.
+    #[clap()]
+    canister_id: String,
+
+    /// The directory to synchronize
+    #[clap()]
+    directory: PathBuf,
+}
+fn create_identity(maybe_pem: Option<PathBuf>) -> Box<dyn Identity + Sync + Send> {
+    if let Some(pem_path) = maybe_pem {
+        Box::new(BasicIdentity::from_pem_file(pem_path).expect("Could not read the key pair."))
+    } else {
+      Box::new(AnonymousIdentity)
+    }
+}
+
+pub fn expiry_duration() -> Duration {
+    // 5 minutes is max ingress timeout
+    Duration::from_secs(60 * 5)
+}
+
+async fn sync(agent: &Agent, canister_id: &CanisterId, o: &SyncOpts) -> Result {
+    let timeout = expiry_duration();
+    ic_asset::sync(&agent, &o.directory, canister_id, timeout).await?;
+    Ok(())
+}
+#[tokio::main(flavor = "multi_thread", worker_threads = 10)]
+async fn main() -> Result {
+    let opts: Opts = Opts::parse();
+
+    let agent = Agent::builder()
+        .with_transport(
+            agent::http_transport::ReqwestHttpReplicaV2Transport::create(opts.replica.clone())?,
+        )
+        .with_boxed_identity(create_identity(opts.pem))
+        .build()?;
+
+    if opts.fetch_root_key {
+        agent.fetch_root_key().await?;
+    }
+
+    match &opts.subcommand {
+        SubCommand::Sync(o) => {
+            let canister_id = Principal::from_text(&o.canister_id)?;
+            sync(&agent, &canister_id, o).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/icx-asset/src/main.rs
+++ b/icx-asset/src/main.rs
@@ -6,6 +6,8 @@ use candid::Principal as CanisterId;
 use std::path::PathBuf;
 use std::time::Duration;
 
+const DEFAULT_IC_GATEWAY: &str = "https://ic0.app";
+
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[derive(Clap)]
@@ -19,10 +21,6 @@ struct Opts {
     /// Some input. Because this isn't an Option<T> it's required to be used
     #[clap(long, default_value = "http://localhost:8000/")]
     replica: String,
-
-    /// Set for non-IC networks: fetch the root key.  If not passed, use real hardcoded key.
-    #[clap(long)]
-    fetch_root_key: bool,
 
     /// An optional PEM file to read the identity from. If none is passed,
     /// a random identity will be created.
@@ -78,7 +76,7 @@ async fn main() -> Result {
         .with_boxed_identity(create_identity(opts.pem))
         .build()?;
 
-    if opts.fetch_root_key {
+    if !opts.replica.starts_with(DEFAULT_IC_GATEWAY) {
         agent.fetch_root_key().await?;
     }
 

--- a/icx-asset/src/main.rs
+++ b/icx-asset/src/main.rs
@@ -76,7 +76,8 @@ async fn main() -> Result {
         .with_boxed_identity(create_identity(opts.pem))
         .build()?;
 
-    if !opts.replica.starts_with(DEFAULT_IC_GATEWAY) {
+    let normalized_replica = opts.replica.strip_suffix("/").unwrap_or(&opts.replica);
+    if normalized_replica != DEFAULT_IC_GATEWAY {
         agent.fetch_root_key().await?;
     }
 


### PR DESCRIPTION
Adds `icx-asset` command-line tool, with a single command: `sync`, which synchronizes the (recursive) contents of a directory to an asset canister.

Also added github workflow e2e (bats) tests, and a shellcheck CI step for them.
