### PR TITLE
chore: release of ic-agent

### DIFF
--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-agent"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Agent library to communicate with the Internet Computer, following the Public Specification."

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-asset"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Library for storing files in an asset canister."
@@ -20,7 +20,7 @@ futures = "0.3.5"
 futures-intrusive = "0.4.0"
 garcon = { version = "0.2", features = ["async"] }
 hex = {version = "0.4.2", features = ["serde"] }
-ic-agent = { path = "../ic-agent", version = "0.6", features = [ "pem" ] }
+ic-agent = { path = "../ic-agent", version = "0.7", features = [ "pem" ] }
 ic-types = { version = "0.2.1", features = [ "serde" ] }
 mime = "0.3.16"
 mime_guess = "2.0.3"

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-identity-hsm"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Identity implementation for HSM for the ic-agent package."
 homepage = "https://docs.rs/ic-identity-hsm"
@@ -14,7 +14,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 hex = "0.4.2"
-ic-agent = { path = "../ic-agent", version = "0.6", features = [ "pem" ] }
+ic-agent = { path = "../ic-agent", version = "0.7", features = [ "pem" ] }
 num-bigint = "0.3.1"
 openssl = "0.10.30"
 pkcs11 = "0.5.0"

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-utils"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Collection of utilities for Rust, on top of ic-agent, to communicate with the Internet Computer, following the Public Specification."
@@ -18,7 +18,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 async-trait = "0.1.40"
 candid = "0.7.4"
 garcon = { version = "0.2", features = ["async"] }
-ic-agent = { path = "../ic-agent", version = "0.6" }
+ic-agent = { path = "../ic-agent", version = "0.7" }
 serde = "1.0.115"
 serde_bytes = "0.11"
 strum = "0.20"

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-asset"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 
@@ -13,10 +13,10 @@ clap = "3.0.0-beta.2"
 delay = "0.3.1"
 garcon = "0.2.2"
 humantime = "2.0.1"
-ic-agent = { path = "../ic-agent", version = "0.6" }
-ic-asset = { path = "../ic-asset", version = "0.1" }
+ic-agent = { path = "../ic-agent", version = "0.7" }
+ic-asset = { path = "../ic-asset", version = "0.2" }
 ic-types = "0.2.1"
-ic-utils = { path = "../ic-utils", version = "0.4" }
+ic-utils = { path = "../ic-utils", version = "0.5" }
 libflate = "1.1.0"
 num-traits = "0.2"
 pem = "0.8.1"

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-cert"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 
@@ -12,7 +12,7 @@ base64 = "0.12"
 clap = "3.0.0-beta.2"
 chrono = "0.4.19"
 hex = "0.4.2"
-ic-agent = { path = "../ic-agent", version = "0.6" }
+ic-agent = { path = "../ic-agent", version = "0.7" }
 leb128 = "0.2.4"
 reqwest = { version = "0.11",features = [ "blocking", "rustls-tls" ] }
 sha2 = "0.9.1"

--- a/icx-proxy/Cargo.toml
+++ b/icx-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-proxy"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to create an HTTP proxy to the Internet Computer."
@@ -23,8 +23,8 @@ garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.3"
 hyper = { version = "0.14.4", features = ["full"] }
 hyper-tls = "0.5.0"
-ic-agent = { path = "../ic-agent", version = "0.6" }
-ic-utils = { path = "../ic-utils", version = "0.4" }
+ic-agent = { path = "../ic-agent", version = "0.7" }
+ic-utils = { path = "../ic-utils", version = "0.5" }
 tokio = { version = "1.8.1", features = ["full"] }
 serde = "1.0.115"
 serde_json = "1.0.57"

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to call canisters on the Internet Computer."
@@ -22,8 +22,8 @@ clap = "3.0.0-beta.1"
 garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.2"
 humantime = "2.0.1"
-ic-agent = { path = "../ic-agent", version = "0.6" }
-ic-utils = { path = "../ic-utils", version = "0.4" }
+ic-agent = { path = "../ic-agent", version = "0.7" }
+ic-utils = { path = "../ic-utils", version = "0.5" }
 pem = "0.8.1"
 ring = "0.16.11"
 serde = "1.0.115"


### PR DESCRIPTION
icx-asset: 0.1.0 => 0.2.0
ic-utils: 0.4.0 => 0.5.0
icx-cert: 0.2.0 => 0.3.0
icx-proxy: 0.4.0 => 0.5.0
ic-asset: 0.1.0 => 0.2.0
ic-identity-hsm: 0.3.3 => 0.3.4
icx: 0.3.0 => 0.4.0
ic-agent: 0.6.0 => 0.7.0


- ic-agent depends on ic-types
- icx-asset (sync, ls)
- candid 0.7.4, ic-types 0.2.1
- icx send/sign updated to new ic-agent api