### PR TITLE
refactor: Replace openssl with pure rust libs

### DIFF
--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -5,9 +5,6 @@ set -ex
 # Enter temporary directory.
 pushd /tmp
 
-# Install brew dependencies
-brew install openssl
-
 # Install Node.
 version=14.15.4
 curl --location --output node.pkg "https://nodejs.org/dist/v$version/node-v$version.pkg"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,21 +30,6 @@ jobs:
           rustup update ${{ matrix.rust }} --no-self-update
           rustup default ${{ matrix.rust }}
 
-      - name: Install dependencies (macos only)
-        if: matrix.os == 'macos-latest'
-        run: brew install openssl
-
-      - name: Install dependencies (windows only)
-        if: matrix.os == 'windows-latest'
-        shell: bash
-        run: |
-          vcpkg integrate install
-          vcpkg install openssl:x64-windows-static-md
-          echo "::set-env OPENSSL_DIR 'C:\Tools\vcpkg\installed\x64-windows-static-md'"
-          echo "::set-env OPENSSL_STATIC Yes"
-        env:
-          VCPKG_ROOT: 'C:\vcpkg'
-
       - name: Run Tests
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base32"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +126,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64ct"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874f8444adcb4952a8bc51305c8be95c8ec8237bb0d2e78d2e039f771f8828a0"
 
 [[package]]
 name = "beef"
@@ -324,6 +336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +382,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,10 +403,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "delay"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8546bb2c80129c9c85cd2b44e160b917f34a8b7ce9f3af675502cf9960e33d62"
+
+[[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+]
 
 [[package]]
 name = "derivative"
@@ -443,10 +493,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4641673db66b0492d99edd8fd1cf2e6eb4ab91de525d1d2d6cc99442ed15f5"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "der",
+ "ff",
+ "generic-array",
+ "group",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "ena"
@@ -464,6 +544,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "ff"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -489,21 +579,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -652,6 +727,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
+name = "group"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +793,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -790,19 +886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "ic-agent"
 version = "0.11.1"
 dependencies = [
@@ -816,20 +899,23 @@ dependencies = [
  "http",
  "hyper-rustls",
  "ic-types",
+ "k256",
  "leb128",
  "mime",
  "mockito",
- "openssl",
  "pem",
+ "pkcs8",
  "proptest",
  "rand",
  "reqwest",
  "ring",
  "rustls",
+ "sec1",
  "serde",
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "sha2 0.10.1",
  "simple_asn1",
  "thiserror",
  "tokio",
@@ -853,10 +939,10 @@ dependencies = [
  "mime",
  "mime_guess",
  "mockito",
- "openssl",
  "proptest",
  "serde",
  "serde_bytes",
+ "sha2 0.10.1",
  "walkdir",
 ]
 
@@ -867,8 +953,8 @@ dependencies = [
  "hex",
  "ic-agent",
  "num-bigint 0.4.3",
- "openssl",
  "pkcs11",
+ "sha2 0.10.1",
  "simple_asn1",
  "thiserror",
 ]
@@ -1036,6 +1122,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "k256"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc5937366afd3b38071f400d1ce5bd8b1d40b5083cc14e6f8dbcc4032a7f5bb"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "sec1",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -1239,24 +1338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,37 +1447,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "os_str_bytes"
@@ -1445,6 +1499,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1501,10 +1564,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.24"
+name = "pkcs8"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der",
+ "spki",
+ "zeroize",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1698,10 +1766,10 @@ dependencies = [
  "ic-agent",
  "ic-identity-hsm",
  "ic-utils",
- "openssl",
  "ring",
  "serde",
  "serde_cbor",
+ "sha2 0.10.1",
  "tokio",
 ]
 
@@ -1746,13 +1814,11 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -1761,7 +1827,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "url",
  "wasm-bindgen",
@@ -1769,6 +1834,17 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+dependencies = [
+ "crypto-bigint",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -1891,6 +1967,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+dependencies = [
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +2098,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+dependencies = [
+ "digest 0.9.0",
+ "rand_core",
+]
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2154,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spki"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,6 +2200,12 @@ dependencies = [
  "rustversion",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2250,16 +2365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,12 +2507,6 @@ name = "utf8-ranges"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2585,3 +2684,9 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -22,21 +22,25 @@ hex = "0.4.0"
 http = "0.2.6"
 hyper-rustls = { version = "0.23.0", features = [ "webpki-roots" ] }
 ic-types = "0.3.0"
+k256 = "0.10"
 leb128 = "0.2.5"
 mime = "0.3.16"
-openssl = "0.10.38"
 rand = "0.8.4"
 rustls = "0.20.2"
 ring = { version = "0.16.11", features = ["std"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_bytes = "0.11.2"
 serde_cbor = "0.11.2"
+sha2 = "0.10"
 simple_asn1 = "0.6.1"
 thiserror = "1.0.30"
 url = "2.1.0"
+pkcs8 = { version = "0.8", features = ["std"] }
+sec1 = { version = "0.2", features = ["pem"]}
 
 [dependencies.reqwest]
 version = "0.11"
+default-features = false
 features = [ "blocking", "json", "rustls-tls" ]
 optional = true
 

--- a/ic-agent/src/identity/error.rs
+++ b/ic-agent/src/identity/error.rs
@@ -15,6 +15,6 @@ pub enum PemError {
     #[error("A key was rejected by Ring: {0}")]
     KeyRejected(#[from] ring::error::KeyRejected),
 
-    #[error("A key was rejected by OpenSSL: {0}")]
-    ErrorStack(#[from] openssl::error::ErrorStack),
+    #[error("A key was rejected by k256: {0}")]
+    ErrorStack(#[from] k256::pkcs8::Error),
 }

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -25,9 +25,9 @@ ic-types = "0.3.0"
 ic-utils = { path = "../ic-utils", version = "0.11" }
 mime = "0.3.16"
 mime_guess = "2.0.3"
-openssl = "0.10.38"
 serde = "1.0"
 serde_bytes = "0.11.2"
+sha2 = "0.10"
 walkdir = "2.2.9"
 
 [dev-dependencies]

--- a/ic-asset/src/content.rs
+++ b/ic-asset/src/content.rs
@@ -2,7 +2,7 @@ use crate::content_encoder::ContentEncoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use mime::Mime;
-use openssl::sha::Sha256;
+use sha2::{Digest, Sha256};
 use std::io::Write;
 use std::path::Path;
 
@@ -40,8 +40,6 @@ impl Content {
     }
 
     pub fn sha256(&self) -> Vec<u8> {
-        let mut sha256 = Sha256::new();
-        sha256.update(&self.data);
-        sha256.finish().to_vec()
+        Sha256::digest(&self.data).to_vec()
     }
 }

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -16,7 +16,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 hex = "0.4.2"
 ic-agent = { path = "../ic-agent", version = "0.11", features = [ "pem" ] }
 num-bigint = "0.4.3"
-openssl = "0.10.38"
 pkcs11 = "0.5.0"
+sha2 = "0.10"
 simple_asn1 = "0.6.0"
 thiserror = "1.0.20"

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -23,8 +23,13 @@ chrono = "0.4.19"
 hex = "0.4.2"
 ic-agent = { path = "../ic-agent", version = "0.11" }
 leb128 = "0.2.4"
-reqwest = { version = "0.11", features = [ "blocking", "rustls-tls" ] }
 sha2 = "0.10.1"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_bytes = "0.11"
 serde_cbor = "0.11"
+
+
+[dependencies.reqwest]
+version = "0.11"
+default-features = false
+features = [ "blocking", "rustls-tls" ]

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -11,9 +11,9 @@ garcon = { version = "0.2.3", features = ["async"] }
 ic-agent = { path = "../ic-agent" }
 ic-identity-hsm = { path = "../ic-identity-hsm" }
 ic-utils = { path = "../ic-utils", features = ["raw"] }
-openssl = "0.10.38"
 ring = "0.16.11"
 serde = { version = "1.0.101", features = ["derive"] }
+sha2 = "0.10"
 tokio = { version = "1.8.1", features = ["full"] }
 
 [dev-dependencies]

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -50,11 +50,11 @@ mod management_canister {
         },
         Argument, Canister,
     };
-    use openssl::sha::Sha256;
     use ref_tests::{
         create_agent, create_basic_identity, create_secp256k1_identity, create_waiter, with_agent,
         with_wallet_canister,
     };
+    use sha2::{Digest, Sha256};
     use std::collections::HashSet;
 
     mod create_canister {
@@ -235,10 +235,8 @@ mod management_canister {
                 .canister_status(&canister_id_3)
                 .call_and_wait(create_waiter())
                 .await?;
-            let mut hasher = Sha256::new();
-            hasher.update(&canister_wasm);
-            let sha256_digest = hasher.finish();
-            assert_eq!(result.0.module_hash, Some(sha256_digest.into()));
+            let sha256_digest = Sha256::digest(&canister_wasm);
+            assert_eq!(result.0.module_hash, Some(sha256_digest.to_vec()));
 
             Ok(())
         })

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.55.0"
+channel = "1.58.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Replaces hash function calls.
Removes default features (native-tls) from `reqwest`
Removes dependencies from CI workflows
Bumps rust compiler version