### PR TITLE
chore: release rust agent 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.3] - 2022-01-06
+## [0.11.0] - 2022-01-07
 
-Updated dependencies
+### Breaking change: Updated to ic-types 0.3.0
+
+The `lookup_path` method now takes an `Iterator<Label>` rather than an `AsRef<[Label]>`
 
 ## [0.10.2] - 2021-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3] - 2022-01-06
+
+Updated dependencies
+
 ## [0.10.2] - 2021-12-22
 
 ### ic-agent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base32",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "ic-asset"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "hex",
  "ic-agent",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "icx-asset"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "async-trait",
  "base32",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "ic-asset"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "candid",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "hex",
  "ic-agent",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "async-trait",
  "candid",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "candid",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "icx-asset"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "candid",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
+checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
 dependencies = [
  "backtrace",
 ]
@@ -711,13 +711,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 0.4.8",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -969,7 +969,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "sha2 0.10.0",
+ "sha2 0.10.1",
 ]
 
 [[package]]
@@ -1440,13 +1440,11 @@ checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "pem"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06673860db84d02a63942fa69cd9543f2624a5df3aea7f33173048fa7ad5cf1a"
+checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
  "base64",
- "once_cell",
- "regex",
 ]
 
 [[package]]
@@ -1917,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
@@ -1945,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1956,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -1992,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d964dd36bb15bcf2f2b35694c072feab74969a54f2bbeec7a2d725d2bdcb6"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "candid"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e50722722e50168832c537161079e6a72d624ab23f815beb7b9e628be3377f"
+checksum = "12970d8d0620d2bdb7e81a5b13ed11e41fcdfeba53d61e45b5853afcbf9611fd"
 dependencies = [
  "anyhow",
  "binread",
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "ic-types"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c021c11ae1d716f45d783f5764f418a11f12aea1fdc4fc8a2b2242e0dae708"
+checksum = "0e78ec6f58886cdc252d6f912dc794211bd6bbc39ddc9dcda434b2dc16c335b3"
 dependencies = [
  "base32",
  "crc32fast",

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -21,7 +21,7 @@ garcon = { version = "0.2", features = ["async"] }
 hex = "0.4.0"
 http = "0.2.5"
 hyper-rustls = { version = "0.23.0", features = [ "webpki-roots" ] }
-ic-types = "0.2.2"
+ic-types = "0.3.0"
 leb128 = "0.2.5"
 mime = "0.3.16"
 openssl = "0.10.38"
@@ -45,7 +45,7 @@ version = "1.0"
 optional = true
 
 [dev-dependencies]
-candid = "0.7.9"
+candid = "0.7.10"
 mockito = "0.30.0"
 proptest = "1.0.0"
 serde_json = "1.0.72"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -19,7 +19,7 @@ base64 = "0.13.0"
 byteorder = "1.3.2"
 garcon = { version = "0.2", features = ["async"] }
 hex = "0.4.0"
-http = "0.2.5"
+http = "0.2.6"
 hyper-rustls = { version = "0.23.0", features = [ "webpki-roots" ] }
 ic-types = "0.3.0"
 leb128 = "0.2.5"
@@ -28,7 +28,7 @@ openssl = "0.10.38"
 rand = "0.8.4"
 rustls = "0.20.2"
 ring = { version = "0.16.11", features = ["std"] }
-serde = { version = "1.0.132", features = ["derive"] }
+serde = { version = "1.0.133", features = ["derive"] }
 serde_bytes = "0.11.2"
 serde_cbor = "0.11.2"
 simple_asn1 = "0.6.1"
@@ -48,7 +48,7 @@ optional = true
 candid = "0.7.10"
 mockito = "0.30.0"
 proptest = "1.0.0"
-serde_json = "1.0.72"
+serde_json = "1.0.74"
 tokio = { version = "1.15.0", features = ["full"] }
 
 [features]

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-agent"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Agent library to communicate with the Internet Computer, following the Public Specification."

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-agent"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Agent library to communicate with the Internet Computer, following the Public Specification."

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -14,14 +14,14 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 anyhow = "1.0"
-candid = "0.7.7"
+candid = "0.7.10"
 flate2 = "1.0.22"
 futures = "0.3.19"
 futures-intrusive = "0.4.0"
 garcon = { version = "0.2", features = ["async"] }
 hex = {version = "0.4.2", features = ["serde"] }
 ic-agent = { path = "../ic-agent", version = "0.10", features = [ "pem" ] }
-ic-types = { version = "0.2.2", features = [ "serde" ] }
+ic-types = { version = "0.3.0", features = [ "serde" ] }
 ic-utils = { path = "../ic-utils", version = "0.10" }
 mime = "0.3.16"
 mime_guess = "2.0.3"

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-asset"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Library for storing files in an asset canister."

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -20,9 +20,9 @@ futures = "0.3.19"
 futures-intrusive = "0.4.0"
 garcon = { version = "0.2", features = ["async"] }
 hex = {version = "0.4.2", features = ["serde"] }
-ic-agent = { path = "../ic-agent", version = "0.10", features = [ "pem" ] }
+ic-agent = { path = "../ic-agent", version = "0.11", features = [ "pem" ] }
 ic-types = { version = "0.3.0", features = [ "serde" ] }
-ic-utils = { path = "../ic-utils", version = "0.10" }
+ic-utils = { path = "../ic-utils", version = "0.11" }
 mime = "0.3.16"
 mime_guess = "2.0.3"
 openssl = "0.10.38"

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -25,7 +25,7 @@ ic-types = { version = "0.3.0", features = [ "serde" ] }
 ic-utils = { path = "../ic-utils", version = "0.10" }
 mime = "0.3.16"
 mime_guess = "2.0.3"
-openssl = "0.10.32"
+openssl = "0.10.38"
 serde = "1.0"
 serde_bytes = "0.11.2"
 walkdir = "2.2.9"

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-asset"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Library for storing files in an asset canister."

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 hex = "0.4.2"
 ic-agent = { path = "../ic-agent", version = "0.10", features = [ "pem" ] }
 num-bigint = "0.4.3"
-openssl = "0.10.30"
+openssl = "0.10.38"
 pkcs11 = "0.5.0"
 simple_asn1 = "0.6.0"
 thiserror = "1.0.20"

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-identity-hsm"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Identity implementation for HSM for the ic-agent package."
 homepage = "https://docs.rs/ic-identity-hsm"

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-identity-hsm"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Identity implementation for HSM for the ic-agent package."
 homepage = "https://docs.rs/ic-identity-hsm"

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 hex = "0.4.2"
-ic-agent = { path = "../ic-agent", version = "0.10", features = [ "pem" ] }
+ic-agent = { path = "../ic-agent", version = "0.11", features = [ "pem" ] }
 num-bigint = "0.4.3"
 openssl = "0.10.38"
 pkcs11 = "0.5.0"

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 async-trait = "0.1.40"
-candid = "0.7.7"
+candid = "0.7.10"
 garcon = { version = "0.2", features = ["async"] }
 ic-agent = { path = "../ic-agent", version = "0.10" }
 serde = "1.0.115"

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-utils"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Collection of utilities for Rust, on top of ic-agent, to communicate with the Internet Computer, following the Public Specification."

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-utils"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "Collection of utilities for Rust, on top of ic-agent, to communicate with the Internet Computer, following the Public Specification."

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -18,7 +18,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 async-trait = "0.1.40"
 candid = "0.7.10"
 garcon = { version = "0.2", features = ["async"] }
-ic-agent = { path = "../ic-agent", version = "0.10" }
+ic-agent = { path = "../ic-agent", version = "0.11" }
 serde = "1.0.115"
 serde_bytes = "0.11"
 strum = "0.23"

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-asset"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to manage assets on an asset canister on the Internet Computer."

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-asset"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to manage assets on an asset canister on the Internet Computer."

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -23,10 +23,10 @@ clap_derive = "=3.0.0-beta.5"
 delay = "0.3.1"
 garcon = "0.2.2"
 humantime = "2.0.1"
-ic-agent = { path = "../ic-agent", version = "0.10" }
-ic-asset = { path = "../ic-asset", version = "0.10" }
+ic-agent = { path = "../ic-agent", version = "0.11" }
+ic-asset = { path = "../ic-asset", version = "0.11" }
 ic-types = "0.3.0"
-ic-utils = { path = "../ic-utils", version = "0.10" }
+ic-utils = { path = "../ic-utils", version = "0.11" }
 libflate = "1.1.1"
 num-traits = "0.2"
 pem = "1.0.1"

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 anyhow = "1.0.34"
-candid = "0.7.4"
+candid = "0.7.10"
 chrono = "0.4.19"
 clap = "=3.0.0-beta.5"
 clap_derive = "=3.0.0-beta.5"
@@ -25,7 +25,7 @@ garcon = "0.2.2"
 humantime = "2.0.1"
 ic-agent = { path = "../ic-agent", version = "0.10" }
 ic-asset = { path = "../ic-asset", version = "0.10" }
-ic-types = "0.2.2"
+ic-types = "0.3.0"
 ic-utils = { path = "../ic-utils", version = "0.10" }
 libflate = "1.1.1"
 num-traits = "0.2"

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -21,7 +21,7 @@ clap = "=3.0.0-beta.5"
 clap_derive = "=3.0.0-beta.5"
 chrono = "0.4.19"
 hex = "0.4.2"
-ic-agent = { path = "../ic-agent", version = "0.10" }
+ic-agent = { path = "../ic-agent", version = "0.11" }
 leb128 = "0.2.4"
 reqwest = { version = "0.11", features = [ "blocking", "rustls-tls" ] }
 sha2 = "0.10.1"

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -23,8 +23,8 @@ chrono = "0.4.19"
 hex = "0.4.2"
 ic-agent = { path = "../ic-agent", version = "0.10" }
 leb128 = "0.2.4"
-reqwest = { version = "0.11",features = [ "blocking", "rustls-tls" ] }
-sha2 = "0.10.0"
+reqwest = { version = "0.11", features = [ "blocking", "rustls-tls" ] }
+sha2 = "0.10.1"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_bytes = "0.11"
 serde_cbor = "0.11"

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-cert"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to download a document from the Internet Computer and pretty-print the contents of its IC-Certificate header."

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-cert"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to download a document from the Internet Computer and pretty-print the contents of its IC-Certificate header."

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -24,8 +24,8 @@ clap_derive = "=3.0.0-beta.5"
 garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.2"
 humantime = "2.0.1"
-ic-agent = { path = "../ic-agent", version = "0.10" }
-ic-utils = { path = "../ic-utils", version = "0.10" }
+ic-agent = { path = "../ic-agent", version = "0.11" }
+ic-utils = { path = "../ic-utils", version = "0.11" }
 pem = "1.0"
 ring = "0.16.11"
 serde = "1.0.115"

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to call canisters on the Internet Computer."

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 description = "CLI tool to call canisters on the Internet Computer."

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
-candid = "0.7.4"
+candid = "0.7.10"
 clap = "=3.0.0-beta.5"
 clap_derive = "=3.0.0-beta.5"
 garcon = { version = "0.2.3", features = ["async"] }

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -11,7 +11,7 @@ garcon = { version = "0.2.3", features = ["async"] }
 ic-agent = { path = "../ic-agent" }
 ic-identity-hsm = { path = "../ic-identity-hsm" }
 ic-utils = { path = "../ic-utils", features = ["raw"] }
-openssl = "0.10.24"
+openssl = "0.10.38"
 ring = "0.16.11"
 serde = { version = "1.0.101", features = ["derive"] }
 tokio = { version = "1.8.1", features = ["full"] }


### PR DESCRIPTION
Updated candid and ic-types, along with minor updates to other dependencies.