### PR TITLE
chore: fetch_root_key fetches only the first time

### DIFF
--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -292,6 +292,12 @@ impl Agent {
     /// *Only use this when you are  _not_ talking to the main Internet Computer, otherwise
     /// you are prone to man-in-the-middle attacks! Do not call this function by default.*
     pub async fn fetch_root_key(&self) -> Result<(), AgentError> {
+        if let Ok(key) = self.read_root_key() {
+            if key != IC_ROOT_KEY.to_vec() {
+                // already fetched the root key
+                return Ok(());
+            }
+        }
         let status = self.status().await?;
         let root_key = status
             .root_key

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -707,6 +707,18 @@ mod management_canister {
             Ok(())
         })
     }
+
+    #[ignore]
+    #[test]
+    // makes sure that calling fetch_root_key twice by accident does not break
+    fn multi_fetch_root_key() {
+        with_agent(|agent| async move {
+            agent.fetch_root_key().await?;
+            agent.fetch_root_key().await?;
+
+            Ok(())
+        })
+    }
 }
 
 mod simple_calls {


### PR DESCRIPTION
Jira: [SDK-133](https://dfinity.atlassian.net/browse/SDK-133)

When a non-default root key is found, it has already been fetched. No need to ask the network a second time.