### PR TITLE
chore: do not add /opt/ghc to path, since it is not found.

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -63,9 +63,7 @@ jobs:
 
       - name: Build ic-hs
         run: |
-          # the next step is failing now, do not know why:
-          ls -l /opt/ghc/
-          export PATH=/opt/ghc/bin:$PATH
+          ghc --version
           cabal --version
           ghc-${{ matrix.ghc }} --version
           mkdir -p $HOME/bin

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -63,6 +63,7 @@ jobs:
 
       - name: Build ic-hs
         run: |
+          # the next step is failing now, do not know why:
           ls -l /opt/ghc/
           export PATH=/opt/ghc/bin:$PATH
           cabal --version


### PR DESCRIPTION
Don't manually add /opt/ghc/bin to the path, since it doesn't seem to be present anymore (maybe from an invalidated cache?) and `ghc --version` reports the expected value.

Compare the build results on main for these two commits:
- https://github.com/dfinity/agent-rs/commit/f7de7670aa3870023fa45d5b5cee719b6eb7a012 ([passed](https://github.com/dfinity/agent-rs/runs/3438435945#step:9:17) Aug 26 2021)
- https://github.com/dfinity/agent-rs/commit/4dbe4d4df4d6ab3d0189bd00da16e3908c7fd698 ([failed](https://github.com/dfinity/agent-rs/runs/3655580805#step:9:11) Sep 20 2021)

The failure is
```
Run ls -l /opt/ghc/
ls: cannot access '/opt/ghc/': No such file or directory
Error: Process completed with exit code 2.
```
The previously successful output looked like this:
```
Run ls -l /opt/ghc/
total 12
drwxrwxrwx+ 5 root root 4096 Aug 16 03:39 8.10.4
drwxrwxrwx+ 5 root root 4096 Aug 16 03:40 9.0.1
drwxrwxrwx+ 2 root root 4096 Aug 16 03:40 bin
cabal-install version 3.4.0.0
compiled using version 3.4.0.0 of the Cabal library 
The Glorious Glasgow Haskell Compilation System, version 8.8.4
```