### PR TITLE
feat: add ic-wasm to perform Wasm transformations for canister

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-wasm"
+version = "0.1.0"
+dependencies = [
+ "walrus",
+]
+
+[[package]]
 name = "icx"
 version = "0.14.0"
 dependencies = [
@@ -976,6 +983,22 @@ dependencies = [
  "serde_cbor",
  "sha2 0.10.1",
 ]
+
+[[package]]
+name = "icx-wasm"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ic-wasm",
+ "walrus",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "idna"
@@ -2438,6 +2461,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "walrus"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb08e48cde54c05f363d984bb54ce374f49e242def9468d2e1b6c2372d291f8"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "leb128",
+ "log",
+ "walrus-macro",
+ "wasmparser",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,6 +2567,12 @@ name = "wasm-bindgen-shared"
 version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "wasmparser"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,9 @@ members = [
     "icx-cert",
     "ic-identity-hsm",
     "ic-utils",
+    "ic-wasm",
     "icx",
     "icx-asset",
+    "icx-wasm",
     "ref-tests"
 ]

--- a/ic-wasm/Cargo.toml
+++ b/ic-wasm/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ic-wasm"
+version = "0.1.0"
+
+[dependencies]
+walrus = "0.19.0"

--- a/ic-wasm/README.md
+++ b/ic-wasm/README.md
@@ -1,0 +1,1 @@
+`ic-wasm` is a library to perform Wasm transformations for canisters running on the Internet Computer.

--- a/ic-wasm/src/lib.rs
+++ b/ic-wasm/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod metadata;

--- a/ic-wasm/src/metadata.rs
+++ b/ic-wasm/src/metadata.rs
@@ -1,0 +1,37 @@
+pub enum Kind {
+    Public,
+    Private,
+}
+
+/// Add or overwrite a metadata section
+pub fn add_metadata(m: &mut walrus::Module, visibility: Kind, name: &str, data: Vec<u8>) {
+    let name = match visibility {
+        Kind::Public => "icp:public ".to_owned(),
+        Kind::Private => "icp:private ".to_owned(),
+    } + name;
+    drop(m.customs.remove_raw(&name));
+    let custom_section = walrus::RawCustomSection { name, data };
+    m.customs.add(custom_section);
+}
+
+/// List current metadata sections
+pub fn list_metadata(m: &walrus::Module) -> Vec<&str> {
+    m.customs
+        .iter()
+        .map(|section| section.1.name())
+        .filter(|name| name.starts_with("icp:"))
+        .collect()
+}
+
+/// Get the content of metadata
+pub fn get_metadata<'a>(
+    m: &'a walrus::Module,
+    name: &'a str,
+) -> Option<std::borrow::Cow<'a, [u8]>> {
+    let public = "icp:public ".to_owned() + name;
+    let private = "icp:private ".to_owned() + name;
+    m.customs
+        .iter()
+        .find(|(_, section)| section.name() == public || section.name() == private)
+        .map(|(_, section)| section.data(&walrus::IdsToIndices::default()))
+}

--- a/icx-wasm/Cargo.toml
+++ b/icx-wasm/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "icx-wasm"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.34"
+clap = { version = "3.0.14", features = ["derive", "cargo"] }
+ic-wasm = { path = "../ic-wasm" }
+walrus = "0.19.0"

--- a/icx-wasm/README.md
+++ b/icx-wasm/README.md
@@ -1,0 +1,19 @@
+# `icx-wasm`
+A command line tool to transform Wasm modules running on the Internet Computer.
+
+## Metadata
+
+Usage: `icx-wasm <input.wasm> [-o output.wasm] metadata [name] [-d <text content> | -f <file content>] [-v <public|private>]`
+
+Example:
+
+```
+// List current metadata sections
+$ icx-wasm input.wasm metadata
+// List a specific metadata content
+$ icx-wasm input.wasm metadata candid:service
+// Add/overwrite a private metadata section
+$ icx-wasm input.wasm -o output.wasm metadata new_section -d "hello, world"
+// Add/overwrite a public metadata section from file
+$ icx-wasm input.wasm -o output.wasm metadata candid:service -f service.did -v public
+```

--- a/icx-wasm/src/main.rs
+++ b/icx-wasm/src/main.rs
@@ -1,0 +1,85 @@
+use clap::{crate_authors, crate_version, AppSettings, Parser};
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[clap(
+version = crate_version!(),
+author = crate_authors!(),
+global_setting = AppSettings::PropagateVersion,
+)]
+struct Opts {
+    /// Input Wasm file.
+    input: PathBuf,
+
+    /// Write the transformed Wasm file if provided.
+    #[clap(short, long)]
+    output: Option<PathBuf>,
+
+    #[clap(subcommand)]
+    subcommand: SubCommand,
+}
+
+#[derive(Parser)]
+enum SubCommand {
+    /// Canister metadata
+    Metadata {
+        /// Name of metadata. If not provided, list the current metadata sections.
+        name: Option<String>,
+        /// Content of metadata as a string
+        #[clap(short, long, requires("name"))]
+        data: Option<String>,
+        /// Content of metadata from a file
+        #[clap(short, long, requires("name"), conflicts_with("data"))]
+        file: Option<PathBuf>,
+        /// Visibility of metadata
+        #[clap(short, long, possible_values = &["public", "private"], default_value = "private")]
+        visibility: String,
+    },
+}
+
+fn main() -> anyhow::Result<()> {
+    let opts: Opts = Opts::parse();
+    let mut m = walrus::Module::from_file(opts.input)?;
+    match &opts.subcommand {
+        SubCommand::Metadata {
+            name,
+            data,
+            file,
+            visibility,
+        } => {
+            use ic_wasm::metadata::*;
+            if let Some(name) = name {
+                let visibility = match visibility.as_str() {
+                    "public" => Kind::Public,
+                    "private" => Kind::Private,
+                    _ => unreachable!(),
+                };
+                let data = match (data, file) {
+                    (Some(data), None) => data.as_bytes().to_vec(),
+                    (None, Some(path)) => std::fs::read(&path)?,
+                    (None, None) => {
+                        let data = get_metadata(&m, name);
+                        if let Some(data) = data {
+                            println!("{}", String::from_utf8_lossy(&data));
+                        } else {
+                            println!("Cannot find metadata {}", name);
+                        }
+                        return Ok(());
+                    }
+                    (_, _) => unreachable!(),
+                };
+                add_metadata(&mut m, visibility, name, data.to_vec());
+            } else {
+                let names = list_metadata(&m);
+                for name in names.iter() {
+                    println!("{}", name);
+                }
+                return Ok(());
+            }
+        }
+    }
+    if let Some(output) = opts.output {
+        m.emit_wasm_file(output)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
Part of https://dfinity.atlassian.net/browse/IC-1147

The library can be used to manage canister metadata. It can be called by dfx or as a standalone CLI tool. 

In the future, this library will also support other Wasm related features, such as canister profiling, code size reduction and inspection of IC system API.