### PR TITLE
chore: release agent 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base32",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "ic-asset"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "hex",
  "ic-agent",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "icx-asset"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "icx-proxy"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/ic-agent/CHANGELOG.md
+++ b/ic-agent/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-10-06
+
 ### Added
 
 - Added field `replica_health_status` to `Status`.

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-agent"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Agent library to communicate with the Internet Computer, following the Public Specification."

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-asset"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Library for storing files in an asset canister."
@@ -20,9 +20,9 @@ futures = "0.3.17"
 futures-intrusive = "0.4.0"
 garcon = { version = "0.2", features = ["async"] }
 hex = {version = "0.4.2", features = ["serde"] }
-ic-agent = { path = "../ic-agent", version = "0.8", features = [ "pem" ] }
+ic-agent = { path = "../ic-agent", version = "0.9", features = [ "pem" ] }
 ic-types = { version = "0.2.2", features = [ "serde" ] }
-ic-utils = { path = "../ic-utils", version = "0.6" }
+ic-utils = { path = "../ic-utils", version = "0.7" }
 mime = "0.3.16"
 mime_guess = "2.0.3"
 openssl = "0.10.32"

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-identity-hsm"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Identity implementation for HSM for the ic-agent package."
 homepage = "https://docs.rs/ic-identity-hsm"
@@ -14,7 +14,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 hex = "0.4.2"
-ic-agent = { path = "../ic-agent", version = "0.8", features = [ "pem" ] }
+ic-agent = { path = "../ic-agent", version = "0.9", features = [ "pem" ] }
 num-bigint = "0.4.1"
 openssl = "0.10.30"
 pkcs11 = "0.5.0"

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-utils"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Collection of utilities for Rust, on top of ic-agent, to communicate with the Internet Computer, following the Public Specification."
@@ -18,7 +18,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 async-trait = "0.1.40"
 candid = "0.7.7"
 garcon = { version = "0.2", features = ["async"] }
-ic-agent = { path = "../ic-agent", version = "0.8" }
+ic-agent = { path = "../ic-agent", version = "0.9" }
 serde = "1.0.115"
 serde_bytes = "0.11"
 strum = "0.21"

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-asset"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to manage assets on an asset canister on the Internet Computer."
@@ -23,10 +23,10 @@ clap_derive = "=3.0.0-beta.2"
 delay = "0.3.1"
 garcon = "0.2.2"
 humantime = "2.0.1"
-ic-agent = { path = "../ic-agent", version = "0.8" }
-ic-asset = { path = "../ic-asset", version = "0.3" }
+ic-agent = { path = "../ic-agent", version = "0.9" }
+ic-asset = { path = "../ic-asset", version = "0.4" }
 ic-types = "0.2.2"
-ic-utils = { path = "../ic-utils", version = "0.6" }
+ic-utils = { path = "../ic-utils", version = "0.7" }
 libflate = "1.1.1"
 num-traits = "0.2"
 pem = "0.8.1"

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-cert"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to download a document from the Internet Computer and pretty-print the contents of its IC-Certificate header."
@@ -21,7 +21,7 @@ clap = "=3.0.0-beta.2"
 clap_derive = "=3.0.0-beta.2"
 chrono = "0.4.19"
 hex = "0.4.2"
-ic-agent = { path = "../ic-agent", version = "0.8" }
+ic-agent = { path = "../ic-agent", version = "0.9" }
 leb128 = "0.2.4"
 reqwest = { version = "0.11",features = [ "blocking", "rustls-tls" ] }
 sha2 = "0.9.8"

--- a/icx-proxy/Cargo.toml
+++ b/icx-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-proxy"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to create an HTTP proxy to the Internet Computer."
@@ -24,8 +24,8 @@ garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.3"
 hyper = { version = "0.14.13", features = ["full"] }
 hyper-tls = "0.5.0"
-ic-agent = { path = "../ic-agent", version = "0.8" }
-ic-utils = { path = "../ic-utils", version = "0.6" }
+ic-agent = { path = "../ic-agent", version = "0.9" }
+ic-utils = { path = "../ic-utils", version = "0.7" }
 tokio = { version = "1.8.1", features = ["full"] }
 serde = "1.0.115"
 serde_json = "1.0.57"

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to call canisters on the Internet Computer."
@@ -24,8 +24,8 @@ clap_derive = "=3.0.0-beta.2"
 garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.2"
 humantime = "2.0.1"
-ic-agent = { path = "../ic-agent", version = "0.8" }
-ic-utils = { path = "../ic-utils", version = "0.6" }
+ic-agent = { path = "../ic-agent", version = "0.9" }
+ic-utils = { path = "../ic-utils", version = "0.7" }
 pem = "0.8.1"
 ring = "0.16.11"
 serde = "1.0.115"


### PR DESCRIPTION
    ic-identity-hsm: 0.3.5 => 0.3.6
    ic-utils: 0.6.0 => 0.7.0
    icx-asset: 0.3.0 => 0.4.0
    ic-asset: 0.3.0 => 0.4.0
    icx-cert: 0.4.0 => 0.5.0
    ic-agent: 0.8.0 => 0.9.0
    icx: 0.5.0 => 0.6.0
    icx-proxy: 0.6.0 => 0.7.0

- Add `replica_health_status` to `Status`
- Add support for multiple controllers, including wallet and management canister interfaces
- Update dependencies
