### PR TITLE
fix: change HttpResponse.upgrade to Option<bool> for backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Changed the 'HttpRequest.upgrade' field to 'Option<bool>' from 'bool'.
+
 ## [0.11.1] - 2022-01-10
 
 The `lookup_value` function now takes generics which can be iterated over (`IntoIterator<Item = &'p Label>`)  and transformed into a `Vec<Label>`, rather than just a `Vec<Label>`.

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -47,7 +47,7 @@ pub struct HttpResponse {
     #[serde(with = "serde_bytes")]
     pub body: Vec<u8>,
     pub streaming_strategy: Option<StreamingStrategy>,
-    pub upgrade: bool,
+    pub upgrade: Option<bool>,
 }
 
 #[derive(CandidType, Deserialize)]


### PR DESCRIPTION
This will be a breaking (minor version increment) release.