### PR TITLE
feat: verify certificates if ic-certificate response header is present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,7 @@ dependencies = [
  "hyper-tls",
  "ic-agent",
  "ic-utils",
+ "openssl",
  "serde",
  "serde_cbor",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,7 @@ name = "icx-proxy"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "clap_derive",
  "garcon",
@@ -1036,6 +1037,7 @@ dependencies = [
  "ic-agent",
  "ic-utils",
  "serde",
+ "serde_cbor",
  "serde_json",
  "slog",
  "slog-async",

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -597,7 +597,8 @@ impl Agent {
         })
     }
 
-    fn verify(&self, cert: &Certificate) -> Result<(), AgentError> {
+    /// Verify a certificate, checking delegation if present.
+    pub fn verify(&self, cert: &Certificate) -> Result<(), AgentError> {
         let sig = &cert.signature;
 
         let root_hash = cert.tree.digest();

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -6,7 +6,7 @@ pub mod http_transport;
 pub(crate) mod nonce;
 pub(crate) mod replica_api;
 pub(crate) mod response;
-mod response_authentication;
+pub(crate) mod response_authentication;
 
 pub mod signed;
 pub mod status;

--- a/ic-agent/src/agent/replica_api.rs
+++ b/ic-agent/src/agent/replica_api.rs
@@ -110,7 +110,7 @@ pub struct ReadStateResponse {
 
 /// A `Certificate` as defined in https://docs.dfinity.systems/public/#_certificate
 #[derive(Deserialize)]
-pub(crate) struct Certificate<'a> {
+pub struct Certificate<'a> {
     pub tree: HashTree<'a>,
 
     #[serde(with = "serde_bytes")]
@@ -120,7 +120,7 @@ pub(crate) struct Certificate<'a> {
 }
 
 #[derive(Deserialize)]
-pub(crate) struct Delegation {
+pub struct Delegation {
     #[serde(with = "serde_bytes")]
     pub subnet_id: Vec<u8>,
 

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -133,7 +133,7 @@ pub(crate) fn lookup_reply(
     Ok(RequestStatusResponse::Replied { reply })
 }
 
-pub(crate) fn lookup_value<'a>(
+pub fn lookup_value<'a>(
     certificate: &'a Certificate<'a>,
     path: Vec<Label>,
 ) -> Result<&'a [u8], AgentError> {

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -115,7 +115,10 @@ pub mod export;
 pub mod identity;
 pub mod request_id;
 
-pub use agent::{agent_error, agent_error::AgentError, Agent, NonceFactory, NonceGenerator, replica_api::Certificate};
+pub use agent::{
+    agent_error, agent_error::AgentError, replica_api::Certificate, Agent, NonceFactory,
+    NonceGenerator,
+};
 pub use identity::{Identity, Signature};
 pub use request_id::{to_request_id, RequestId, RequestIdError};
 

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -121,3 +121,5 @@ pub use request_id::{to_request_id, RequestId, RequestIdError};
 
 pub(crate) use crate::ic_types::hash_tree;
 pub use ic_types;
+
+pub use agent::response_authentication::lookup_value;

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -115,7 +115,7 @@ pub mod export;
 pub mod identity;
 pub mod request_id;
 
-pub use agent::{agent_error, agent_error::AgentError, Agent, NonceFactory, NonceGenerator};
+pub use agent::{agent_error, agent_error::AgentError, Agent, NonceFactory, NonceGenerator, replica_api::Certificate};
 pub use identity::{Identity, Signature};
 pub use request_id::{to_request_id, RequestId, RequestIdError};
 

--- a/icx-proxy/Cargo.toml
+++ b/icx-proxy/Cargo.toml
@@ -27,6 +27,7 @@ hyper = { version = "0.14.13", features = ["full"] }
 hyper-tls = "0.5.0"
 ic-agent = { path = "../ic-agent", version = "0.9" }
 ic-utils = { path = "../ic-utils", version = "0.7" }
+openssl = "0.10.32"
 tokio = { version = "1.8.1", features = ["full"] }
 serde = "1.0.115"
 serde_cbor = "0.11"

--- a/icx-proxy/Cargo.toml
+++ b/icx-proxy/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.34"
+base64 = "0.13"
 clap = "=3.0.0-beta.2"
 clap_derive = "=3.0.0-beta.2"
 garcon = { version = "0.2.3", features = ["async"] }
@@ -28,6 +29,7 @@ ic-agent = { path = "../ic-agent", version = "0.9" }
 ic-utils = { path = "../ic-utils", version = "0.7" }
 tokio = { version = "1.8.1", features = ["full"] }
 serde = "1.0.115"
+serde_cbor = "0.11"
 serde_json = "1.0.57"
 slog = { version = "2.7.0", features = ["max_level_trace"] }
 slog-async = "2.7.0"

--- a/icx-proxy/src/main.rs
+++ b/icx-proxy/src/main.rs
@@ -7,9 +7,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Body, Client, Request, Response, Server, StatusCode, Uri,
 };
-use ic_agent::{
-    agent::http_transport::ReqwestHttpReplicaV2Transport, export::Principal, Agent, AgentError,
-};
+use ic_agent::{agent::http_transport::ReqwestHttpReplicaV2Transport, export::Principal, Agent, AgentError, Certificate};
 use ic_utils::{
     call::SyncCall,
     interfaces::http_request::{
@@ -28,7 +26,6 @@ use std::{
         Arc, Mutex,
     },
 };
-use ic_agent::agent::replica_api::Certificate;
 
 mod config;
 mod logging;

--- a/icx-proxy/src/main.rs
+++ b/icx-proxy/src/main.rs
@@ -252,14 +252,11 @@ async fn forward_request(
     let mut builder = Response::builder().status(StatusCode::from_u16(http_response.status_code)?);
     for HeaderField(name, value) in http_response.headers {
         if name.to_uppercase() == "IC-CERTIFICATE" {
-            eprintln!("ic cert!");
             for s in value.split(|c| c == ',' || c == ' ') {
-                eprintln!("s={}", s);
                 if let Some(first_equal) = s.find('=') {
                     let n = &s[..first_equal];
                     // remove leading =:, trailing :
                     let v = &s[(first_equal + 2)..(s.len() - 1)];
-                    eprintln!("n='{}' v='{}'", n, v);
                     slog::trace!(logger, ">> certificate {}: {}", n, v);
                     let bytes = match base64::decode(v) {
                         Ok(d) => d,

--- a/icx-proxy/src/main.rs
+++ b/icx-proxy/src/main.rs
@@ -429,9 +429,7 @@ fn validate_body(
     let tree: HashTree = serde_cbor::from_slice(&tree).map_err(AgentError::InvalidCborData)?;
 
     if let Err(e) = agent.verify(&cert) {
-        slog::trace!(
-            logger,
-            ">> certificate failed verification: {}", e );
+        slog::trace!(logger, ">> certificate failed verification: {}", e);
         return Ok(false);
     }
 
@@ -444,8 +442,10 @@ fn validate_body(
         Ok(witness) => witness,
         Err(e) => {
             slog::trace!(
-            logger,
-            ">> Could not find certified data for this canister in the certificate: {}", e );
+                logger,
+                ">> Could not find certified data for this canister in the certificate: {}",
+                e
+            );
             return Ok(false);
         }
     };
@@ -457,7 +457,7 @@ fn validate_body(
             ">> witness ({}) did not match digest ({})",
             hex::encode(witness),
             hex::encode(digest)
-       );
+        );
 
         return Ok(false);
     }
@@ -470,7 +470,11 @@ fn validate_body(
             match tree.lookup_path(&fallback_path) {
                 LookupResult::Found(v) => v,
                 _ => {
-                    slog::trace!(logger, ">> Invalid Tree in the header. Does not contain path {:?}", path);
+                    slog::trace!(
+                        logger,
+                        ">> Invalid Tree in the header. Does not contain path {:?}",
+                        path
+                    );
                     return Ok(false);
                 }
             }


### PR DESCRIPTION
This PR is for discussion about how best to expose types and methods that are currently private to ic-agent, for example as needed here by icx-proxy.

The actual certificate verification code presented here does not work in all cases and is not expected to, in part because the certified assets canister returns encoded (per `content-encoding`) data in the response body, but (usually, though there can be exceptions) the sha256 of the `identity` encoding in the certificate.

This PR will not be merged. 
