### PR TITLE
chore: remove chrono dependency from ic-agent, ic-identity-hsm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -1702,6 +1702,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,14 +2104,14 @@ dependencies = [
 
 [[package]]
 name = "simple_asn1"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb4ea60fb301dc81dfc113df680571045d375ab7345d171c5dc7d7e13107a80"
+checksum = "69e392b68e8f171f7399608dabaa3a099525b7daca0fd1c8690bda08eb110355"
 dependencies = [
- "chrono",
  "num-bigint 0.4.2",
  "num-traits",
  "thiserror",
+ "time 0.3.4",
 ]
 
 [[package]]
@@ -2277,6 +2286,24 @@ dependencies = [
  "wasi",
  "winapi",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
+dependencies = [
+ "itoa",
+ "libc",
+ "quickcheck",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tiny-keccak"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -30,7 +30,7 @@ ring = { version = "0.16.11", features = ["std"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_bytes = "0.11.2"
 serde_cbor = "0.11.2"
-simple_asn1 = "0.5.4"
+simple_asn1 = "0.6.0"
 thiserror = "1.0.28"
 url = "2.1.0"
 webpki-roots = "0.21.1"

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -18,5 +18,5 @@ ic-agent = { path = "../ic-agent", version = "0.9", features = [ "pem" ] }
 num-bigint = "0.4.1"
 openssl = "0.10.30"
 pkcs11 = "0.5.0"
-simple_asn1 = "0.5.4"
+simple_asn1 = "0.6.0"
 thiserror = "1.0.20"


### PR DESCRIPTION
This PR upgrades to simple_asn 0.6.0 in order to remove a dependency on `chrono`.

This is because of a cargo audit failure with no safe upgrade available:
    https://rustsec.org/advisories/RUSTSEC-2020-0159

icx-asset, icx-cert, and zzz-release still depend on chrono.