### PR TITLE
chore: update cargo_metadata library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,14 +254,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
+checksum = "c297bd3135f558552f99a0daa180876984ea2c4ffa7470314540dff8c654109a"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
- "semver-parser",
  "serde",
  "serde_json",
 ]
@@ -1578,15 +1577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,21 +2038,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 dependencies = [
- "semver-parser",
  "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -2544,12 +2524,6 @@ name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/zzz-release/Cargo.toml
+++ b/zzz-release/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.40"
-cargo_metadata = "0.13.1"
+cargo_metadata = "0.14.0"
 clap = "3.0.0-beta.2"
 git2 = "0.13.20"
 toml-parse = "0.2.11"

--- a/zzz-release/src/main.rs
+++ b/zzz-release/src/main.rs
@@ -427,14 +427,16 @@ fn main() -> Result<()> {
 
     let mut version_map = VersionMap::new();
     for (name, package) in packages_minor.iter() {
-        let mut v = package.version.clone();
-        v.increment_minor();
-        version_map.insert(name.clone(), (package.clone(), v));
+        let incremented = Version::new(package.version.major, package.version.minor + 1, 0);
+        version_map.insert(name.clone(), (package.clone(), incremented));
     }
     for (name, package) in packages_patch.iter() {
-        let mut v = package.version.clone();
-        v.increment_patch();
-        version_map.insert(name.clone(), (package.clone(), v));
+        let incremented = Version::new(
+            package.version.major,
+            package.version.minor,
+            package.version.patch + 1,
+        );
+        version_map.insert(name.clone(), (package.clone(), incremented));
     }
 
     for patch in opts.package {


### PR DESCRIPTION
cargo_metadata 0.14.0 depends on semver 1.0.0, which no longer provides Version.increment_minor() or Version.increment_patch().