### PR TITLE
chore: ic-agent depends on ic-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce6a365c345f4f690d22ae6cfe468e8865fa2720923af20da9384f0f698534"
+checksum = "8303b0828baf50ba6d7d725533845a1b2caa86416898ad42597a69f0f93cabf2"
 dependencies = [
  "anyhow",
  "binread",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base32",
@@ -875,6 +875,7 @@ dependencies = [
  "garcon",
  "hex",
  "http",
+ "ic-types",
  "leb128",
  "mime",
  "mockito",
@@ -897,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "ic-asset"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -920,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hex",
  "ic-agent",
@@ -948,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -965,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "candid",
  "clap",
@@ -984,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.12.3",
@@ -1002,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "icx-proxy"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "candid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,6 @@ name = "icx-proxy"
 version = "0.4.0"
 dependencies = [
  "anyhow",
- "candid",
  "clap",
  "garcon",
  "hex",

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -17,10 +17,10 @@ async-trait = "0.1.35"
 base32 = "0.4.0"
 base64 = "0.12.3"
 byteorder = "1.3.2"
-candid = "0.7.1"
 garcon = { version = "0.2", features = ["async"] }
 hex = "0.4.0"
 http = "0.2.3"
+ic-types = "0.2.0"
 leb128 = "0.2.4"
 mime = "0.3.16"
 openssl = "0.10.32"
@@ -45,6 +45,7 @@ version = "0.8.1"
 optional = true
 
 [dev-dependencies]
+candid = "0.7.1"
 mockito = "0.27.0"
 proptest = "0.9.5"
 tokio = { version = "1.8.1", features = ["full"] }

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -119,5 +119,5 @@ pub use agent::{agent_error, agent_error::AgentError, nonce::NonceFactory, Agent
 pub use identity::{Identity, Signature};
 pub use request_id::{to_request_id, RequestId, RequestIdError};
 
-pub use ic_types;
 pub(crate) use crate::ic_types::hash_tree;
+pub use ic_types;

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -119,5 +119,5 @@ pub use agent::{agent_error, agent_error::AgentError, nonce::NonceFactory, Agent
 pub use identity::{Identity, Signature};
 pub use request_id::{to_request_id, RequestId, RequestIdError};
 
+pub use ic_types;
 pub(crate) use crate::ic_types::hash_tree;
-pub use candid::types::ic_types;

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 anyhow = "1.0.34"
-candid = { version = "0.7.1" }
+candid = "0.7.1"
 flate2 = "1.0.11"
 futures = "0.3.5"
 futures-intrusive = "0.4.0"

--- a/icx-proxy/Cargo.toml
+++ b/icx-proxy/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.34"
-candid = "0.7.1"
 clap = "3.0.0-beta.2"
 garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.3"


### PR DESCRIPTION
When there is an upgrade in `ic-types` itself, we won't need wait for `candid` upgrade first.