### PR TITLE
fix: retry failures when uploading assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Updated crate dependencies, most notably updating rustls,
 removing the direct dependency on webpki-roots, and allowing
 consumers of ic-agent to update to reqwest 0.11.7.
 
+### ic-asset
+
+#### Fixed: sync and upload will now attempt retries as expected
+
+Fixed a defect in asset synchronization where no retries would be attempted after the first 30 seconds overall.
+
+### icx-asset
+
+#### Fixed: now works with secp256k1 .pem files.
+
 ## [0.10.0] - 2021-11-15
 
 Unified all version numbers and removed the zzz-release tool.

--- a/ic-asset/src/asset_canister/batch.rs
+++ b/ic-asset/src/asset_canister/batch.rs
@@ -4,22 +4,46 @@ use crate::asset_canister::protocol::{
 };
 use crate::convenience::waiter_with_timeout;
 use crate::params::CanisterCallParams;
+use crate::retryable::retryable;
 use candid::Nat;
+use garcon::{Delay, Waiter};
 
 pub(crate) async fn create_batch(
     canister_call_params: &CanisterCallParams<'_>,
 ) -> anyhow::Result<Nat> {
-    let create_batch_args = CreateBatchRequest {};
-    let response = canister_call_params
-        .canister
-        .update_(CREATE_BATCH)
-        .with_arg(&create_batch_args)
-        .build()
-        .map(|result: (CreateBatchResponse,)| (result.0.batch_id,))
-        .call_and_wait(waiter_with_timeout(canister_call_params.timeout))
-        .await?;
-    let batch_id = response.0;
-    Ok(batch_id)
+    let mut waiter = Delay::builder()
+        .with(Delay::count_timeout(30))
+        .exponential_backoff_capped(
+            std::time::Duration::from_secs(1),
+            2.0,
+            std::time::Duration::from_secs(16),
+        )
+        .build();
+    waiter.start();
+
+    let result = loop {
+        let create_batch_args = CreateBatchRequest {};
+        let response = canister_call_params
+            .canister
+            .update_(CREATE_BATCH)
+            .with_arg(&create_batch_args)
+            .build()
+            .map(|result: (CreateBatchResponse,)| (result.0.batch_id,))
+            .call_and_wait(waiter_with_timeout(canister_call_params.timeout))
+            .await;
+        match response {
+            Ok((batch_id,)) => break Ok(batch_id),
+            Err(agent_err) if !retryable(&agent_err) => {
+                break Err(agent_err);
+            }
+            Err(agent_err) => {
+                if let Err(_waiter_err) = waiter.async_wait().await {
+                    break Err(agent_err);
+                }
+            }
+        };
+    }?;
+    Ok(result)
 }
 
 pub(crate) async fn commit_batch(
@@ -27,16 +51,39 @@ pub(crate) async fn commit_batch(
     batch_id: &Nat,
     operations: Vec<BatchOperationKind>,
 ) -> anyhow::Result<()> {
+    let mut waiter = Delay::builder()
+        .with(Delay::count_timeout(30))
+        .exponential_backoff_capped(
+            std::time::Duration::from_secs(1),
+            2.0,
+            std::time::Duration::from_secs(16),
+        )
+        .build();
+    waiter.start();
+
     let arg = CommitBatchArguments {
         batch_id,
         operations,
     };
-    canister_call_params
-        .canister
-        .update_(COMMIT_BATCH)
-        .with_arg(arg)
-        .build()
-        .call_and_wait(waiter_with_timeout(canister_call_params.timeout))
-        .await?;
-    Ok(())
+    let result = loop {
+        match canister_call_params
+            .canister
+            .update_(COMMIT_BATCH)
+            .with_arg(&arg)
+            .build()
+            .call_and_wait(waiter_with_timeout(canister_call_params.timeout))
+            .await
+        {
+            Ok(()) => break Ok(()),
+            Err(agent_err) if !retryable(&agent_err) => {
+                break Err(agent_err);
+            }
+            Err(agent_err) => {
+                if let Err(_waiter_err) = waiter.async_wait().await {
+                    break Err(agent_err);
+                }
+            }
+        }
+    }?;
+    Ok(result)
 }

--- a/ic-asset/src/lib.rs
+++ b/ic-asset/src/lib.rs
@@ -5,6 +5,8 @@ mod convenience;
 mod operations;
 mod params;
 mod plumbing;
+mod retryable;
+mod semaphores;
 mod sync;
 mod upload;
 

--- a/ic-asset/src/retryable.rs
+++ b/ic-asset/src/retryable.rs
@@ -6,9 +6,7 @@ pub(crate) fn retryable(agent_error: &AgentError) -> bool {
         AgentError::ReplicaError {
             reject_code,
             reject_message,
-        } if *reject_code == 5 && reject_message.contains("is out of cycles") => {
-            false
-        }
+        } if *reject_code == 5 && reject_message.contains("is out of cycles") => false,
         AgentError::HttpError(HttpErrorPayload {
             status,
             content_type: _,

--- a/ic-asset/src/retryable.rs
+++ b/ic-asset/src/retryable.rs
@@ -1,0 +1,23 @@
+use ic_agent::agent_error::HttpErrorPayload;
+use ic_agent::AgentError;
+
+pub(crate) fn retryable(agent_error: &AgentError) -> bool {
+    match agent_error {
+        AgentError::ReplicaError {
+            reject_code,
+            reject_message,
+        } if *reject_code == 5 && reject_message.contains("is out of cycles") => {
+            false
+        }
+        AgentError::HttpError(HttpErrorPayload {
+            status,
+            content_type: _,
+            content: _,
+        }) if *status == 403 => {
+            // sometimes out of cycles looks like this
+            // assume any 403(unauthorized) is not retryable
+            false
+        }
+        _ => true,
+    }
+}

--- a/ic-asset/src/semaphores.rs
+++ b/ic-asset/src/semaphores.rs
@@ -1,0 +1,53 @@
+use futures_intrusive::sync::SharedSemaphore;
+
+// Maximum MB of file data to load at once.  More memory may be used, due to encodings.
+const MAX_SIMULTANEOUS_LOADED_MB: usize = 50;
+
+// How many simultaneous chunks being created at once
+const MAX_SIMULTANEOUS_CREATE_CHUNK: usize = 12;
+
+// How many simultaneous Agent.call() to create_chunk
+const MAX_SIMULTANEOUS_CREATE_CHUNK_CALLS: usize = 4;
+
+// How many simultaneous Agent.wait() on create_chunk result
+const MAX_SIMULTANEOUS_CREATE_CHUNK_WAITS: usize = 4;
+
+pub(crate) struct Semaphores {
+    // The "file" semaphore limits how much file data to load at once.  A given loaded file's data
+    // may be simultaneously encoded (gzip and so forth).
+    pub file: SharedSemaphore,
+
+    // The create_chunk semaphore limits the number of chunks that can be in the process
+    // of being created at one time.  Since each chunk creation can involve retries,
+    // this focuses those retries on a smaller number of chunks.
+    // Without this semaphore, every chunk would make its first attempt, before
+    // any chunk made its second attempt.
+    pub create_chunk: SharedSemaphore,
+
+    // The create_chunk_call semaphore limits the number of simultaneous
+    // agent.call()s to create_chunk.
+    pub create_chunk_call: SharedSemaphore,
+
+    // The create_chunk_wait semaphore limits the number of simultaneous
+    // agent.wait() calls for outstanding create_chunk requests.
+    pub create_chunk_wait: SharedSemaphore,
+}
+
+impl Semaphores {
+    pub fn new() -> Semaphores {
+        let file = SharedSemaphore::new(true, MAX_SIMULTANEOUS_LOADED_MB);
+
+        let create_chunk = SharedSemaphore::new(true, MAX_SIMULTANEOUS_CREATE_CHUNK);
+
+        let create_chunk_call = SharedSemaphore::new(true, MAX_SIMULTANEOUS_CREATE_CHUNK_CALLS);
+
+        let create_chunk_wait = SharedSemaphore::new(true, MAX_SIMULTANEOUS_CREATE_CHUNK_WAITS);
+
+        Semaphores {
+            file,
+            create_chunk,
+            create_chunk_call,
+            create_chunk_wait,
+        }
+    }
+}

--- a/icx-asset/src/commands/sync.rs
+++ b/icx-asset/src/commands/sync.rs
@@ -1,7 +1,7 @@
 use ic_utils::Canister;
 
 use crate::{support, SyncOpts};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 pub(crate) async fn sync(
     canister: &Canister<'_>,

--- a/icx-asset/src/commands/sync.rs
+++ b/icx-asset/src/commands/sync.rs
@@ -1,7 +1,7 @@
 use ic_utils::Canister;
 
 use crate::{support, SyncOpts};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 pub(crate) async fn sync(
     canister: &Canister<'_>,

--- a/icx-asset/src/main.rs
+++ b/icx-asset/src/main.rs
@@ -5,7 +5,7 @@ use crate::commands::list::list;
 use crate::commands::sync::sync;
 use candid::Principal;
 use clap::{crate_authors, crate_version, AppSettings, Clap};
-use ic_agent::identity::{AnonymousIdentity, BasicIdentity};
+use ic_agent::identity::{AnonymousIdentity, BasicIdentity, Secp256k1Identity};
 use ic_agent::{agent, Agent, Identity};
 
 use crate::commands::upload::upload;
@@ -84,7 +84,11 @@ struct UploadOpts {
 
 fn create_identity(maybe_pem: Option<PathBuf>) -> Box<dyn Identity + Sync + Send> {
     if let Some(pem_path) = maybe_pem {
-        Box::new(BasicIdentity::from_pem_file(pem_path).expect("Could not read the key pair."))
+        if let Ok(secp256k_identity) = Secp256k1Identity::from_pem_file(&pem_path) {
+            Box::new(secp256k_identity)
+        } else {
+            Box::new(BasicIdentity::from_pem_file(pem_path).expect("Could not read the key pair."))
+        }
     } else {
         Box::new(AnonymousIdentity)
     }


### PR DESCRIPTION
There are a few things going on here.

The main fix here is in `create_chunk`: using a `count_timeout` rather than a `timeout`.  This is because a semaphore is acquired after starting the waiter but before each attempt to send the update request.  The result was that all retries would fail after the first 30 seconds, because the timeout for every chunk was started at the same time.

Other changes:
- Use exponential backoff for the retry delay.
- Call Waiter.async_wait rather than Waiter.wait, since we are in an async fn, in order to not prevent the runtime from swapping the current task.
- Check for failure due to being out of cycles, or 403/unauthorized in general, and don't retry.
- Added a new `create_chunk` semaphore, which limits how many chunks can be in the process of being uploaded/retried.  This is because otherwise, every chunk will get its first attempt before any chunk gets its second.  This limit focuses retries on a smaller number of chunks, and gives their exponential-backoff a chance to work.
- Increased the allowed concurrency for chunk uploads.  When we were proxying these requests through the actix http server in dfx, the http client would sometimes get irrecoverably stuck.  This does not appear to be happening now that we are using icx-proxy.
- Retry failures in `create_batch` and `commit_batch`.
- Refactored the semaphores into a struct, since there are now 4 of them.
- icx-asset now accepts secp256k1 pem files.

This fixes https://dfinity.atlassian.net/browse/SDK-84
