### PR TITLE
feat: icx-asset ls

### DIFF
--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -23,6 +23,24 @@ icx_asset_sync() {
   assert_command "$ICX_ASSET" --pem "$HOME"/.config/dfx/identity/default/identity.pem sync "$CANISTER_ID" src/e2e_project_assets/assets
 }
 
+icx_asset_list() {
+  CANISTER_ID=$(dfx canister id e2e_project_assets)
+  assert_command "$ICX_ASSET" --pem "$HOME"/.config/dfx/identity/default/identity.pem ls "$CANISTER_ID"
+}
+
+@test "lists assets" {
+    for i in $(seq 1 400); do
+      echo "some easily duplicate text $i" >>src/e2e_project_assets/assets/notreally.js
+    done
+    icx_asset_sync
+
+    icx_asset_list
+
+    assert_match "sample-asset.txt.*text/plain.*identity"
+    assert_match "notreally.js.*application/javascript.*gzip"
+    assert_match "notreally.js.*application/javascript.*identity"
+}
+
 @test "creates new files" {
   echo "new file content" >src/e2e_project_assets/assets/new-asset.txt
   icx_asset_sync
@@ -77,3 +95,4 @@ icx_asset_sync() {
     assert_command dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"identity"}})'
     assert_command_fail dfx canister --no-wallet call --query e2e_project_assets get '(record{key="/sample-asset.txt";accept_encodings=vec{"arbitrary"}})'
 }
+

--- a/icx-asset/src/main.rs
+++ b/icx-asset/src/main.rs
@@ -6,11 +6,11 @@ use ic_agent::identity::{AnonymousIdentity, BasicIdentity};
 use ic_agent::{agent, Agent, Identity};
 use ic_utils::call::SyncCall;
 
+use ic_utils::Canister;
 use num_traits::ToPrimitive;
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
-use ic_utils::Canister;
 
 const DEFAULT_IC_GATEWAY: &str = "https://ic0.app";
 


### PR DESCRIPTION
Sample output:
```
$ icx-asset ls ryjl3-tyaaa-aaaaa-aaaba-cai
 2021-07-19 13:11:59           25397 /logo.png                                          (image/png, identity)
 2021-07-19 13:11:59              24 /sample-asset.txt                                  (text/plain, identity)
 2021-07-19 13:11:59             340 /index.html                                        (text/html, gzip)
 2021-07-19 13:11:59             570 /index.html                                        (text/html, identity)
 2021-07-19 13:11:59          148995 /index.js.map                                      (text/plain, gzip)
 2021-07-19 13:11:59          649242 /index.js.map                                      (text/plain, identity)
 2021-07-19 13:11:59             263 /main.css                                          (text/css, gzip)
 2021-07-19 13:11:59             484 /main.css                                          (text/css, identity)
 2021-07-19 13:11:59          143875 /index.js                                          (application/javascript, gzip)
 2021-07-19 13:11:59          605596 /index.js                                          (application/javascript, identity)
```