### PR TITLE
fix: Remove the erroneous exit

### DIFF
--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -496,7 +496,6 @@ async fn main() -> Result<()> {
                     _ => unreachable!(),
                 }
             }
-            exit(1)
         }
         SubCommand::Status => {
             let status = agent


### PR DESCRIPTION
Think this `exit(1)` didn't achieve what it was supposed to do (#229), it is better to remove it.