### PR TITLE
fix: candid compatibility: mismatched enum.

### DIFF
--- a/ic-asset/src/asset_canister/protocol.rs
+++ b/ic-asset/src/asset_canister/protocol.rs
@@ -104,6 +104,7 @@ pub struct ClearArguments {}
 
 /// Batch operations that can be applied atomically.
 #[derive(CandidType, Debug)]
+#[allow(dead_code)]
 pub enum BatchOperationKind {
     /// Create a new asset.
     CreateAsset(CreateAssetArguments),
@@ -118,7 +119,7 @@ pub enum BatchOperationKind {
     DeleteAsset(DeleteAssetArguments),
 
     /// Clear all state from the asset canister.
-    _Clear(ClearArguments),
+    Clear(ClearArguments),
 }
 
 /// Apply all of the operations in the batch, and then remove the batch.

--- a/ic-asset/src/retryable.rs
+++ b/ic-asset/src/retryable.rs
@@ -7,6 +7,14 @@ pub(crate) fn retryable(agent_error: &AgentError) -> bool {
             reject_code,
             reject_message,
         } if *reject_code == 5 && reject_message.contains("is out of cycles") => false,
+        AgentError::ReplicaError {
+            reject_code,
+            reject_message,
+        } if *reject_code == 5 && reject_message.contains("Fail to decode") => false,
+        AgentError::ReplicaError {
+            reject_code,
+            reject_message,
+        } if *reject_code == 4 && reject_message.contains("is not authorized") => false,
         AgentError::HttpError(HttpErrorPayload {
             status,
             content_type: _,


### PR DESCRIPTION
The struct BatchOperationKind which is used to send batch commands to the certified asset canister
using icx-asset is encoded into Candid which uses hashes of enum variants as keys.  This enum
has a "Clear" field in the certified asset canister, but a _Clear field in the ic-asset crate because
it was not used and was giving a warning.  However, because of the Candid format dependency
on the names of the variants these are incompatible which causes "icx-asset ... sync" to fail.

This PR changes the name to the compatible "Clear" and avoids the warning with #[allow(dead_code)].

A better change would be to add these types to an ic-certified-assets-types crate or somesuch,
but I will leave that to the reviewers to decided.

Signed-off-by: John Plevyak <jplevyak@gmail.com>