### PR TITLE
fix: openssl build error on macos-11

### DIFF
--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -10,6 +10,8 @@ curl --location --output install-brew.sh "https://raw.githubusercontent.com/Home
 bash install-brew.sh
 rm install-brew.sh
 
+brew install openssl
+
 # Install Node.
 version=14.15.4
 curl --location --output node.pkg "https://nodejs.org/dist/v$version/node-v$version.pkg"
@@ -41,6 +43,8 @@ echo "BATS_SUPPORT=${BATS_SUPPORT}" >> "$GITHUB_ENV"
 
 # Exit temporary directory.
 popd
+
+ls -l /usr/local/opt
 
 # Build icx-asset
 cargo build -p icx-asset

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -5,11 +5,7 @@ set -ex
 # Enter temporary directory.
 pushd /tmp
 
-# Install Homebrew
-curl --location --output install-brew.sh "https://raw.githubusercontent.com/Homebrew/install/master/install.sh"
-bash install-brew.sh
-rm install-brew.sh
-
+# Install brew dependencies
 brew install openssl
 
 # Install Node.
@@ -43,8 +39,6 @@ echo "BATS_SUPPORT=${BATS_SUPPORT}" >> "$GITHUB_ENV"
 
 # Exit temporary directory.
 popd
-
-ls -l /usr/local/opt
 
 # Build icx-asset
 cargo build -p icx-asset

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,10 @@ jobs:
           rustup update ${{ matrix.rust }} --no-self-update
           rustup default ${{ matrix.rust }}
 
+      - name: Install dependencies (macos only)
+        if: matrix.os == 'macos-latest'
+        run: brew install openssl
+
       - name: Install dependencies (windows only)
         if: matrix.os == 'windows-latest'
         shell: bash


### PR DESCRIPTION
Fixes errors seen on macos-11 runners of the form:
```
 = note: ld: warning: directory not found for option '-L/usr/local/opt/openssl@3/lib'
          ld: library not found for -lssl
```