### PR TITLE
chore: update workflow scripts to refer to main branch

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -3,7 +3,7 @@ name: ic-ref
 on:
   push:
     branches:
-      - next
+      - main
   pull_request_target:
   # Also run on every pull_request that changes the workflow, as the repo.
   pull_request:

--- a/.github/workflows/icx_asset.yml
+++ b/.github/workflows/icx_asset.yml
@@ -2,7 +2,7 @@ name: test-icx-asset
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 jobs:
   icx-asset-darwin:

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -3,7 +3,7 @@ name: Publish Cargo docs
 on:
   push:
     branches:
-      - next
+      - main
   pull_request_target:
 
 jobs:
@@ -31,8 +31,8 @@ jobs:
          # Add an index.html for the root of the netlify docs.
         rustdoc README.md --output target/doc && mv target/doc/README.html target/doc/index.html
 
-    - if: github.ref == 'refs/heads/next'
-      name: Deploy to Netlify (next only)
+    - if: github.ref == 'refs/heads/main'
+      name: Deploy to Netlify (main only)
       uses: South-Paw/action-netlify-deploy@v1.0.4
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
         build-dir: target/doc/
         comment-on-commit: true
 
-    - if: github.ref != 'refs/heads/next'
+    - if: github.ref != 'refs/heads/main'
       name: Deploy to Netlify (PR only)
       id: deploy_docs
       uses: netlify/actions/cli@6c34c3fcafc69ac2e1d6dbf226560329c6dfc51b
@@ -51,7 +51,7 @@ jobs:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
-    - if: github.ref != 'refs/heads/next'
+    - if: github.ref != 'refs/heads/main'
       name: Commenting on PR
       uses: unsplash/comment-on-pr@v1.2.0
       env:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,7 +10,7 @@ on:
       - '.github/**'
   push:
     branches:
-      - master
+      - main
 
 jobs:
   check_macos:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches:
-      - next
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
When we renamed the `master` branch to `main`, we stopped getting the little green checks in the commit history.