### PR TITLE
chore: valiate curve params when loading identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Secp256k1 identity now checks if a curve actually uses the secp256k1 parameters. It cannot be used to load non-secp256k1 identities anymore.
+
 ## [0.12.1] - 2022-02-09
 
 Renamed BatchOperationKind._Clear to Clear for compatibility with the certified assets canister.

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -115,7 +115,10 @@ oGSXVWaGxcQhQWlFG4pbnOG+93xXzfRD7eKWOdmun2bKxQ==
     #[test]
     #[should_panic(expected = "Wrong curve detected when trying to load secp256k1 identity.")]
     fn test_secp256k1_reject_wrong_curve() {
-        let _ = Secp256k1Identity::from_pem(WRONG_CURVE_IDENTITY_FILE.as_bytes());
+        let private_key =
+            EcKey::private_key_from_pem(WRONG_CURVE_IDENTITY_FILE.as_bytes()).unwrap();
+
+        let _ = Secp256k1Identity::from_private_key(private_key);
     }
 }
 


### PR DESCRIPTION
Jira: [SDK-317](https://dfinity.atlassian.net/browse/SDK-317)

Secp256k1Identity failed to check if a key actually is a secp256k1 key. It now checks for the correct curve params.