### PR TITLE
chore: Run e2e tests against dfx 0.7.2 and 0.8.4

### DIFF
--- a/.github/workflows/icx_asset.yml
+++ b/.github/workflows/icx_asset.yml
@@ -5,12 +5,13 @@ on:
       - main
   pull_request:
 jobs:
-  icx-asset-darwin:
+  icx-asset:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-latest ]
+        os: [ macos-latest, ubuntu-latest ]
         rust: [ '1.55.0' ]
+        dfx: [ '0.7.2', '0.8.4' ]
 
     steps:
       - uses: actions/checkout@v1
@@ -29,34 +30,16 @@ jobs:
           rustup component add rustfmt
 
       - name: Provision Darwin
-        run: bash .github/workflows/provision-darwin.sh
-      - name: 'Test icx-asset'
-        run: bats e2e/bash/icx-asset.bash
-
-  icx-asset-linux:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        rust: [ '1.55.0' ]
-        os: [ ubuntu-latest ]
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: Cache Cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
-      - name: Install Rust
-        run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
-          rustup component add rustfmt
-
+        if: contains(matrix.os, 'macos')
+        run: bash scripts/workflows/provision-darwin.sh
+        env:
+          DFX_VERSION: ${{ matrix.dfx }}
       - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
+        if: contains(matrix.os, 'ubuntu')
+        run: bash scripts/workflows/provision-linux.sh
+        env:
+          DFX_VERSION: ${{ matrix.dfx }}
+
       - name: 'Test icx-asset'
         run: bats e2e/bash/icx-asset.bash
+

--- a/.github/workflows/icx_asset.yml
+++ b/.github/workflows/icx_asset.yml
@@ -31,12 +31,12 @@ jobs:
 
       - name: Provision Darwin
         if: contains(matrix.os, 'macos')
-        run: bash scripts/workflows/provision-darwin.sh
+        run: bash .github/workflows/provision-darwin.sh
         env:
           DFX_VERSION: ${{ matrix.dfx }}
       - name: Provision Linux
         if: contains(matrix.os, 'ubuntu')
-        run: bash scripts/workflows/provision-linux.sh
+        run: bash .github/workflows/provision-linux.sh
         env:
           DFX_VERSION: ${{ matrix.dfx }}
 

--- a/.github/workflows/icx_asset.yml
+++ b/.github/workflows/icx_asset.yml
@@ -43,3 +43,12 @@ jobs:
       - name: 'Test icx-asset'
         run: bats e2e/bash/icx-asset.bash
 
+  aggregate:
+    name: icx-asset:required
+    if: ${{ always() }}
+    needs: [ icx-asset ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: check e2e test result
+        if: ${{ needs.icx-asset.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/icx_asset.yml
+++ b/.github/workflows/icx_asset.yml
@@ -33,12 +33,12 @@ jobs:
         if: contains(matrix.os, 'macos')
         run: bash .github/workflows/provision-darwin.sh
         env:
-          DFX_VERSION: ${{ matrix.dfx }}
+          INSTALL_DFX_VERSION: ${{ matrix.dfx }}
       - name: Provision Linux
         if: contains(matrix.os, 'ubuntu')
         run: bash .github/workflows/provision-linux.sh
         env:
-          DFX_VERSION: ${{ matrix.dfx }}
+          INSTALL_DFX_VERSION: ${{ matrix.dfx }}
 
       - name: 'Test icx-asset'
         run: bats e2e/bash/icx-asset.bash

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -28,10 +28,11 @@ tar --directory /usr/local/lib/bats-support --extract --file bats-support.tar.gz
 rm bats-support.tar.gz
 
 # Install DFINITY SDK.
-version=0.8.4
 curl --location --output install-dfx.sh "https://sdk.dfinity.org/install.sh"
-DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
+echo "DFX VERSION IS $DFX_VERSION"
+bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
+dfx --version
 
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -29,10 +29,8 @@ rm bats-support.tar.gz
 
 # Install DFINITY SDK.
 curl --location --output install-dfx.sh "https://sdk.dfinity.org/install.sh"
-echo "DFX VERSION IS $DFX_VERSION"
-bash install-dfx.sh < <(yes Y)
+DFX_VERSION="$INSTALL_DFX_VERSION" bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
-dfx --version
 
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -28,7 +28,7 @@ tar --directory /usr/local/lib/bats-support --extract --file bats-support.tar.gz
 rm bats-support.tar.gz
 
 # Install DFINITY SDK.
-version=0.7.2
+version=0.8.4
 curl --location --output install-dfx.sh "https://sdk.dfinity.org/install.sh"
 DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -23,10 +23,8 @@ rm v$version.tar.gz
 
 # Install DFINITY SDK.
 wget --output-document install-dfx.sh "https://sdk.dfinity.org/install.sh"
-echo "DFX VERSION IS $DFX_VERSION"
-bash install-dfx.sh < <(yes Y)
+DFX_VERSION="$INSTALL_DFX_VERSION" bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
-dfx --version
 
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -22,10 +22,11 @@ sudo tar --directory /usr/local/lib/bats-support --extract --file v$version.tar.
 rm v$version.tar.gz
 
 # Install DFINITY SDK.
-version=0.8.4
 wget --output-document install-dfx.sh "https://sdk.dfinity.org/install.sh"
-DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
+echo "DFX VERSION IS $DFX_VERSION"
+bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
+dfx --version
 
 # Set environment variables.
 BATS_SUPPORT="/usr/local/lib/bats-support"

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -22,7 +22,7 @@ sudo tar --directory /usr/local/lib/bats-support --extract --file v$version.tar.
 rm v$version.tar.gz
 
 # Install DFINITY SDK.
-version=0.7.2
+version=0.8.4
 wget --output-document install-dfx.sh "https://sdk.dfinity.org/install.sh"
 DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh


### PR DESCRIPTION
Also DRY the workflow definition.

It's expected that the `icx-asset-darwin` and `icx-asset-linux` required statuses do not pass, because this PR changes these and aggregates them into a single required status.  Once this PR is approved, I will update the required statuses and then merge.