### PR TITLE
chore: fix darwin provisioning due to macos-latest upgrade

### DIFF
--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -17,7 +17,9 @@ sudo installer -pkg node.pkg -store -target /
 rm node.pkg
 
 # Install Bats.
-brew unlink bats
+if [ "$(uname -r)" = "19.6.0" ]; then
+    brew unlink bats
+fi
 brew install bats-core
 
 # Install Bats support.


### PR DESCRIPTION
macos-latest is being rolled out, scheduled to be completed Dec 13.  https://github.com/actions/virtual-environments/issues/4060

This change will handle macos-latest being either macos-10.15 or macos-11.