### PR TITLE
feat: Complete docs and Debug coverage

### DIFF
--- a/ic-agent/src/agent/agent_config.rs
+++ b/ic-agent/src/agent/agent_config.rs
@@ -5,11 +5,15 @@ use crate::{
 use std::{sync::Arc, time::Duration};
 
 /// A configuration for an agent.
-
+#[derive(Debug)]
 pub struct AgentConfig {
+    /// See [`with_nonce_factory`](super::AgentBuilder::with_nonce_factory).
     pub nonce_factory: Arc<dyn NonceGenerator>,
+    /// See [`with_identity`](super::AgentBuilder::with_identity).
     pub identity: Arc<dyn Identity>,
+    /// See [`with_ingress_expiry`](super::AgentBuilder::with_ingress_expiry).
     pub ingress_expiry_duration: Option<Duration>,
+    /// The [`with_transport`](super::AgentBuilder::with_transport).
     pub transport: Option<Arc<dyn ReplicaV2Transport>>,
 }
 

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -1,3 +1,5 @@
+//! Errors that can occur when using the replica agent.
+
 use crate::{agent::status::Status, hash_tree::Label, RequestIdError};
 use leb128::read;
 use std::{
@@ -6,122 +8,174 @@ use std::{
 };
 use thiserror::Error;
 
+/// An error that occurred when using the agent.
 #[derive(Error, Debug)]
 pub enum AgentError {
+    /// The replica URL was invalid.
     #[error(r#"Invalid Replica URL: "{0}""#)]
     InvalidReplicaUrl(String),
 
+    /// The request timed out.
     #[error("The request timed out.")]
     TimeoutWaitingForResponse(),
 
+    /// The waiter was restarted without being started first.
     #[error("The waiter was restarted without being started first.")]
     WaiterRestartError(),
 
+    /// An error occurred when signing with the identity.
     #[error("Identity had a signing error: {0}")]
     SigningError(String),
 
+    /// The data fetched was invalid CBOR.
     #[error("Invalid CBOR data, could not deserialize: {0}")]
     InvalidCborData(#[from] serde_cbor::Error),
 
+    /// There was an error calculating a request ID.
     #[error("Cannot calculate a RequestID: {0}")]
     CannotCalculateRequestId(#[from] RequestIdError),
 
+    /// There was an error when de/serializing with Candid.
     #[error("Candid returned an error: {0}")]
     CandidError(Box<dyn Send + Sync + std::error::Error>),
 
+    /// There was an error parsing a URL.
     #[error(r#"Cannot parse url: "{0}""#)]
     UrlParseError(#[from] url::ParseError),
 
+    /// The HTTP method was invalid.
     #[error(r#"Invalid method: "{0}""#)]
     InvalidMethodError(#[from] http::method::InvalidMethod),
 
+    /// The principal string was not a valid principal.
     #[error("Cannot parse Principal: {0}")]
     PrincipalError(#[from] crate::export::PrincipalError),
 
+    /// The replica rejected the message.
     #[error(r#"The Replica returned an error: code {reject_code}, message: "{reject_message}""#)]
     ReplicaError {
+        /// The [reject code](https://smartcontracts.org/docs/interface-spec/index.html#reject-codes) returned by the replica.
         reject_code: u64,
+        /// The rejection message.
         reject_message: String,
     },
 
+    /// The replica returned an HTTP error.
     #[error("The replica returned an HTTP Error: {0}")]
     HttpError(HttpErrorPayload),
 
+    /// Attempted to use HTTP authentication in a non-secure URL (either HTTPS or localhost).
     #[error("HTTP Authentication cannot be used in a non-secure URL (either HTTPS or localhost)")]
     CannotUseAuthenticationOnNonSecureUrl(),
 
+    /// The password manager returned an error.
     #[error("Password Manager returned an error: {0}")]
     AuthenticationError(String),
 
+    /// The status endpoint returned an invalid status.
     #[error("Status endpoint returned an invalid status.")]
     InvalidReplicaStatus,
 
+    /// The call was marked done, but no reply was provided.
     #[error("Call was marked as done but we never saw the reply. Request ID: {0}")]
     RequestStatusDoneNoReply(String),
 
+    /// A string error occurred in an external tool.
     #[error("A tool returned a string message error: {0}")]
     MessageError(String),
 
+    /// An error occurred in an external tool.
     #[error("A tool returned a custom error: {0}")]
     CustomError(#[from] Box<dyn Send + Sync + std::error::Error>),
 
+    /// There was an error reading a LEB128 value.
     #[error("Error reading LEB128 value: {0}")]
     Leb128ReadError(#[from] read::Error),
 
+    /// A string was invalid UTF-8.
     #[error("Error in UTF-8 string: {0}")]
     Utf8ReadError(#[from] Utf8Error),
 
+    /// The lookup path was absent in the certificate.
     #[error("The lookup path ({0:?}) is absent in the certificate.")]
     LookupPathAbsent(Vec<Label>),
 
+    /// The lookup path was unknown in the certificate.
     #[error("The lookup path ({0:?}) is unknown in the certificate.")]
     LookupPathUnknown(Vec<Label>),
 
+    /// The lookup path did not make sense for the certificate.
     #[error("The lookup path ({0:?}) does not make sense for the certificate.")]
     LookupPathError(Vec<Label>),
 
+    /// The request status at the requested path was invalid.
     #[error("The request status ({1}) at path {0:?} is invalid.")]
     InvalidRequestStatus(Vec<Label>, String),
 
+    /// The certificate verification failed.
     #[error("Certificate verification failed.")]
     CertificateVerificationFailed(),
 
+    /// There was a length mismatch between the expected and actual length of the BLS DER-encoded public key.
     #[error(
         r#"BLS DER-encoded public key must be ${expected} bytes long, but is {actual} bytes long."#
     )]
-    DerKeyLengthMismatch { expected: usize, actual: usize },
+    DerKeyLengthMismatch {
+        /// The expected length of the key.
+        expected: usize,
+        /// The actual length of the key.
+        actual: usize,
+    },
 
+    /// There was a mismatch between the expected and actual prefix of the BLS DER-encoded public key.
     #[error("BLS DER-encoded public key is invalid. Expected the following prefix: ${expected:?}, but got ${actual:?}")]
-    DerPrefixMismatch { expected: Vec<u8>, actual: Vec<u8> },
+    DerPrefixMismatch {
+        /// The expected key prefix.
+        expected: Vec<u8>,
+        /// The actual key prefix.
+        actual: Vec<u8>,
+    },
 
+    /// The status response did not contain a root key.
     #[error("The status response did not contain a root key.  Status: {0}")]
     NoRootKeyInStatus(Status),
 
+    /// Could not read the replica root key.
     #[error("Could not read the root key")]
     CouldNotReadRootKey(),
 
+    /// Failed to initialize the BLS library.
     #[error("Failed to initialize the BLS library")]
     BlsInitializationFailure(),
 
+    /// The invocation to the wallet call forward method failed with an error.
     #[error("The invocation to the wallet call forward method failed with the error: {0}")]
     WalletCallFailed(String),
 
+    /// The wallet operation failed.
     #[error("The  wallet operation failed: {0}")]
     WalletError(String),
 
+    /// The wallet canister must be upgraded. See [`dfx wallet upgrade`](https://smartcontracts.org/docs/developers-guide/cli-reference/dfx-wallet.html)
     #[error("The wallet canister must be upgraded: {0}")]
     WalletUpgradeRequired(String),
 
+    /// The transport was not specified in the [`AgentBuilder`](super::AgentBuilder).
     #[error("Missing replica transport in the Agent Builder.")]
     MissingReplicaTransport(),
 
+    /// An unknown error occurred during communication with the replica.
     #[error("An error happened during communication with the replica: {0}")]
     TransportError(Box<dyn std::error::Error + Send + Sync>),
 
+    /// There was a mismatch between the expected and actual CBOR data during inspection.
     #[error("There is a mismatch between the CBOR encoded call and the arguments: field {field}, value in argument is {value_arg}, value in CBOR is {value_cbor}")]
     CallDataMismatch {
+        /// The field that was mismatched.
         field: String,
+        /// The value that was expected to be in the CBOR.
         value_arg: String,
+        /// The value that was actually in the CBOR.
         value_cbor: String,
     },
 }
@@ -134,9 +188,13 @@ impl PartialEq for AgentError {
     }
 }
 
+/// A HTTP error from the replica.
 pub struct HttpErrorPayload {
+    /// The HTTP status code.
     pub status: u16,
+    /// The MIME type of `content`.
     pub content_type: Option<String>,
+    /// The body of the error.
     pub content: Vec<u8>,
 }
 

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -4,6 +4,8 @@ use crate::{
 };
 use std::sync::Arc;
 
+/// A builder for an [`Agent`].
+#[derive(Debug)]
 pub struct AgentBuilder {
     config: AgentConfig,
 }

--- a/ic-agent/src/agent/http_transport.rs
+++ b/ic-agent/src/agent/http_transport.rs
@@ -22,7 +22,10 @@ pub trait PasswordManager: Send + Sync {
     fn required(&self, url: &str) -> Result<(String, String), String>;
 }
 
+impl_debug_empty!(dyn PasswordManager);
+
 /// A [ReplicaV2Transport] using Reqwest to make HTTP calls to the internet computer.
+#[derive(Debug)]
 pub struct ReqwestHttpReplicaV2Transport {
     url: reqwest::Url,
     client: reqwest::Client,
@@ -33,6 +36,7 @@ const IC0_DOMAIN: &str = "ic0.app";
 const IC0_SUB_DOMAIN: &str = ".ic0.app";
 
 impl ReqwestHttpReplicaV2Transport {
+    /// Creates a replica transport from a HTTP URL.
     pub fn create<U: Into<String>>(url: U) -> Result<Self, AgentError> {
         let mut tls_config = rustls::ClientConfig::builder()
             .with_safe_defaults()
@@ -64,6 +68,7 @@ impl ReqwestHttpReplicaV2Transport {
         })
     }
 
+    /// Sets a password manager to use with HTTP authentication.
     pub fn with_password_manager<P: 'static + PasswordManager>(self, password_manager: P) -> Self {
         ReqwestHttpReplicaV2Transport {
             password_manager: Some(Arc::new(password_manager)),
@@ -72,6 +77,7 @@ impl ReqwestHttpReplicaV2Transport {
         }
     }
 
+    /// Same as [`with_password_manager`], but providing the Arc so one does not have to be created.
     pub fn with_arc_password_manager(self, password_manager: Arc<dyn PasswordManager>) -> Self {
         ReqwestHttpReplicaV2Transport {
             password_manager: Some(password_manager),
@@ -80,6 +86,7 @@ impl ReqwestHttpReplicaV2Transport {
         }
     }
 
+    /// Gets the set password manager, if one exists. Otherwise returns None.
     pub fn password_manager(&self) -> Option<&dyn PasswordManager> {
         self.password_manager.as_deref()
     }

--- a/ic-agent/src/agent/replica_api.rs
+++ b/ic-agent/src/agent/replica_api.rs
@@ -109,17 +109,20 @@ pub struct ReadStateResponse {
 }
 
 /// A `Certificate` as defined in https://smartcontracts.org/docs/interface-spec/index.html#_certificate
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Certificate<'a> {
+    /// The hash tree.
     pub tree: HashTree<'a>,
 
+    /// The signature of the root hash in `tree`.
     #[serde(with = "serde_bytes")]
     pub signature: Vec<u8>,
 
+    /// A delegation from the root key to the key used to sign `signature`, if one exists.
     pub delegation: Option<Delegation>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct Delegation {
     #[serde(with = "serde_bytes")]
     pub subnet_id: Vec<u8>,

--- a/ic-agent/src/agent/response.rs
+++ b/ic-agent/src/agent/response.rs
@@ -1,19 +1,31 @@
 /// The response of /api/v2/canister/<effective_canister_id>/read_state with "request_status" request type.
+///
+/// See [the HTTP interface specification](https://smartcontracts.org/docs/interface-spec/index.html#http-call-overview) for more details.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum RequestStatusResponse {
+    /// The status of the request is unknown.
     Unknown,
+    /// The request has been received, and will probably get processed.
     Received,
+    /// The request is currently being processed.
     Processing,
+    /// The request has been successfully replied to.
     Replied {
+        /// The reply from the replica.
         reply: Replied,
     },
+    /// The request has been rejected.
     Rejected {
+        /// The [reject code](https://smartcontracts.org/docs/interface-spec/index.html#reject-codes) from the replica.
         reject_code: u64,
+        /// The rejection message.
         reject_message: String,
     },
+    /// The call has been completed, and it has been long enough that the reply/reject data has been purged, but the call has not expired yet.
     Done,
 }
 
+#[allow(missing_docs)]
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Replied {
     CallReplied(Vec<u8>),

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -145,6 +145,9 @@ pub(crate) fn lookup_reply(
     Ok(RequestStatusResponse::Replied { reply })
 }
 
+/// Looks up a value in the certificate's tree at the specified hash.
+///
+/// Returns the value if it was found; otherwise, errors with `LookupPathAbsent`, `LookupPathUnknown`, or `LookupPathError`.
 pub fn lookup_value<'a, P>(
     certificate: &'a Certificate<'a>,
     path: P,

--- a/ic-agent/src/agent/signed.rs
+++ b/ic-agent/src/agent/signed.rs
@@ -1,44 +1,70 @@
+//! Types representing signed ingress messages.
+
 use crate::{export::Principal, RequestId};
 
 use serde::{Deserialize, Serialize};
 
+/// A signed query request message. Produced by [`QueryBuilder::sign`](super::QueryBuilder::sign).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SignedQuery {
+    /// The Unix timestamp that the request will expire at.
     pub ingress_expiry: u64,
+    /// The principal ID of the caller.
     pub sender: Principal,
+    /// The principal ID of the canister being called.
     pub canister_id: Principal,
+    /// The name of the canister method being called.
     pub method_name: String,
+    /// The argument blob to be passed to the method.
     #[serde(with = "serde_bytes")]
     pub arg: Vec<u8>,
+    /// The [effective canister ID](https://smartcontracts.org/docs/interface-spec/index.html#http-effective-canister-id) of the destination.
     pub effective_canister_id: Principal,
+    /// The CBOR-encoded [authentication envelope](https://smartcontracts.org/docs/interface-spec/index.html#authentication) for the request.
     #[serde(with = "serde_bytes")]
     pub signed_query: Vec<u8>,
 }
 
+/// A signed update request message. Produced by [`UpdateBuilder::sign`](super::UpdateBuilder::sign).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SignedUpdate {
+    /// A nonce to uniquely identify this update call.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "serde_bytes")]
     pub nonce: Option<Vec<u8>>,
+    /// The Unix timestamp that the request will expire at.
     pub ingress_expiry: u64,
+    /// The principal ID of the caller.
     pub sender: Principal,
+    /// The principal ID of the canister being called.
     pub canister_id: Principal,
+    /// The name of the canister method being called.
     pub method_name: String,
+    /// The argument blob to be passed to the method.
     #[serde(with = "serde_bytes")]
     pub arg: Vec<u8>,
+    /// The [effective canister ID](https://smartcontracts.org/docs/interface-spec/index.html#http-effective-canister-id) of the destination.
     pub effective_canister_id: Principal,
     #[serde(with = "serde_bytes")]
+    /// The CBOR-encoded [authentication envelope](https://smartcontracts.org/docs/interface-spec/index.html#authentication) for the request.
     pub signed_update: Vec<u8>,
+    /// The request ID.
     pub request_id: RequestId,
 }
 
+/// A signed request-status request message. Produced by [`Agent::sign_request_status`](super::Agent::sign_request_status).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SignedRequestStatus {
+    /// The Unix timestamp that the request will expire at.
     pub ingress_expiry: u64,
+    /// The principal ID of the caller.
     pub sender: Principal,
+    /// The [effective canister ID](https://smartcontracts.org/docs/interface-spec/index.html#http-effective-canister-id) of the destination.
     pub effective_canister_id: Principal,
+    /// The request ID.
     pub request_id: RequestId,
+    /// The CBOR-encoded [authentication envelope](https://smartcontracts.org/docs/interface-spec/index.html#authentication) for the request.
     #[serde(with = "serde_bytes")]
     pub signed_request_status: Vec<u8>,
 }

--- a/ic-agent/src/agent/status.rs
+++ b/ic-agent/src/agent/status.rs
@@ -1,3 +1,5 @@
+//! Types for interacting with the status endpoint of a replica. See [`Status`] for details.
+
 use std::{collections::BTreeMap, fmt::Debug};
 
 /// Value returned by the status endpoint of a replica. This is a loose mapping to CBOR values.
@@ -5,12 +7,19 @@ use std::{collections::BTreeMap, fmt::Debug};
 /// we reimplement it as [`Value`] here.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Hash)]
 pub enum Value {
+    /// See [`Null`](serde_cbor::Value::Null).
     Null,
+    /// See [`String`](serde_cbor::Value::String).
     String(String),
+    /// See [`Integer`](serde_cbor::Value::Integer).
     Integer(i64),
+    /// See [`Bool`](serde_cbor::Value::Bool).
     Bool(bool),
+    /// See [`Bytes`](serde_cbor::Value::Bytes).
     Bytes(Vec<u8>),
+    /// See [`Vec`](serde_cbor::Value::Vec).
     Vec(Vec<Value>),
+    /// See [`Map`](serde_cbor::Value::Map).
     Map(BTreeMap<String, Box<Value>>),
 }
 

--- a/ic-agent/src/identity/anonymous.rs
+++ b/ic-agent/src/identity/anonymous.rs
@@ -1,5 +1,9 @@
 use crate::{export::Principal, identity::Identity, Signature};
 
+/// The anonymous identity.
+///
+/// The caller will be represented as [`Principal::anonymous`], or `2vxsx-fae`.
+#[derive(Debug, Copy, Clone)]
 pub struct AnonymousIdentity;
 
 impl Identity for AnonymousIdentity {

--- a/ic-agent/src/identity/basic.rs
+++ b/ic-agent/src/identity/basic.rs
@@ -9,10 +9,20 @@ use simple_asn1::{
     ASN1Block::{BitString, ObjectIdentifier, Sequence},
 };
 
+use std::fmt;
+
 /// A Basic Identity which sign using an ED25519 key pair.
 pub struct BasicIdentity {
     key_pair: Ed25519KeyPair,
     der_encoded_public_key: Vec<u8>,
+}
+
+impl fmt::Debug for BasicIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BasicIdentity")
+            .field("der_encoded_public_key", &self.der_encoded_public_key)
+            .finish_non_exhaustive()
+    }
 }
 
 impl BasicIdentity {

--- a/ic-agent/src/identity/error.rs
+++ b/ic-agent/src/identity/error.rs
@@ -5,16 +5,20 @@ use thiserror::Error;
 /// An error happened while reading a PEM file.
 #[derive(Error, Debug)]
 pub enum PemError {
+    /// An error occurred with disk I/O.
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
+    /// An error occurred while reading the file in PEM format.
     #[cfg(feature = "pem")]
     #[error("An error occurred while reading the file: {0}")]
     PemError(#[from] pem::PemError),
 
+    /// The key was rejected by Ring.
     #[error("A key was rejected by Ring: {0}")]
     KeyRejected(#[from] ring::error::KeyRejected),
 
+    /// The key was rejected by OpenSSL.
     #[error("A key was rejected by OpenSSL: {0}")]
     ErrorStack(#[from] openssl::error::ErrorStack),
 }

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -15,10 +15,12 @@ pub use secp256k1::Secp256k1Identity;
 #[cfg(feature = "pem")]
 pub use error::PemError;
 
+/// A cryptographic signature, signed by an [Identity].
 #[derive(Clone, Debug)]
 pub struct Signature {
     /// This is the DER-encoded public key.
     pub public_key: Option<Vec<u8>>,
+    /// The signature bytes.
     pub signature: Option<Vec<u8>>,
 }
 
@@ -36,3 +38,5 @@ pub trait Identity: Send + Sync {
     /// creating the sender signature.
     fn sign(&self, blob: &[u8]) -> Result<Signature, String>;
 }
+
+impl_debug_empty!(dyn Identity);

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -16,6 +16,9 @@ use simple_asn1::{
     ASN1Block::{BitString, ObjectIdentifier, Sequence},
 };
 
+/// A cryptographic identity based on the Secp256k1 elliptic curve.
+///
+/// The caller will be represented via [`Principal::self_authenticating`], which contains the SHA-224 hash of the public key.
 #[derive(Clone, Debug)]
 pub struct Secp256k1Identity {
     private_key: EcKey<Private>,
@@ -24,11 +27,13 @@ pub struct Secp256k1Identity {
 }
 
 impl Secp256k1Identity {
+    /// Creates an identity from a PEM file. Shorthand for calling `from_pem` with `std::fs::read`.
     #[cfg(feature = "pem")]
     pub fn from_pem_file<P: AsRef<std::path::Path>>(file_path: P) -> Result<Self, PemError> {
         Self::from_pem(std::fs::File::open(file_path)?)
     }
 
+    /// Creates an identity from a PEM certificate.
     #[cfg(feature = "pem")]
     pub fn from_pem<R: std::io::Read>(pem_reader: R) -> Result<Self, PemError> {
         let contents = pem_reader
@@ -38,6 +43,7 @@ impl Secp256k1Identity {
         Ok(Self::from_private_key(private_key))
     }
 
+    /// Creates an identity from a private key.
     pub fn from_private_key(private_key: EcKey<Private>) -> Self {
         let group = private_key.group();
         let public_key = EcKey::from_public_key(group, private_key.public_key())

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -105,7 +105,17 @@
 //! publicly available yet. When these specifications are made public and
 //! generally available, additional details about the versions supported will
 //! be available here.
-//!
+
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links
+)]
+
+#[macro_use]
+mod macros;
+
 #[allow(clippy::all)]
 #[allow(dead_code)]
 mod bls;

--- a/ic-agent/src/macros.rs
+++ b/ic-agent/src/macros.rs
@@ -1,0 +1,9 @@
+macro_rules! impl_debug_empty {
+    ($name:ty) => {
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(concat!("? ", stringify!($name)))
+            }
+        }
+    };
+}

--- a/ic-agent/src/request_id/error.rs
+++ b/ic-agent/src/request_id/error.rs
@@ -5,9 +5,11 @@ use thiserror::Error;
 /// deserialization.
 #[derive(Error, Debug)]
 pub enum RequestIdFromStringError {
+    /// The string was not of a valid length.
     #[error("Invalid string size: {0}. Must be even.")]
     InvalidSize(usize),
 
+    /// The string was not in a valid hexadecimal format.
     #[error("Error while decoding hex: {0}")]
     FromHexError(hex::FromHexError),
 }
@@ -17,74 +19,100 @@ pub enum RequestIdFromStringError {
 /// serde expects, such as Display
 #[derive(Error, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
 pub enum RequestIdError {
+    /// An unknown error occurred inside `serde`.
     #[error("A custom error happened inside Serde: {0}")]
     CustomSerdeError(String),
-
+    /// The serializer was not given any data.
     #[error("Need to provide data to serialize")]
     EmptySerializer,
-
+    /// The serializer was in an invalid state.
     #[error("RequestId Serializer was in an invalid state")]
     InvalidState,
-
+    /// The serializer received a nested struct, which it does not support.
     #[error("RequestId does not support struct inside other structs")]
     UnsupportedStructInsideStruct,
-
+    /// The serializer received a `bool`, which it does not support.
     #[error("Unsupported type: Bool")]
     UnsupportedTypeBool,
+    /// The serializer received a `u8`, which it does not support.
     #[error("Unsupported type: U8")]
     UnsupportedTypeU8,
+    /// The serializer received a `u16`, which it does not support.
     #[error("Unsupported type: U16")]
     UnsupportedTypeU16,
+    /// The serializer received a `u32`, which it does not support.
     #[error("Unsupported type: U32")]
     UnsupportedTypeU32,
+    /// The serializer received a `u64`, which it does not support.
     #[error("Unsupported type: U64")]
     UnsupportedTypeU64,
+    /// The serializer received a `u128`, which it does not support.
     #[error("Unsupported type: U128")]
     UnsupportedTypeU128,
+    /// The serializer received a `i8`, which it does not support.
     #[error("Unsupported type: I8")]
     UnsupportedTypeI8,
+    /// The serializer received a `i16`, which it does not support.
     #[error("Unsupported type: I16")]
     UnsupportedTypeI16,
+    /// The serializer received a `i32`, which it does not support.
     #[error("Unsupported type: I32")]
     UnsupportedTypeI32,
+    /// The serializer received a `i64`, which it does not support.
     #[error("Unsupported type: I64")]
     UnsupportedTypeI64,
+    /// The serializer received a `i128`, which it does not support.
     #[error("Unsupported type: I128")]
     UnsupportedTypeI128,
+    /// The serializer received a `f32`, which it does not support.
     #[error("Unsupported type: F32")]
     UnsupportedTypeF32,
+    /// The serializer received a `f64`, which it does not support.
     #[error("Unsupported type: F64")]
     UnsupportedTypeF64,
+    /// The serializer received a `char`, which it does not support.
     #[error("Unsupported type: Char")]
     UnsupportedTypeChar,
     // UnsupportedTypeStr, // Supported
+    /// The serializer received a byte sequence, which it does not support.
     #[error("Unsupported type: Bytes")]
     UnsupportedTypeBytes,
     // UnsupportedTypeNone, // Supported
     // UnsupportedTypeSome, // Supported
+    /// The serializer received a `()`, which it does not support.
     #[error("Unsupported type: Unit")]
     UnsupportedTypeUnit,
+    /// The serializer received a `PhantomData`, which it does not support.
     #[error("Unsupported type: PhantomData")]
     UnsupportedTypePhantomData,
 
     // Variants and complex types.
+    /// The serializer received an enum unit variant, which it does not support.
     #[error("Unsupported type: UnitVariant")]
     UnsupportedTypeUnitVariant,
+    /// The serializer received a newtype struct, which it does not support.
     #[error("Unsupported type: NewtypeStruct")]
     UnsupportedTypeNewtypeStruct(String),
+    /// The serializer received an enum newtype variant, which it does not support.
     #[error("Unsupported type: NewTypeVariant")]
     UnsupportedTypeNewTypeVariant,
+    /// The serializer received a sequence, which it does not support.
     #[error("Unsupported type: Sequence")]
     UnsupportedTypeSequence,
+    /// The serializer received a tuple, which it does not support.
     #[error("Unsupported type: Tuple")]
     UnsupportedTypeTuple,
+    /// The serializer received a tuple struct, which it does not support.
     #[error("Unsupported type: TupleStruct")]
     UnsupportedTypeTupleStruct,
+    /// The serializer received an enum tuple variant, which it does not support.
     #[error("Unsupported type: TupleVariant")]
     UnsupportedTypeTupleVariant,
+    /// The serializer received a map, which it does not support.
     #[error("Unsupported type: Map")]
     UnsupportedTypeMap,
     // UnsupportedTypeStruct, // Supported
+    /// The serializer received an enum struct variant, which it does not support.
     #[error("Unsupported type: StructVariant")]
     UnsupportedTypeStructVariant,
 }

--- a/ic-agent/src/request_id/mod.rs
+++ b/ic-agent/src/request_id/mod.rs
@@ -22,10 +22,12 @@ type Sha256Hash = [u8; 32];
 pub struct RequestId(Sha256Hash);
 
 impl RequestId {
+    /// Creates a new `RequestId` from a SHA-256 hash.
     pub fn new(from: &[u8; 32]) -> RequestId {
         RequestId(*from)
     }
 
+    /// Returns the SHA-256 hash this ID is based on.
     pub fn as_slice(&self) -> &[u8] {
         &self.0
     }

--- a/ic-asset/src/lib.rs
+++ b/ic-asset/src/lib.rs
@@ -1,3 +1,35 @@
+//! A library for manipulating assets in an asset canister.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use ic_agent::agent::{Agent, http_transport::ReqwestHttpReplicaV2Transport};
+//! use ic_agent::identity::BasicIdentity;
+//! use ic_utils::Canister;
+//! use std::time::Duration;
+//! # async fn not_main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let replica_url = "";
+//! # let pemfile = "";
+//! # let canister_id = "";
+//! let agent = Agent::builder()
+//!     .with_transport(ReqwestHttpReplicaV2Transport::create(replica_url)?)
+//!     .with_identity(BasicIdentity::from_pem_file(pemfile)?)
+//!     .build()?;
+//! let canister = Canister::builder()
+//!     .with_canister_id(canister_id)
+//!     .with_agent(&agent)
+//!     .build()?;
+//! ic_asset::sync(&canister, concat!(env!("CARGO_MANIFEST_DIR"), "assets/").as_ref(), Duration::from_secs(60)).await?;
+//! # Ok(())
+//! # }
+
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links
+)]
+
 mod asset_canister;
 mod content;
 mod content_encoder;

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 use std::time::Duration;
 use walkdir::WalkDir;
 
+/// Sets the contents of the asset canister to the contents of a directory, including deleting old assets.
 pub async fn sync(canister: &Canister<'_>, dir: &Path, timeout: Duration) -> anyhow::Result<()> {
     let asset_locations = gather_asset_locations(dir);
 

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -31,45 +31,63 @@ const EXPECTED_EC_PARAMS: &[u8; 10] = b"\x06\x08\x2a\x86\x48\xce\x3d\x03\x01\x07
 /// An error happened related to a HardwareIdentity.
 #[derive(Error, Debug)]
 pub enum HardwareIdentityError {
+    /// A PKCS11 error occurred.
     #[error(transparent)]
     PKCS11(#[from] pkcs11::errors::Error),
 
     // ASN1DecodeError does not implement the Error trait and so we cannot use #[from]
+    /// An error occurred when decoding ASN1.
     #[error("ASN decode error {0}")]
     ASN1Decode(ASN1DecodeErr),
 
+    /// An error occurred when encoding ASN1.
     #[error(transparent)]
     ASN1Encode(#[from] ASN1EncodeErr),
 
+    /// An error occurred when decoding a key ID.
     #[error(transparent)]
     KeyIdDecode(#[from] hex::FromHexError),
 
+    /// The key was not found.
     #[error("Key not found")]
     KeyNotFound,
 
+    /// An unexpected key type was found.
     #[error("Unexpected key type {0}")]
     UnexpectedKeyType(CK_KEY_TYPE),
 
+    /// An EcPoint block was expected to be an OctetString, but was not.
     #[error("Expected EcPoint to be an OctetString")]
     ExpectedEcPointOctetString,
 
+    /// An EcPoint block was unexpectedly empty.
     #[error("EcPoint is empty")]
     EcPointEmpty,
 
+    /// The attribute with the specified type was not found.
     #[error("Attribute with type={0} not found")]
     AttributeNotFound(CK_ATTRIBUTE_TYPE),
 
+    /// The EcParams given were not the ones the crate expected.
     #[error("Invalid EcParams.  Expected prime256v1 {:02x?}, actual is {:02x?}", .expected, .actual)]
-    InvalidEcParams { expected: Vec<u8>, actual: Vec<u8> },
+    InvalidEcParams {
+        /// The expected value of the EcParams.
+        expected: Vec<u8>,
+        /// The actual value of the EcParams.
+        actual: Vec<u8>,
+    },
 
+    /// The PIN login function returned an error, but PIN login was required.
     #[error("User PIN is required: {0}")]
     UserPinRequired(String),
 
+    /// A slot index was provided that does not exist.
     #[error("No such slot index ({0}")]
     NoSuchSlotIndex(usize),
 }
 
 /// An identity based on an HSM
+#[derive(Debug)]
 pub struct HardwareIdentity {
     key_id: KeyIdVec,
     ctx: Ctx,

--- a/ic-identity-hsm/src/lib.rs
+++ b/ic-identity-hsm/src/lib.rs
@@ -1,2 +1,30 @@
+//! A crate to manage identities related to HSM (Hardware Security Module),
+//! allowing users to sign Internet Computer messages with their hardware key.
+//! Also supports SoftHSM.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use ic_agent::agent::{Agent, http_transport::ReqwestHttpReplicaV2Transport};
+//! use ic_identity_hsm::HardwareIdentity;
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let replica_url = "";
+//! # let lib_path = "";
+//! # let slot_index = 0;
+//! # let key_id = "";
+//! let agent = Agent::builder()
+//!     .with_transport(ReqwestHttpReplicaV2Transport::create(replica_url))
+//!     .with_identity(HardwareIdentity::new(lib_path, slot_index, key_id, || Ok("hunter2".to_string()))?)
+//!     .build();
+//! # Ok(())
+//! # }
+
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links
+)]
+
 pub(crate) mod hsm;
 pub use hsm::{HardwareIdentity, HardwareIdentityError};

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -3,22 +3,27 @@ use candid::{parser::value::IDLValue, ser::IDLBuilder, utils::ArgumentDecoder, C
 use garcon::Waiter;
 use ic_agent::{ic_types::Principal, Agent, AgentError, RequestId};
 use std::convert::TryInto;
+use std::fmt;
 use thiserror::Error;
 
 /// An error happened while building a canister.
 #[derive(Debug, Error)]
 pub enum CanisterBuilderError {
+    /// There was an error parsing the canister ID.
     #[error("Getting the Canister ID returned an error: {0}")]
     PrincipalError(#[from] Box<dyn std::error::Error + std::marker::Send + std::marker::Sync>),
 
+    /// The agent was not provided.
     #[error("Must specify an Agent")]
     MustSpecifyAnAgent(),
 
+    /// The canister ID was not provided.
     #[error("Must specify a Canister ID")]
     MustSpecifyCanisterId(),
 }
 
 /// A canister builder, which can be used to create a canister abstraction.
+#[derive(Debug)]
 pub struct CanisterBuilder<'agent, T = ()> {
     agent: Option<&'agent Agent>,
     canister_id: Option<Result<Principal, CanisterBuilderError>>,
@@ -102,6 +107,7 @@ impl<'agent> CanisterBuilder<'agent, ()> {
 ///
 /// This is the higher level construct for talking to a canister on the Internet
 /// Computer.
+#[derive(Debug)]
 pub struct Canister<'agent, T = ()> {
     pub(super) agent: &'agent Agent,
     pub(super) canister_id: Principal,
@@ -153,6 +159,7 @@ impl<'agent, T> Canister<'agent, T>
 where
     T: Clone,
 {
+    /// Creates a copy of this canister, changing the canister ID to the provided principal.
     pub fn clone_with_(&self, id: Principal) -> Self {
         Self {
             agent: self.agent,
@@ -180,6 +187,17 @@ enum ArgumentType {
     Idl(IDLBuilder),
 }
 
+impl fmt::Debug for ArgumentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Raw(v) => f.debug_tuple("ArgumentType::Raw").field(v).finish(),
+            Self::Idl(_) => f.debug_struct("ArgumentType::Idl").finish_non_exhaustive(),
+        }
+    }
+}
+
+/// A builder for a canister argument, allowing you to append elements to [`ArgumentType`] with chaining syntax.
+#[derive(Debug)]
 pub struct Argument(Result<ArgumentType, AgentError>);
 
 impl Argument {
@@ -229,6 +247,7 @@ impl Argument {
         }
     }
 
+    /// Encodes the completed argument into an IDL blob.
     pub fn serialize(self) -> Result<Vec<u8>, AgentError> {
         match self.0 {
             Ok(ArgumentType::Idl(mut idl_builder)) => idl_builder
@@ -239,6 +258,7 @@ impl Argument {
         }
     }
 
+    /// Resets the argument to an empty builder.
     pub fn reset(&mut self) {
         *self = Default::default();
     }
@@ -253,6 +273,7 @@ impl Default for Argument {
 /// A builder for a synchronous call (ie. query) to the Internet Computer.
 ///
 /// See [SyncCaller] for a description of this structure once built.
+#[derive(Debug)]
 pub struct SyncCallBuilder<'agent, 'canister: 'agent, T> {
     canister: &'canister Canister<'agent, T>,
     method_name: String,
@@ -307,6 +328,7 @@ impl<'agent, 'canister: 'agent, Interface> SyncCallBuilder<'agent, 'canister, In
         self
     }
 
+    /// Sets the [effective canister ID](https://smartcontracts.org/docs/interface-spec/index.html#http-effective-canister-id) of the destination.
     pub fn with_effective_canister_id(
         mut self,
         canister_id: Principal,
@@ -336,6 +358,7 @@ impl<'agent, 'canister: 'agent, Interface> SyncCallBuilder<'agent, 'canister, In
 /// A builder for an asynchronous call (ie. update) to the Internet Computer.
 ///
 /// See [AsyncCaller] for a description of this structure.
+#[derive(Debug)]
 pub struct AsyncCallBuilder<'agent, 'canister: 'agent, T> {
     canister: &'canister Canister<'agent, T>,
     method_name: String,
@@ -379,6 +402,7 @@ impl<'agent, 'canister: 'agent, Interface> AsyncCallBuilder<'agent, 'canister, I
         self
     }
 
+    /// Sets the [effective canister ID](https://smartcontracts.org/docs/interface-spec/index.html#http-effective-canister-id) of the destination.
     pub fn with_effective_canister_id(
         mut self,
         canister_id: Principal,

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -1,25 +1,35 @@
+//! The canister interface for canisters that implement HTTP requests.
+
 use crate::{call::AsyncCall, call::SyncCall, canister::CanisterBuilder, Canister};
 use candid::{CandidType, Deserialize, Func, Nat};
 use ic_agent::{export::Principal, Agent};
 use serde_bytes::ByteBuf;
 use std::fmt::Debug;
 
+/// A canister that can serve a HTTP request.
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub struct HttpRequestCanister;
 
-#[derive(CandidType, Clone, Deserialize)]
+/// A key-value pair for a HTTP header.
+#[derive(Debug, CandidType, Clone, Deserialize)]
 pub struct HeaderField(pub String, pub String);
 
-#[derive(CandidType, Deserialize)]
+/// The important components of an HTTP request.
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct HttpRequest<'body> {
+    /// The HTTP method string.
     pub method: String,
+    /// The URL that was visited.
     pub url: String,
+    /// The request headers.
     pub headers: Vec<HeaderField>,
+    /// The request body.
     #[serde(with = "serde_bytes")]
     pub body: &'body [u8],
 }
 
-#[derive(CandidType, Deserialize)]
+/// A token for continuing a callback streaming strategy.
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct Token {
     key: String,
     content_encoding: String,
@@ -29,31 +39,45 @@ pub struct Token {
     sha256: Option<ByteBuf>,
 }
 
-#[derive(CandidType, Deserialize)]
+/// A callback-token pair for a callback streaming strategy.
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct CallbackStrategy {
+    /// The callback function to be called to continue the stream.
     pub callback: Func,
+    /// The token to pass to the function.
     pub token: Token,
 }
 
-#[derive(CandidType, Deserialize)]
+/// Possible strategies for a streaming response.
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub enum StreamingStrategy {
+    /// A callback-based streaming strategy, where a callback function is provided for continuing the stream.
     Callback(CallbackStrategy),
 }
 
-#[derive(CandidType, Deserialize)]
+/// A HTTP response.
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct HttpResponse {
+    /// The HTTP status code.
     pub status_code: u16,
+    /// The response header map.
     pub headers: Vec<HeaderField>,
     #[serde(with = "serde_bytes")]
+    /// The response body.
     pub body: Vec<u8>,
+    /// The strategy for streaming the rest of the data, if the full response is to be streamed.
     pub streaming_strategy: Option<StreamingStrategy>,
+    /// Whether the query call should be upgraded to an update call.
     pub upgrade: Option<bool>,
 }
 
-#[derive(CandidType, Deserialize)]
+/// The next chunk of a streaming HTTP response.
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct StreamingCallbackHttpResponse {
+    /// The body of the stream chunk.
     #[serde(with = "serde_bytes")]
     pub body: Vec<u8>,
+    /// The new stream continuation token.
     pub token: Option<Token>,
 }
 
@@ -79,6 +103,7 @@ impl HttpRequestCanister {
 }
 
 impl<'agent> Canister<'agent, HttpRequestCanister> {
+    /// Performs a HTTP request, receiving a HTTP response.
     pub fn http_request<'canister: 'agent, M: Into<String>, U: Into<String>, B: AsRef<[u8]>>(
         &'canister self,
         method: M,
@@ -96,6 +121,8 @@ impl<'agent> Canister<'agent, HttpRequestCanister> {
             .build()
     }
 
+    /// Performs a HTTP request over an update call. Unlike query calls, update calls must pass consensus
+    /// and therefore cannot be tampered with by a malicious node.
     pub fn http_request_update<
         'canister: 'agent,
         M: Into<String>,
@@ -118,6 +145,7 @@ impl<'agent> Canister<'agent, HttpRequestCanister> {
             .build()
     }
 
+    /// Retrieves the next chunk of a stream from a streaming callback, using the method from [`CallbackStrategy`].
     pub fn http_request_stream_callback<'canister: 'agent, M: Into<String>>(
         &'canister self,
         method: M,

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -1,3 +1,7 @@
+//! The canister interface for the IC management canister. See the [specification][spec] for full documentation of the interface.
+//!
+//! [spec]: https://smartcontracts.org/docs/interface-spec/index.html#ic-management-canister
+
 use crate::{call::AsyncCall, canister::CanisterBuilder, Canister};
 use candid::{CandidType, Deserialize, Nat};
 use ic_agent::{export::Principal, Agent};
@@ -8,23 +12,38 @@ pub mod attributes;
 pub mod builders;
 pub use builders::{CreateCanisterBuilder, InstallCodeBuilder, UpdateCanisterBuilder};
 
+/// The IC management canister.
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub struct ManagementCanister;
 
+/// All the known methods of the management canister.
 #[derive(AsRefStr, Debug, EnumString)]
 #[strum(serialize_all = "snake_case")]
 pub enum MgmtMethod {
+    // FIXME when rust-lang/rust#85960 is resolved, update these to links.
+    /// See `Canister::<ManagementCanister>::create_canister`.
     CreateCanister,
+    /// See `Canister::<ManagementCanister>::install_code`.
     InstallCode,
+    /// See `Canister::<ManagementCanister>::start_canister`.
     StartCanister,
+    /// See `Canister::<ManagementCanister>::stop_canister`.
     StopCanister,
+    /// See `Canister::<ManagementCanister>::canister_status`.
     CanisterStatus,
+    /// See `Canister::<ManagementCanister>::delete_canister`.
     DeleteCanister,
+    /// See `Canister::<ManagementCanister>::deposit_cycles`.
     DepositCycles,
+    /// See `Canister::<ManagementCanister>::raw_rand`.
     RawRand,
+    /// See `Canister::<ManagementCanister>::provisional_create_canister_with_cycles`.
     ProvisionalCreateCanisterWithCycles,
+    /// See `Canister::<ManagementCanister>::provisional_top_up_canister`.
     ProvisionalTopUpCanister,
+    /// See `Canister::<ManagementCanister>::uninstall_code`.
     UninstallCode,
+    /// See `Canister::<ManagementCanister>::update_settings`.
     UpdateSettings,
 }
 
@@ -55,18 +74,28 @@ impl ManagementCanister {
 /// the contoller of the canister, the canisters memory size, and its balance in cycles.
 #[derive(Clone, Debug, Deserialize, CandidType)]
 pub struct StatusCallResult {
+    /// The status of the canister.
     pub status: CanisterStatus,
+    /// The canister's settings.
     pub settings: DefiniteCanisterSettings,
+    /// The SHA-256 hash of the canister's installed code, if any.
     pub module_hash: Option<Vec<u8>>,
+    /// The total size, in bytes, of the memory the canister is using.
     pub memory_size: Nat,
+    /// The canister's cycle balance.
     pub cycles: Nat,
 }
 
+/// The concrete settings of a canister.
 #[derive(Clone, Debug, Deserialize, CandidType)]
 pub struct DefiniteCanisterSettings {
+    /// The set of canister controllers. Controllers can update the canister via the management canister.
     pub controllers: Vec<Principal>,
+    /// The allocation percentage (between 0 and 100 inclusive) for *guaranteed* compute capacity.
     pub compute_allocation: Nat,
+    /// The allocation, in bytes (up to 256 TiB) that the canister is allowed to use for storage.
     pub memory_allocation: Nat,
+    /// The IC will freeze a canister protectively if it will likely run out of cycles before this amount of time, in seconds (up to `u64::MAX`), has passed.
     pub freezing_threshold: Nat,
 }
 
@@ -80,10 +109,13 @@ impl std::fmt::Display for StatusCallResult {
 /// stopped.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, CandidType)]
 pub enum CanisterStatus {
+    /// The canister is currently running.
     #[serde(rename = "running")]
     Running,
+    /// The canister is in the process of stopping.
     #[serde(rename = "stopping")]
     Stopping,
+    /// The canister is stopped.
     #[serde(rename = "stopped")]
     Stopped,
 }

--- a/ic-utils/src/interfaces/management_canister/attributes.rs
+++ b/ic-utils/src/interfaces/management_canister/attributes.rs
@@ -1,11 +1,19 @@
+//! Checked wrappers around certain numeric values used in management calls.
+
 use thiserror::Error;
 
+/// An error encountered when attempting to construct a [`ComputeAllocation`].
 #[derive(Error, Debug)]
 pub enum ComputeAllocationError {
+    /// The provided value was not a percentage in the range [0, 100].
     #[error("Must be a percent between 0 and 100.")]
     MustBeAPercentage(),
 }
 
+/// A compute allocation for a canister, represented as a percentage between 0 and 100 inclusive.
+///
+/// This represents the percentage of a canister's maximum compute capacity that the IC should commit to guaranteeing for the canister.
+/// If 0, computation is provided on a best-effort basis.
 #[derive(Copy, Clone, Debug)]
 pub struct ComputeAllocation(u8);
 
@@ -40,12 +48,19 @@ try_from_compute_alloc_decl!(i16);
 try_from_compute_alloc_decl!(i32);
 try_from_compute_alloc_decl!(i64);
 
+/// An error encountered when attempting to construct a [`MemoryAllocation`].
 #[derive(Error, Debug)]
 pub enum MemoryAllocationError {
-    #[error("Memory allocation must be between 0 and 2^48 (i.e 256TB), inclusively. Got {0}.")]
+    /// The provided value was not in the range [0, 2^48] (i.e. 256 TiB).
+    #[error("Memory allocation must be between 0 and 2^48 (i.e 256TiB), inclusively. Got {0}.")]
     InvalidMemorySize(u64),
 }
 
+/// A memory allocation for a canister. Can be anywhere from 0 to 2^48 (i.e. 256 TiB) inclusive.
+///
+/// This represents the size, in bytes, that the IC guarantees to the canister and limits the canister to.
+/// If a canister attempts to exceed this value (and the value is nonzero), the attempt will fail. If 0,
+/// memory allocation is provided on a best-effort basis.
 #[derive(Copy, Clone, Debug)]
 pub struct MemoryAllocation(u64);
 
@@ -80,12 +95,20 @@ try_from_memory_alloc_decl!(i16);
 try_from_memory_alloc_decl!(i32);
 try_from_memory_alloc_decl!(i64);
 
+/// An error encountered when attempting to construct a [`FreezingThreshold`].
 #[derive(Error, Debug)]
 pub enum FreezingThresholdError {
+    /// The provided value was not in the range [0, 2^64-1].
     #[error("Freezing threshold must be between 0 and 2^64-1, inclusively. Got {0}.")]
     InvalidFreezingThreshold(u64),
 }
 
+/// A freezing threshold for a canister. Can be anywhere from 0 to 2^64-1 inclusive.
+///
+/// This represents the time, in seconds, of 'runway' the IC tries to guarantee the canister.
+/// If the canister's persistent costs, like storage, will likely lead it to run out of cycles within this amount of time,
+/// then the IC will 'freeze' the canister. Attempts to call its methods will be rejected unconditionally.
+/// The canister also cannot make any calls that push its cycle count into freezing threshold range.
 #[derive(Copy, Clone, Debug)]
 pub struct FreezingThreshold(u64);
 

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -1,3 +1,5 @@
+//! Builder interfaces for some method calls of the management canister.
+
 use crate::{
     call::AsyncCall, canister::Argument, interfaces::management_canister::MgmtMethod, Canister,
 };
@@ -10,14 +12,35 @@ use std::str::FromStr;
 pub use super::attributes::{ComputeAllocation, FreezingThreshold, MemoryAllocation};
 use std::convert::{From, TryInto};
 
-#[derive(CandidType, Deserialize)]
+/// The set of possible canister settings. Similar to [`DefiniteCanisterSettings`](super::DefiniteCanisterSettings),
+/// but all the fields are optional.
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct CanisterSettings {
+    /// The set of canister controllers. Controllers can update the canister via the management canister.
+    ///
+    /// If unspecified and a canister is being created with these settings, defaults to the caller.
     pub controllers: Option<Vec<Principal>>,
+    /// The allocation percentage (between 0 and 100 inclusive) for *guaranteed* compute capacity.
+    ///
+    /// The settings update will be rejected if the IC can't commit to allocating this much compupte capacity.
+    ///
+    /// If unspecified and a canister is being created with these settings, defaults to 0, i.e. best-effort.
     pub compute_allocation: Option<Nat>,
+    /// The allocation, in bytes (up to 256 TiB) that the canister is allowed to use for storage.
+    ///
+    /// The settings update will be rejected if the IC can't commit to allocating this much storage.
+    ///
+    /// If unspecified and a canister is being created with these settings, defaults to 0, i.e. best-effort.
     pub memory_allocation: Option<Nat>,
+
+    /// The IC will freeze a canister protectively if it will run out of cycles before this amount of time, in seconds (up to `u64::MAX`), has passed.
+    ///
+    /// If unspecified and a canister is being created with these settings, defaults to 2592000, i.e. ~30 days.
     pub freezing_threshold: Option<Nat>,
 }
 
+/// A builder for a `create_canister` call.
+#[derive(Debug)]
 pub struct CreateCanisterBuilder<'agent, 'canister: 'agent, T> {
     canister: &'canister Canister<'agent, T>,
     controllers: Option<Result<Vec<Principal>, AgentError>>,
@@ -266,22 +289,30 @@ impl<'agent, 'canister: 'agent, T: Sync> AsyncCall<(Principal,)>
 /// The install mode of the canister to install. If a canister is already installed,
 /// using [InstallMode::Install] will be an error. [InstallMode::Reinstall] overwrites
 /// the module, and [InstallMode::Upgrade] performs an Upgrade step.
-#[derive(Copy, Clone, CandidType, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, CandidType, Deserialize, Eq, PartialEq)]
 pub enum InstallMode {
+    /// Install the module into the empty canister.
     #[serde(rename = "install")]
     Install,
+    /// Overwrite the canister with this module.
     #[serde(rename = "reinstall")]
     Reinstall,
+    /// Upgrade the canister with this module.
     #[serde(rename = "upgrade")]
     Upgrade,
 }
 
-#[derive(CandidType, Deserialize)]
+/// A prepared call to `install_code`.
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct CanisterInstall {
+    /// The installation mode to install the module with.
     pub mode: InstallMode,
+    /// The ID of the canister to install the module into.
     pub canister_id: Principal,
+    /// The WebAssembly code blob to install.
     #[serde(with = "serde_bytes")]
     pub wasm_module: Vec<u8>,
+    /// The encoded argument to pass to the module's constructor.
     #[serde(with = "serde_bytes")]
     pub arg: Vec<u8>,
 }
@@ -299,6 +330,8 @@ impl FromStr for InstallMode {
     }
 }
 
+/// A builder for an `install_code` call.
+#[derive(Debug)]
 pub struct InstallCodeBuilder<'agent, 'canister: 'agent, T> {
     canister: &'canister Canister<'agent, T>,
     canister_id: Principal,
@@ -393,6 +426,8 @@ impl<'agent, 'canister: 'agent, T: Sync> AsyncCall<()>
     }
 }
 
+/// A builder for an `update_settings` call.
+#[derive(Debug)]
 pub struct UpdateCanisterBuilder<'agent, 'canister: 'agent, T> {
     canister: &'canister Canister<'agent, T>,
     canister_id: Principal,

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -1,3 +1,7 @@
+//! The canister interface for the [cycles wallet] canister.
+//!
+//! [cycles wallet]: https://github.com/dfinity/cycles-wallet
+
 use crate::{
     call::{AsyncCall, AsyncCaller, SyncCall},
     canister::{Argument, CanisterBuilder},
@@ -15,6 +19,8 @@ use ic_agent::{agent::UpdateBuilder, export::Principal, Agent, AgentError, Reque
 const REPLICA_ERROR_NO_SUCH_QUERY_METHOD: &str = "has no query method 'wallet_api_version'";
 const IC_REF_ERROR_NO_SUCH_QUERY_METHOD: &str = "query method does not exist";
 
+/// An interface for forwarding a canister method call through the wallet canister via `wallet_canister_call`.
+#[derive(Debug)]
 pub struct CallForwarder<'agent, 'canister: 'agent, Out>
 where
     Self: 'canister,
@@ -28,11 +34,17 @@ where
     phantom_out: std::marker::PhantomData<Out>,
 }
 
-#[derive(CandidType, Deserialize)]
+/// A canister's settings. Similar to the canister settings struct from [`management_canister`](super::management_canister),
+/// but the management canister may evolve to have more settings without the wallet canister evolving to recognize them.
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct CanisterSettingsV1 {
+    /// The set of canister controllers. Controllers can update the canister via the management canister.
     pub controller: Option<Principal>,
+    /// The allocation percentage (between 0 and 100 inclusive) for *guaranteed* compute capacity.
     pub compute_allocation: Option<Nat>,
+    /// The allocation, in bytes (up to 256 TiB) that the canister is allowed to use for storage.
     pub memory_allocation: Option<Nat>,
+    /// The IC will freeze a canister protectively if it will likely run out of cycles before this amount of time, in seconds (up to `u64::MAX`), has passed.
     pub freezing_threshold: Option<Nat>,
 }
 
@@ -57,6 +69,7 @@ where
         self
     }
 
+    /// Creates an [`AsyncCall`] implementation that, when called, will forward the specified canister call.
     pub fn build(self) -> Result<impl 'agent + AsyncCall<Out>, AgentError> {
         #[derive(CandidType, Deserialize)]
         struct In {
@@ -83,10 +96,12 @@ where
             }))
     }
 
+    /// Calls the forwarded canister call on the wallet canister. Equivalent to `.build().call()`.
     pub async fn call(self) -> Result<RequestId, AgentError> {
         self.build()?.call().await
     }
 
+    /// Calls the forwarded canister call on the wallet canister, and waits for the result. Equivalent to `.build().call_and_wait(waiter)`.
     pub async fn call_and_wait<W>(self, waiter: W) -> Result<Out, AgentError>
     where
         W: Waiter,
@@ -114,79 +129,124 @@ where
 
 /// A wallet canister interface, for the standard wallet provided by DFINITY.
 /// This interface implements most methods conveniently for the user.
+#[derive(Debug, Copy, Clone)]
 pub struct Wallet;
 
+/// The possible kinds of events that can be stored in an [`Event`].
 #[derive(CandidType, Debug, Deserialize)]
 pub enum EventKind {
+    /// Cycles were sent to a canister.
     CyclesSent {
+        /// The canister the cycles were sent to.
         to: Principal,
+        /// The number of cycles that were initially sent.
         amount: u64,
+        /// The number of cycles that were refunded by the canister.
         refund: u64,
     },
+    /// Cycles were received from a canister.
     CyclesReceived {
+        /// The canister that sent the cycles.
         from: Principal,
+        /// The number of cycles received.
         amount: u64,
     },
+    /// A known principal was added to the address book.
     AddressAdded {
+        /// The principal that was added.
         id: Principal,
+        /// The friendly name of the principal, if any.
         name: Option<String>,
+        /// The significance of this principal to the wallet.
         role: Role,
     },
+    /// A principal was removed from the address book.
     AddressRemoved {
+        /// The principal that was removed.
         id: Principal,
     },
+    /// A canister was created.
     CanisterCreated {
+        /// The canister that was created.
         canister: Principal,
+        /// The initial cycles balance that the canister was created with.
         cycles: u64,
     },
+    /// A call was forwarded to the canister.
     CanisterCalled {
+        /// The canister that was called.
         canister: Principal,
+        /// The name of the canister method that was called.
         method_name: String,
+        /// The number of cycles that were supplied with the call.
         cycles: u64,
     },
 }
 
+/// A transaction event tracked by the wallet's history feature.
 #[derive(CandidType, Debug, Deserialize)]
 pub struct Event {
+    /// An ID uniquely identifying this event.
     pub id: u32,
+    /// The Unix timestamp that this event occurred at.
     pub timestamp: u64,
+    /// The kind of event that occurred.
     pub kind: EventKind,
 }
 
+/// The significance of a principal in the wallet's address book.
 #[derive(CandidType, Debug, Deserialize)]
 pub enum Role {
+    /// The principal has no particular significance, and is only there to be assigned a friendly name or be mentioned in the event log.
     Contact,
+    /// The principal is a custodian of the wallet, and can therefore access the wallet, create canisters, and send and receive cycles.
     Custodian,
+    /// The principal is a controller of the wallet, and can therefore access any wallet function or action.
     Controller,
 }
 
+/// The kind of principal that a particular principal is.
 #[derive(CandidType, Debug, Deserialize)]
 pub enum Kind {
+    /// The kind of principal is unknown, such as the anonymous principal `2vxsx-fae`.
     Unknown,
+    /// The principal belongs to an external user.
     User,
+    /// The principal belongs to an IC canister.
     Canister,
 }
 
+/// An entry in the address book.
 #[derive(CandidType, Debug, Deserialize)]
 pub struct AddressEntry {
+    /// The principal being identified.
     pub id: Principal,
+    /// The friendly name for this principal, if one exists.
     pub name: Option<String>,
+    /// The kind of principal it is.
     pub kind: Kind,
+    /// The significance of this principal to the wallet canister.
     pub role: Role,
 }
 
-#[derive(CandidType, Deserialize)]
+/// The result of a balance request.
+#[derive(Debug, Copy, Clone, CandidType, Deserialize)]
 pub struct BalanceResult {
+    /// The balance of the wallet, in cycles.
     pub amount: u64,
 }
 
-#[derive(CandidType, Deserialize)]
+/// The result of a canister creation request.
+#[derive(Debug, Copy, Clone, CandidType, Deserialize)]
 pub struct CreateResult {
+    /// The principal ID of the newly created (empty) canister.
     pub canister_id: Principal,
 }
 
-#[derive(CandidType, Deserialize)]
+/// The result of a call forwarding request.
+#[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct CallResult {
+    /// The encoded return value blob of the canister method.
     #[serde(with = "serde_bytes")]
     pub r#return: Vec<u8>,
 }
@@ -211,16 +271,19 @@ impl Wallet {
 }
 
 impl<'agent> Canister<'agent, Wallet> {
+    /// Get the API version string of the wallet.
     pub fn wallet_api_version<'canister: 'agent>(
         &'canister self,
     ) -> impl 'agent + SyncCall<(Option<String>,)> {
         self.query_("wallet_api_version").build()
     }
 
+    /// Get the friendly name of the wallet (if one exists).
     pub fn name<'canister: 'agent>(&'canister self) -> impl 'agent + SyncCall<(Option<String>,)> {
         self.query_("name").build()
     }
 
+    /// Set the friendly name of the wallet.
     pub fn set_name<'canister: 'agent>(
         &'canister self,
         name: String,
@@ -243,6 +306,7 @@ impl<'agent> Canister<'agent, Wallet> {
         self.update_("add_controller").with_arg(principal).build()
     }
 
+    /// Remove a user as a wallet controller.
     pub fn remove_controller<'canister: 'agent>(
         &'canister self,
         principal: Principal,
@@ -552,6 +616,7 @@ impl<'agent> Canister<'agent, Wallet> {
             .build()
     }
 
+    /// Add a principal to the address book.
     pub fn add_address<'canister: 'agent>(
         &'canister self,
         address: AddressEntry,
@@ -559,12 +624,14 @@ impl<'agent> Canister<'agent, Wallet> {
         self.update_("add_address").with_arg(address).build()
     }
 
+    /// List the entries in the address book.
     pub fn list_addresses<'canister: 'agent>(
         &'canister self,
     ) -> impl 'agent + SyncCall<(Vec<AddressEntry>,)> {
         self.query_("list_addresses").build()
     }
 
+    /// Remove a principal from the address book.
     pub fn remove_address<'canister: 'agent>(
         &'canister self,
         principal: Principal,
@@ -572,6 +639,7 @@ impl<'agent> Canister<'agent, Wallet> {
         self.update_("remove_address").with_arg(principal).build()
     }
 
+    /// Get a list of all transaction events this wallet remembers.
     pub fn get_events<'canister: 'agent>(
         &'canister self,
         from: Option<u32>,

--- a/ic-utils/src/lib.rs
+++ b/ic-utils/src/lib.rs
@@ -1,9 +1,18 @@
 //! ic-utils is a collection of utilities to help build clients and canisters running
 //! on the Internet Computer. It is meant as a higher level tool.
 
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links
+)]
+
 /// Utilities to encapsulate calls to a canister.
 pub mod call;
+/// A higher-level canister type for managing various aspects of a canister.
 pub mod canister;
+/// A few known canister types for use with [`Canister`](canister::Canister).
 pub mod interfaces;
 
 pub use canister::{Argument, Canister};


### PR DESCRIPTION
This adds `#[deny(missing_docs, missing_debug_implemenations)]`, which makes it a compile error to release public interface without documentation or to release a public data type without a Debug impl. It also fills all the existing holes in that regard.