### PR TITLE
fix: run ic ref tests against pr branch

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Build wallet canister
         run: |
           cd wallet-rs/
+          echo "[workspace]" >>Cargo.toml
           sh ./wallet/build.sh
           cp wallet/target/wasm32-unknown-unknown/release/wallet-opt.wasm $HOME/wallet.wasm
 

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
-  # Also run on every pull_request that changes the workflow, as the repo.
   pull_request:
-    paths:
-      - '.github/**'
 
 jobs:
   test:
@@ -25,8 +21,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          path: main
       - uses: actions/checkout@v2
         with:
           repository: 'dfinity/ic-hs'

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Build universal-canister
         run: |
           cd ic-hs/universal-canister
+          echo "[workspace]" >>Cargo.toml
           cargo build --target wasm32-unknown-unknown --release
           cp target/wasm32-unknown-unknown/release/universal_canister.wasm $HOME/canister.wasm
 

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          path: main
       - uses: actions/checkout@v2
         with:
           repository: 'dfinity/ic-hs'
@@ -73,14 +75,12 @@ jobs:
       - name: Build universal-canister
         run: |
           cd ic-hs/universal-canister
-          echo "[workspace]" >>Cargo.toml
           cargo build --target wasm32-unknown-unknown --release
           cp target/wasm32-unknown-unknown/release/universal_canister.wasm $HOME/canister.wasm
 
       - name: Build wallet canister
         run: |
           cd wallet-rs/
-          echo "[workspace]" >>Cargo.toml
           sh ./wallet/build.sh
           cp wallet/target/wasm32-unknown-unknown/release/wallet-opt.wasm $HOME/wallet.wasm
 

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -29,16 +29,12 @@ jobs:
           path: main
       - uses: actions/checkout@v2
         with:
-          repository: 'dfinity-lab/ic-ref'
-          # Personal Read-only Access Token created by hans.larsen@dfinity.org
-          token: ${{ secrets.IC_REF_TOKEN }}
-          path: ic-ref
+          repository: 'dfinity/ic-hs'
+          path: ic-hs
           ref: ${{ matrix.spec }}
       - uses: actions/checkout@v2
         with:
           repository: 'dfinity/wallet-rs'
-          # Personal Read-only Access Token created by hans.larsen@dfinity.org
-          token: ${{ secrets.IC_REF_TOKEN }}
           path: wallet-rs
           ref: b5e38e1f1e3f414f15c139a49eee269769928ee2
 
@@ -69,20 +65,20 @@ jobs:
           rustup default ${{ matrix.rust }}
           rustup target add wasm32-unknown-unknown
 
-      - name: Build ic-ref
+      - name: Build ic-hs
         run: |
           ls -l /opt/ghc/
           export PATH=/opt/ghc/bin:$PATH
           cabal --version
           ghc-${{ matrix.ghc }} --version
           mkdir -p $HOME/bin
-          cd ic-ref/impl
+          cd ic-hs
           cabal update
           cabal install exe:ic-ref -w ghc-${{ matrix.ghc }} --overwrite-policy=always  --installdir=$HOME/bin
 
       - name: Build universal-canister
         run: |
-          cd ic-ref/universal-canister
+          cd ic-hs/universal-canister
           cargo build --target wasm32-unknown-unknown --release
           cp target/wasm32-unknown-unknown/release/universal_canister.wasm $HOME/canister.wasm
 


### PR DESCRIPTION
Prerequisite for merging this pr: removal of the IC_REF_TOKEN from github repo settings.

Since we're now using the public ic-hs repo, we don't need a github token in order to access it, and so we can run CI against the PR branch (`pull_request`) rather than the PR's base branch (`pull_request_target`).