### PR TITLE
chore: use ic-hs rather than ic-ref; remove IC_REF_TOKEN secret

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -29,16 +29,12 @@ jobs:
           path: main
       - uses: actions/checkout@v2
         with:
-          repository: 'dfinity-lab/ic-ref'
-          # Personal Read-only Access Token created by hans.larsen@dfinity.org
-          token: ${{ secrets.IC_REF_TOKEN }}
-          path: ic-ref
+          repository: 'dfinity/ic-hs'
+          path: ic-hs
           ref: ${{ matrix.spec }}
       - uses: actions/checkout@v2
         with:
           repository: 'dfinity/wallet-rs'
-          # Personal Read-only Access Token created by hans.larsen@dfinity.org
-          token: ${{ secrets.IC_REF_TOKEN }}
           path: wallet-rs
           ref: b5e38e1f1e3f414f15c139a49eee269769928ee2
 
@@ -69,20 +65,20 @@ jobs:
           rustup default ${{ matrix.rust }}
           rustup target add wasm32-unknown-unknown
 
-      - name: Build ic-ref
+      - name: Build ic-hs
         run: |
           ls -l /opt/ghc/
           export PATH=/opt/ghc/bin:$PATH
           cabal --version
           ghc-${{ matrix.ghc }} --version
           mkdir -p $HOME/bin
-          cd ic-ref/impl
+          cd ic-hs
           cabal update
           cabal install exe:ic-ref -w ghc-${{ matrix.ghc }} --overwrite-policy=always  --installdir=$HOME/bin
 
       - name: Build universal-canister
         run: |
-          cd ic-ref/universal-canister
+          cd ic-hs/universal-canister
           cargo build --target wasm32-unknown-unknown --release
           cp target/wasm32-unknown-unknown/release/universal_canister.wasm $HOME/canister.wasm
 


### PR DESCRIPTION
Copied from https://github.com/dfinity/agent-rs/pull/228

The ic-ref repo requires a github token (since it's a private repo).  By using the public ic-hs repo, we won't need that token.  That will allow us to remove the IC_REF_TOKEN secret from settings, and to then run ic-ref tests against `pull_request` (the PR branch) rather than `pull_request_target` (the main branch).