### PR TITLE
chore: update ic-hs to a version that builds from source

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - build: linux-stable
             ghc: '8.8.4'
-            spec: '0.18.0'
+            spec: 'f771c6b3e7cdde413d3b960f63165c6ecf3e0b7c'
             os: ubuntu-latest
             rust: 1.55.0
 

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -14,7 +14,7 @@ jobs:
         build: [ linux-stable ]
         include:
           - build: linux-stable
-            ghc: '8.8.4'
+            ghc: '8.10.7'
             spec: 'f771c6b3e7cdde413d3b960f63165c6ecf3e0b7c'
             os: ubuntu-latest
             rust: 1.55.0

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -20,6 +20,9 @@ jobs:
             rust: 1.55.0
 
     steps:
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: ${{ matrix.ghc }}
       - uses: actions/checkout@v2
         with:
           path: main

--- a/ic-identity-hsm/src/lib.rs
+++ b/ic-identity-hsm/src/lib.rs
@@ -13,7 +13,7 @@
 //! # let slot_index = 0;
 //! # let key_id = "";
 //! let agent = Agent::builder()
-//!     .with_transport(ReqwestHttpReplicaV2Transport::create(replica_url))
+//!     .with_transport(ReqwestHttpReplicaV2Transport::create(replica_url)?)
 //!     .with_identity(HardwareIdentity::new(lib_path, slot_index, key_id, || Ok("hunter2".to_string()))?)
 //!     .build();
 //! # Ok(())

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -594,7 +594,7 @@ mod management_canister {
     #[test]
     fn provisional_create_canister_with_cycles() {
         with_wallet_canister(None, |agent, wallet_id| async move {
-            let max_canister_balance: u64 = 1152921504606846976;
+            let default_canister_balance: u128 = 100_000_000_000_000;
 
             // empty cycle balance on create
             let wallet = Wallet::create(&agent, wallet_id);
@@ -643,7 +643,7 @@ mod management_canister {
             assert_eq!(result.cycles, 0_u64);
 
             let ic00 = ManagementCanister::create(&agent);
-            // cycle balance is max_canister_balance when creating with
+            // cycle balance is default_canister_balance when creating with
             // provisional_create_canister_with_cycles(None)
             let (canister_id_1,) = ic00
                 .create_canister()
@@ -654,7 +654,7 @@ mod management_canister {
                 .canister_status(&canister_id_1)
                 .call_and_wait(create_waiter())
                 .await?;
-            assert_eq!(result.0.cycles, max_canister_balance);
+            assert_eq!(result.0.cycles, default_canister_balance);
 
             // cycle balance should be amount specified to
             // provisional_create_canister_with_cycles call


### PR DESCRIPTION
The ic-hs version used in the ic-ref integration test does not build without using cached artefacts, which is not replicable locally. With this update, it's possible to run ref-tests locally again.

Per [EXC-738](https://dfinity.atlassian.net/browse/EXC-783) there is no upper limit for cycles balances anymore, so the corresponding test has been adjusted.