### PR TITLE
chore: make read_state_raw public

### DIFF
--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -572,7 +572,7 @@ impl Agent {
         }
     }
 
-    async fn read_state_raw(
+    pub async fn read_state_raw(
         &self,
         paths: Vec<Vec<Label>>,
         effective_canister_id: Principal,

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -122,5 +122,5 @@ pub use agent::{
 pub use identity::{Identity, Signature};
 pub use request_id::{to_request_id, RequestId, RequestIdError};
 
-pub(crate) use crate::ic_types::hash_tree;
+pub use crate::ic_types::hash_tree;
 pub use ic_types;


### PR DESCRIPTION
To allow more flexible ways to query canister info on the client side