### PR TITLE
feat: expose underlying generics for `Agent`

### DIFF
--- a/ic-agent/src/agent/agent_config.rs
+++ b/ic-agent/src/agent/agent_config.rs
@@ -6,13 +6,14 @@ use std::{sync::Arc, time::Duration};
 
 /// A configuration for an agent.
 
-pub type AgentConfig = AgentConfigImpl<NonceFactory>;
+pub type AgentConfig =
+    AgentConfigImpl<NonceFactory, Arc<dyn Identity>, Arc<dyn ReplicaV2Transport>>;
 
-pub struct AgentConfigImpl<N: NonceGenerator> {
+pub struct AgentConfigImpl<N: NonceGenerator, I: Identity, T: ReplicaV2Transport> {
     pub nonce_factory: N,
-    pub identity: Arc<dyn Identity>,
+    pub identity: I,
     pub ingress_expiry_duration: Option<Duration>,
-    pub transport: Option<Arc<dyn ReplicaV2Transport>>,
+    pub transport: Option<T>,
 }
 
 impl Default for AgentConfig {

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -4,6 +4,7 @@
 use crate::{
     agent::{
         http_transport::ReqwestHttpReplicaV2Transport,
+        query_raw,
         replica_api::{CallReply, QueryResponse},
         Status,
     },
@@ -33,15 +34,15 @@ fn query() -> Result<(), AgentError> {
         .build()?;
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(async {
-        agent
-            .query_raw(
-                &Principal::management_canister(),
-                Principal::management_canister(),
-                "main",
-                &[],
-                None,
-            )
-            .await
+        query_raw(
+            &agent,
+            &Principal::management_canister(),
+            Principal::management_canister(),
+            "main",
+            &[],
+            None,
+        )
+        .await
     });
 
     query_mock.assert();
@@ -64,15 +65,15 @@ fn query_error() -> Result<(), AgentError> {
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
 
     let result = runtime.block_on(async {
-        agent
-            .query_raw(
-                &Principal::management_canister(),
-                Principal::management_canister(),
-                "greet",
-                &[],
-                None,
-            )
-            .await
+        query_raw(
+            &agent,
+            &Principal::management_canister(),
+            Principal::management_canister(),
+            "greet",
+            &[],
+            None,
+        )
+        .await
     });
 
     query_mock.assert();
@@ -103,15 +104,15 @@ fn query_rejected() -> Result<(), AgentError> {
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
 
     let result = runtime.block_on(async {
-        agent
-            .query_raw(
-                &Principal::management_canister(),
-                Principal::management_canister(),
-                "greet",
-                &[],
-                None,
-            )
-            .await
+        query_raw(
+            &agent,
+            &Principal::management_canister(),
+            Principal::management_canister(),
+            "greet",
+            &[],
+            None,
+        )
+        .await
     });
 
     query_mock.assert();

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -40,6 +40,15 @@ impl<N: NonceGenerator, I: Identity, T: ReplicaV2Transport> AgentBuilderImpl<N, 
         }
     }
 
+    /// Same as [with_transport], but provides a boxed implementation instead
+    /// of a direct type.
+    pub fn with_boxed_transport(
+        self,
+        transport: Box<dyn ReplicaV2Transport>,
+    ) -> AgentBuilderImpl<N, I, Arc<dyn ReplicaV2Transport>> {
+        self.with_transport(Arc::from(transport))
+    }
+
     /// Add a NonceFactory to this AgentImpl. By default, no nonce is produced.
     pub fn with_nonce_factory(
         self,
@@ -88,14 +97,7 @@ impl<N: NonceGenerator, I: Identity, T: ReplicaV2Transport> AgentBuilderImpl<N, 
         self,
         identity: Box<dyn Identity>,
     ) -> AgentBuilderImpl<N, Arc<dyn Identity>, T> {
-        AgentBuilderImpl {
-            config: AgentConfigImpl {
-                nonce_factory: self.config.nonce_factory,
-                identity: Arc::from(identity),
-                ingress_expiry_duration: self.config.ingress_expiry_duration,
-                transport: self.config.transport,
-            },
-        }
+        self.with_identity(Arc::from(identity))
     }
 
     /// Provides a _default_ ingress expiry. This is the delta that will be applied

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -180,7 +180,7 @@ pub enum PollResult {
 /// ```ignore
 /// # // This test is ignored because it requires an ic to be running. We run these
 /// # // in the ic-ref workflow.
-/// use ic_agent::{Agent, ic_types::Principal};
+/// use ic_agent::{agent::http_transport::ReqwestHttpReplicaV2Transport, Agent, ic_types::Principal};
 /// use candid::{Encode, Decode, CandidType, Nat};
 /// use serde::Deserialize;
 ///
@@ -209,7 +209,7 @@ pub enum PollResult {
 /// #
 /// async fn create_a_canister() -> Result<Principal, Box<dyn std::error::Error>> {
 ///   let agent = Agent::builder()
-///     .with_url(URL)
+///     .with_transport(ReqwestHttpReplicaV2Transport::create(URL).unwrap())
 ///     .with_identity(create_identity())
 ///     .build()?;
 ///
@@ -252,7 +252,7 @@ pub type Agent = AgentImpl<NonceFactory, Arc<dyn Identity>, Arc<dyn ReplicaV2Tra
 /// ```ignore
 /// # // This test is ignored because it requires an ic to be running. We run these
 /// # // in the ic-ref workflow.
-/// use ic_agent::{Agent, ic_types::Principal};
+/// use ic_agent::{agent::http_transport::ReqwestHttpReplicaV2Transport, Agent, ic_types::Principal};
 /// use candid::{Encode, Decode, CandidType, Nat};
 /// use serde::Deserialize;
 ///
@@ -281,7 +281,7 @@ pub type Agent = AgentImpl<NonceFactory, Arc<dyn Identity>, Arc<dyn ReplicaV2Tra
 /// #
 /// async fn create_a_canister() -> Result<Principal, Box<dyn std::error::Error>> {
 ///   let agent = Agent::builder()
-///     .with_url(URL)
+///     .with_transport(ReqwestHttpReplicaV2Transport::create(URL).unwrap())
 ///     .with_identity(create_identity())
 ///     .build()?;
 ///

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -1,5 +1,6 @@
 //! Types and traits dealing with identity across the Internet Computer.
 use crate::export::Principal;
+use std::sync::Arc;
 
 pub(crate) mod anonymous;
 pub(crate) mod basic;
@@ -35,4 +36,21 @@ pub trait Identity: Send + Sync {
     /// Sign a blob, the concatenation of the domain separator & request ID,
     /// creating the sender signature.
     fn sign(&self, blob: &[u8]) -> Result<Signature, String>;
+}
+
+impl<I: Identity + ?Sized> Identity for Box<I> {
+    fn sender(&self) -> Result<Principal, String> {
+        (**self).sender()
+    }
+    fn sign(&self, blob: &[u8]) -> Result<Signature, String> {
+        (**self).sign(blob)
+    }
+}
+impl<I: Identity + ?Sized> Identity for Arc<I> {
+    fn sender(&self) -> Result<Principal, String> {
+        (**self).sender()
+    }
+    fn sign(&self, blob: &[u8]) -> Result<Signature, String> {
+        (**self).sign(blob)
+    }
 }

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -29,7 +29,7 @@
 //! ```ignore
 //! # // This test is ignored because it requires an ic to be running. We run these
 //! # // in the ic-ref workflow.
-//! use ic_agent::{Agent, ic_types::Principal};
+//! use ic_agent::{agent::http_transport::ReqwestHttpReplicaV2Transport, Agent, ic_types::Principal};
 //! use candid::{Encode, Decode, CandidType, Nat};
 //! use serde::Deserialize;
 //!
@@ -58,7 +58,7 @@
 //! #
 //! async fn create_a_canister() -> Result<Principal, Box<dyn std::error::Error>> {
 //!   let agent = Agent::builder()
-//!     .with_url(URL)
+//!     .with_transport(ReqwestHttpReplicaV2Transport::create(URL).unwrap())
 //!     .with_identity(create_identity())
 //!     .build()?;
 //!   // Only do the following call when not contacting the IC main net (e.g. a local emulator).

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -60,7 +60,7 @@ where
     /// ```ignored
     /// # // This test is ignored because it requires an ic to be running. We run these
     /// # // in the ic-ref workflow.
-    /// use ic_agent::{Agent, Principal};
+    /// use ic_agent::{agent::http_transport::ReqwestHttpReplicaV2Transport, Agent, Principal};
     /// use ic_utils::{Canister, interfaces};
     /// use candid::{Encode, Decode, CandidType};
     ///
@@ -80,7 +80,7 @@ where
     /// #
     /// async fn create_a_canister() -> Result<Principal, Box<dyn std::error::Error>> {
     ///   let agent = Agent::builder()
-    ///     .with_url(URL)
+    ///     .with_transport(ReqwestHttpReplicaV2Transport::create(URL).unwrap())
     ///     .with_identity(create_identity())
     ///     .build()?;
     ///   let management_canister = Canister::builder()

--- a/ic-utils/src/call/expiry.rs
+++ b/ic-utils/src/call/expiry.rs
@@ -1,4 +1,4 @@
-use ic_agent::agent::{NonceGenerator, QueryBuilder, UpdateBuilder};
+use ic_agent::agent::{QueryBuilder, UpdateBuilder};
 
 /// An expiry value. Either not specified (the default), a delay relative to the time the
 /// call is made, or a specific date time.
@@ -28,7 +28,7 @@ impl Expiry {
         Self::DateTime(dt)
     }
 
-    pub(crate) fn apply_to_update<N: NonceGenerator>(self, u: &mut UpdateBuilder<'_, N>) {
+    pub(crate) fn apply_to_update(self, u: &mut UpdateBuilder) {
         match self {
             Expiry::Unspecified => {}
             Expiry::Delay(d) => {
@@ -40,7 +40,7 @@ impl Expiry {
         }
     }
 
-    pub(crate) fn apply_to_query<N: NonceGenerator>(self, u: &mut QueryBuilder<'_, N>) {
+    pub(crate) fn apply_to_query(self, u: &mut QueryBuilder) {
         match self {
             Expiry::Unspecified => {}
             Expiry::Delay(d) => {

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -1,6 +1,6 @@
 use crate::{call::SyncCall, canister::CanisterBuilder, Canister};
 use candid::{CandidType, Deserialize, Func, Nat};
-use ic_agent::{export::Principal, Agent};
+use ic_agent::{agent::AgentTrait, export::Principal};
 use serde_bytes::ByteBuf;
 use std::fmt::Debug;
 
@@ -59,7 +59,7 @@ pub struct StreamingCallbackHttpResponse {
 impl HttpRequestCanister {
     /// Create an instance of a [Canister] implementing the [HttpRequestCanister] interface
     /// and pointing to the right Canister ID.
-    pub fn create(agent: &Agent, canister_id: Principal) -> Canister<HttpRequestCanister> {
+    pub fn create(agent: &dyn AgentTrait, canister_id: Principal) -> Canister<HttpRequestCanister> {
         Canister::builder()
             .with_agent(agent)
             .with_canister_id(canister_id)
@@ -70,7 +70,7 @@ impl HttpRequestCanister {
 
     /// Creating a CanisterBuilder with the right interface and Canister Id. This can
     /// be useful, for example, for providing additional Builder information.
-    pub fn with_agent(agent: &Agent) -> CanisterBuilder<HttpRequestCanister> {
+    pub fn with_agent(agent: &dyn AgentTrait) -> CanisterBuilder<HttpRequestCanister> {
         Canister::builder()
             .with_agent(agent)
             .with_interface(HttpRequestCanister)

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -1,6 +1,6 @@
 use crate::{call::AsyncCall, canister::CanisterBuilder, Canister};
 use candid::{CandidType, Deserialize};
-use ic_agent::{export::Principal, Agent};
+use ic_agent::{agent::AgentTrait, export::Principal};
 use std::{convert::AsRef, fmt::Debug};
 use strum_macros::{AsRefStr, EnumString};
 
@@ -31,7 +31,7 @@ pub enum MgmtMethod {
 impl ManagementCanister {
     /// Create an instance of a [Canister] implementing the ManagementCanister interface
     /// and pointing to the right Canister ID.
-    pub fn create(agent: &Agent) -> Canister<ManagementCanister> {
+    pub fn create(agent: &dyn AgentTrait) -> Canister<ManagementCanister> {
         Canister::builder()
             .with_agent(agent)
             .with_canister_id(Principal::management_canister())
@@ -42,7 +42,7 @@ impl ManagementCanister {
 
     /// Creating a CanisterBuilder with the right interface and Canister Id. This can
     /// be useful, for example, for providing additional Builder information.
-    pub fn with_agent(agent: &Agent) -> CanisterBuilder<ManagementCanister> {
+    pub fn with_agent(agent: &dyn AgentTrait) -> CanisterBuilder<ManagementCanister> {
         Canister::builder()
             .with_agent(agent)
             .with_canister_id(Principal::management_canister())

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -10,7 +10,7 @@ use crate::{
 use async_trait::async_trait;
 use candid::{decode_args, utils::ArgumentDecoder, CandidType, Deserialize};
 use garcon::Waiter;
-use ic_agent::{agent::UpdateBuilder, export::Principal, Agent, AgentError, RequestId};
+use ic_agent::{agent::AgentTrait, agent::UpdateBuilder, export::Principal, AgentError, RequestId};
 
 pub struct CallForwarder<'agent, 'canister: 'agent, Out>
 where
@@ -183,7 +183,7 @@ pub struct CallResult {
 impl Wallet {
     /// Create an instance of a [Canister] implementing the Wallet interface
     /// and pointing to the right Canister ID.
-    pub fn create(agent: &Agent, canister_id: Principal) -> Canister<Wallet> {
+    pub fn create(agent: &dyn AgentTrait, canister_id: Principal) -> Canister<Wallet> {
         Canister::builder()
             .with_agent(agent)
             .with_canister_id(canister_id)
@@ -194,7 +194,7 @@ impl Wallet {
 
     /// Creating a CanisterBuilder with the right interface and Canister Id. This can
     /// be useful, for example, for providing additional Builder information.
-    pub fn with_agent(agent: &Agent) -> CanisterBuilder<Wallet> {
+    pub fn with_agent(agent: &dyn AgentTrait) -> CanisterBuilder<Wallet> {
         Canister::builder().with_agent(agent).with_interface(Wallet)
     }
 }
@@ -446,7 +446,7 @@ impl<'agent> Canister<'agent, Wallet> {
         CallForwarder {
             wallet: self,
             destination: canister_id,
-            method_name,
+            method_name: method_name.into(),
             amount,
             arg: argument,
             phantom_out: std::marker::PhantomData,

--- a/icx-asset/src/main.rs
+++ b/icx-asset/src/main.rs
@@ -6,11 +6,10 @@ use crate::commands::sync::sync;
 use candid::Principal;
 use clap::{crate_authors, crate_version, AppSettings, Clap};
 use ic_agent::identity::{AnonymousIdentity, BasicIdentity};
-use ic_agent::{agent, Agent, Identity};
+use ic_agent::{agent::http_transport::ReqwestHttpReplicaV2Transport, Agent, Identity};
 
 use crate::commands::upload::upload;
-use std::path::PathBuf;
-use std::time::Duration;
+use std::{path::PathBuf, sync::Arc, time::Duration};
 
 const DEFAULT_IC_GATEWAY: &str = "https://ic0.app";
 
@@ -100,9 +99,9 @@ async fn main() -> support::Result {
         .unwrap_or_else(|| Duration::from_secs(60 * 5)); // 5 minutes is max ingress timeout
 
     let agent = Agent::builder()
-        .with_transport(
-            agent::http_transport::ReqwestHttpReplicaV2Transport::create(opts.replica.clone())?,
-        )
+        .with_transport(Arc::new(ReqwestHttpReplicaV2Transport::create(
+            opts.replica.clone(),
+        )?))
         .with_boxed_identity(create_identity(opts.pem))
         .build()?;
 

--- a/icx-asset/src/main.rs
+++ b/icx-asset/src/main.rs
@@ -9,7 +9,7 @@ use ic_agent::identity::{AnonymousIdentity, BasicIdentity};
 use ic_agent::{agent::http_transport::ReqwestHttpReplicaV2Transport, Agent, Identity};
 
 use crate::commands::upload::upload;
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{path::PathBuf, time::Duration};
 
 const DEFAULT_IC_GATEWAY: &str = "https://ic0.app";
 
@@ -99,7 +99,7 @@ async fn main() -> support::Result {
         .unwrap_or_else(|| Duration::from_secs(60 * 5)); // 5 minutes is max ingress timeout
 
     let agent = Agent::builder()
-        .with_transport(Arc::new(ReqwestHttpReplicaV2Transport::create(
+        .with_boxed_transport(Box::new(ReqwestHttpReplicaV2Transport::create(
             opts.replica.clone(),
         )?))
         .with_boxed_identity(create_identity(opts.pem))

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -7,7 +7,7 @@ use candid::{
 };
 use clap::{crate_authors, crate_version, AppSettings, Clap};
 use ic_agent::{
-    agent::{self, signed::SignedUpdate, Replied},
+    agent::{self, signed::SignedUpdate, AgentTrait, Replied},
     agent::{
         agent_error::HttpErrorPayload,
         signed::{SignedQuery, SignedRequestStatus},
@@ -255,7 +255,7 @@ fn print_idl_blob(
     Ok(())
 }
 
-async fn fetch_root_key_from_non_ic(agent: &Agent, replica: &str) -> Result<()> {
+async fn fetch_root_key_from_non_ic(agent: &dyn AgentTrait, replica: &str) -> Result<()> {
     let normalized_replica = replica.strip_suffix("/").unwrap_or(replica);
     if normalized_replica != DEFAULT_IC_GATEWAY {
         agent

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -635,7 +635,7 @@ mod simple_calls {
         with_universal_canister(|agent, canister_id| async move {
             let arg = payload().reply_data(b"hello").build();
             let result = agent
-                .update(&canister_id, "non_existent_method")
+                .update(&canister_id, "non_existent_method".to_string())
                 .with_arg(&arg)
                 .call_and_wait(create_waiter())
                 .await;


### PR DESCRIPTION
Add generics for `Identity` and `Transport` to everything (`Agent`, `AgentConfig`, and `AgentBuilder`)
Add an `AgentTrait` to abstract out the generics for simple use.
This does not retain full backwards compatibility (`Box<dyn AgentTrait`> replaces a lot of `Agent`), so a version bump is prudent.