### PR TITLE
refactor: attempt to use Canister interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,7 @@ dependencies = [
  "hex",
  "ic-agent",
  "ic-types",
+ "ic-utils",
  "mime",
  "mime_guess",
  "mockito",

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -22,6 +22,7 @@ garcon = { version = "0.2", features = ["async"] }
 hex = {version = "0.4.2", features = ["serde"] }
 ic-agent = { path = "../ic-agent", version = "0.6", features = [ "pem" ] }
 ic-types = { version = "0.2.1", features = [ "serde" ] }
+ic-utils = { path = "../ic-utils", version = "0.4" }
 mime = "0.3.16"
 mime_guess = "2.0.3"
 openssl = "0.10.32"

--- a/ic-asset/src/asset_canister/list.rs
+++ b/ic-asset/src/asset_canister/list.rs
@@ -4,6 +4,8 @@ use crate::convenience::waiter_with_timeout;
 use crate::params::CanisterCallParams;
 use candid::{Decode, Encode};
 use std::collections::HashMap;
+use std::time::Duration;
+use ic_utils::Canister;
 
 pub(crate) async fn list_assets(
     canister_call_params: &CanisterCallParams<'_>,
@@ -18,6 +20,28 @@ pub(crate) async fn list_assets(
         .await?;
 
     let assets: HashMap<_, _> = candid::Decode!(&response, Vec<AssetDetails>)?
+        .into_iter()
+        .map(|d| (d.key.clone(), d))
+        .collect();
+
+    Ok(assets)
+}
+
+pub(crate) async fn _list_assets(
+    canister: &Canister<'_>,
+    timeout: Duration,
+) -> anyhow::Result<HashMap<String, AssetDetails>> {
+    let args = ListAssetsRequest {};
+    let response = canister
+        .update_(LIST)
+        .with_arg(candid::Encode!(&args)?)
+        //.expire_after(canister_call_params.timeout)
+        .build()
+        .map(|result: (Vec<AssetDetails>,)|result.0)
+        .call_and_wait(waiter_with_timeout(timeout))
+        .await?;
+
+    let assets: HashMap<_, _> = response
         .into_iter()
         .map(|d| (d.key.clone(), d))
         .collect();


### PR DESCRIPTION
Seeking help with error:
```
error[E0277]: the trait bound `for<'de> std::vec::Vec<asset_canister::protocol::AssetDetails>: candid::utils::ArgumentDecoder<'de>` is not satisfied
  --> ic-asset/src/asset_canister/list.rs:40:10
   |
40 |         .map(|result: (Vec<AssetDetails>,)|result.0)
   |          ^^^ the trait `for<'de> candid::utils::ArgumentDecoder<'de>` is not implemented for `std::vec::Vec<asset_canister::protocol::AssetDetails>`

error[E0599]: no method named `call_and_wait` found for struct `ic_utils::call::MappedAsyncCaller<(std::vec::Vec<asset_canister::protocol::AssetDetails>,), std::vec::Vec<asset_canister::protocol::AssetDetails>, ic_utils::call::AsyncCaller<'_, (std::vec::Vec<asset_canister::protocol::AssetDetails>,)>, [closure@ic-asset/src/asset_canister/list.rs:40:14: 40:52]>` in the current scope
   --> ic-asset/src/asset_canister/list.rs:41:10
    |
41  |         .call_and_wait(waiter_with_timeout(timeout))
    |          ^^^^^^^^^^^^^ method not found in `ic_utils::call::MappedAsyncCaller<(std::vec::Vec<asset_canister::protocol::AssetDetails>,), std::vec::Vec<asset_canister::protocol::AssetDetails>, ic_utils::call::AsyncCaller<'_, (std::vec::Vec<asset_canister::protocol::AssetDetails>,)>, [closure@ic-asset/src/asset_canister/list.rs:40:14: 40:52]>`

```