### PR TITLE
feat: Add an option to let icx read from stdin

### DIFF
--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -22,7 +22,7 @@ use ic_utils::interfaces::management_canister::{
 use ring::signature::Ed25519KeyPair;
 use std::{
     collections::VecDeque, convert::TryFrom, future::Future, io::BufRead, path::PathBuf, pin::Pin,
-    str::FromStr,
+    std::process::exit, str::FromStr,
 };
 use thiserror::Error;
 
@@ -483,8 +483,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Ok(blob) => {
                     print_idl_blob(&blob, &t.output, &method_type)
                         .map_err(|e| format!("Invalid IDL blob: {}", e))?;
+                    return Ok(());
                 }
-                Err(AgentError::TransportError(_)) => return Ok(()),
+                Err(AgentError::TransportError(_)) => (),
                 Err(AgentError::HttpError(HttpErrorPayload {
                     status,
                     content_type,
@@ -505,6 +506,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 Err(s) => eprintln!("Error: {:?}", s),
             }
+            exit(1)
         }
         SubCommand::Status => println!("{:#}", agent.status().await?),
         SubCommand::PrincipalConvert(t) => {
@@ -574,6 +576,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         r#"Error: Invalid STDIN format. Unexpected line: "{}""#,
                         other
                     );
+                    exit(1)
                 }
             }
         }

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -22,7 +22,7 @@ use ic_utils::interfaces::management_canister::{
 use ring::signature::Ed25519KeyPair;
 use std::{
     collections::VecDeque, convert::TryFrom, future::Future, io::BufRead, path::PathBuf, pin::Pin,
-    std::process::exit, str::FromStr,
+    process::exit, str::FromStr,
 };
 use thiserror::Error;
 


### PR DESCRIPTION
Taking call arguments from command line would exceed max limit for big inputs. This adds support to read from stdin when the input is `-`.

Also fixed a minor problem to properly exit with non-zero exit code when error.