### PR TITLE
feat: Update wallet interface for 128-bit API

### DIFF
--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -21,7 +21,7 @@ const IC_REF_ERROR_NO_SUCH_QUERY_METHOD: &str = "query method does not exist";
 
 /// An interface for forwarding a canister method call through the wallet canister via `wallet_canister_call`.
 #[derive(Debug)]
-pub struct CallForwarder<'agent, 'canister: 'agent, Out>
+pub struct CallForwarder<'agent, 'canister: 'agent, Out, TCycles = u128>
 where
     Self: 'canister,
     Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
@@ -29,7 +29,7 @@ where
     wallet: &'canister Canister<'agent, Wallet>,
     destination: Principal,
     method_name: String,
-    amount: u64,
+    amount: TCycles,
     arg: Argument,
     phantom_out: std::marker::PhantomData<Out>,
 }
@@ -48,9 +48,31 @@ pub struct CanisterSettingsV1 {
     pub freezing_threshold: Option<Nat>,
 }
 
-impl<'agent, 'canister: 'agent, Out> CallForwarder<'agent, 'canister, Out>
+/// Types that can be used as cycle counts. The IC supports a 128-bit cycle size, but older wallets only have a 64-bit interface.
+pub trait CycleCount: CandidType + Send + Sync + Sealed {
+    #[doc(hidden)]
+    const CALL_FUNC: &'static str;
+}
+
+impl CycleCount for u64 {
+    const CALL_FUNC: &'static str = "wallet_call";
+}
+
+impl CycleCount for u128 {
+    const CALL_FUNC: &'static str = "wallet_call128";
+}
+
+use private::Sealed;
+mod private {
+    pub trait Sealed {}
+    impl Sealed for u64 {}
+    impl Sealed for u128 {}
+}
+
+impl<'agent, 'canister: 'agent, Out, TCycles> CallForwarder<'agent, 'canister, Out, TCycles>
 where
     Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
+    TCycles: CycleCount,
 {
     /// Add an argument to the candid argument list. This requires Candid arguments, if
     /// there is a raw argument set (using [with_arg_raw]), this will fail.
@@ -72,16 +94,16 @@ where
     /// Creates an [`AsyncCall`] implementation that, when called, will forward the specified canister call.
     pub fn build(self) -> Result<impl 'agent + AsyncCall<Out>, AgentError> {
         #[derive(CandidType, Deserialize)]
-        struct In {
+        struct In<TCycles> {
             canister: Principal,
             method_name: String,
             #[serde(with = "serde_bytes")]
             args: Vec<u8>,
-            cycles: u64,
+            cycles: TCycles,
         }
         Ok(self
             .wallet
-            .update_("wallet_call")
+            .update_(TCycles::CALL_FUNC)
             .with_arg(In {
                 canister: self.destination,
                 method_name: self.method_name,
@@ -134,22 +156,24 @@ pub struct Wallet;
 
 /// The possible kinds of events that can be stored in an [`Event`].
 #[derive(CandidType, Debug, Deserialize)]
-pub enum EventKind {
+pub enum EventKind<TCycles = u128> {
     /// Cycles were sent to a canister.
     CyclesSent {
         /// The canister the cycles were sent to.
         to: Principal,
         /// The number of cycles that were initially sent.
-        amount: u64,
+        amount: TCycles,
         /// The number of cycles that were refunded by the canister.
-        refund: u64,
+        refund: TCycles,
     },
     /// Cycles were received from a canister.
     CyclesReceived {
         /// The canister that sent the cycles.
         from: Principal,
         /// The number of cycles received.
-        amount: u64,
+        amount: TCycles,
+        /// The memo provided with the payment.
+        memo: Option<String>,
     },
     /// A known principal was added to the address book.
     AddressAdded {
@@ -170,7 +194,7 @@ pub enum EventKind {
         /// The canister that was created.
         canister: Principal,
         /// The initial cycles balance that the canister was created with.
-        cycles: u64,
+        cycles: TCycles,
     },
     /// A call was forwarded to the canister.
     CanisterCalled {
@@ -179,19 +203,19 @@ pub enum EventKind {
         /// The name of the canister method that was called.
         method_name: String,
         /// The number of cycles that were supplied with the call.
-        cycles: u64,
+        cycles: TCycles,
     },
 }
 
 /// A transaction event tracked by the wallet's history feature.
 #[derive(CandidType, Debug, Deserialize)]
-pub struct Event {
+pub struct Event<TCycles = u128> {
     /// An ID uniquely identifying this event.
     pub id: u32,
     /// The Unix timestamp that this event occurred at.
     pub timestamp: u64,
     /// The kind of event that occurred.
-    pub kind: EventKind,
+    pub kind: EventKind<TCycles>,
 }
 
 /// The significance of a principal in the wallet's address book.
@@ -229,11 +253,57 @@ pub struct AddressEntry {
     pub role: Role,
 }
 
+/// A canister that the wallet is responsible for managing.
+#[derive(CandidType, Debug, Deserialize)]
+pub struct ManagedCanisterInfo {
+    /// The principal ID of the canister.
+    pub id: Principal,
+    /// The friendly name of the canister, if one has been set.
+    pub name: Option<String>,
+    /// The Unix timestamp that the canister was created at.
+    pub created_at: u64,
+}
+
+/// The possible kinds of events that can be stored in a [`ManagedCanisterEvent`].
+#[derive(CandidType, Debug, Deserialize)]
+pub enum ManagedCanisterEventKind<TCycles = u128> {
+    /// Cycles were sent to the canister.
+    CyclesSent {
+        /// The number of cycles that were sent.
+        amount: TCycles,
+        /// The number of cycles that were refunded.
+        refund: TCycles,
+    },
+    /// A function call was forwarded to the canister.
+    Called {
+        /// The name of the function that was called.
+        method_name: String,
+        /// The number of cycles that were provided along with the call.
+        cycles: TCycles,
+    },
+    /// The canister was created.
+    Created {
+        /// The number of cycles the canister was created with.
+        cycles: TCycles,
+    },
+}
+
+/// A transaction event related to a [`ManagedCanisterInfo`].
+#[derive(CandidType, Deserialize, Debug)]
+pub struct ManagedCanisterEvent<TCycles = u128> {
+    /// The event ID.
+    pub id: u32,
+    /// The Unix timestamp the event occurred at.
+    pub timestamp: u64,
+    /// The kind of event that occurred.
+    pub kind: ManagedCanisterEventKind<TCycles>,
+}
+
 /// The result of a balance request.
 #[derive(Debug, Copy, Clone, CandidType, Deserialize)]
-pub struct BalanceResult {
+pub struct BalanceResult<TCycles = u128> {
     /// The balance of the wallet, in cycles.
-    pub amount: u64,
+    pub amount: TCycles,
 }
 
 /// The result of a canister creation request.
@@ -339,15 +409,22 @@ impl<'agent> Canister<'agent, Wallet> {
         self.update_("deauthorize").with_arg(custodian).build()
     }
 
+    /// Get the balance with the 64-bit API.
+    pub fn wallet_balance64<'canister: 'agent>(
+        &'canister self,
+    ) -> impl 'agent + SyncCall<(BalanceResult<u64>,)> {
+        self.query_("wallet_balance").build()
+    }
+
     /// Get the balance.
     pub fn wallet_balance<'canister: 'agent>(
         &'canister self,
     ) -> impl 'agent + SyncCall<(BalanceResult,)> {
-        self.query_("wallet_balance").build()
+        self.query_("wallet_balance128").build()
     }
 
-    /// Send cycles to another (hopefully Wallet) canister.
-    pub fn wallet_send<'canister: 'agent>(
+    /// Send cycles to another (hopefully Wallet) canister using the 64-bit API.
+    pub fn wallet_send64<'canister: 'agent>(
         &'canister self,
         destination: &'_ Canister<'agent, Wallet>,
         amount: u64,
@@ -367,12 +444,41 @@ impl<'agent> Canister<'agent, Wallet> {
     }
 
     /// Send cycles to another (hopefully Wallet) canister.
-    pub fn wallet_receive<'canister: 'agent>(&'canister self) -> impl 'agent + AsyncCall<((),)> {
-        self.update_("wallet_receive").build()
+    pub fn wallet_send<'canister: 'agent>(
+        &'canister self,
+        destination: &'_ Canister<'agent, Wallet>,
+        amount: u128,
+    ) -> impl 'agent + AsyncCall<(Result<(), String>,)> {
+        #[derive(CandidType)]
+        struct In {
+            canister: Principal,
+            amount: u128,
+        }
+
+        self.update_("wallet_send128")
+            .with_arg(In {
+                canister: *destination.canister_id_(),
+                amount,
+            })
+            .build()
     }
 
-    /// Wallet API version 0.1.0 only accepts a single controller
-    pub fn wallet_create_canister_v1<'canister: 'agent>(
+    /// Send cycles to another (hopefully Wallet) canister.
+    pub fn wallet_receive<'canister: 'agent>(
+        &'canister self,
+        memo: Option<String>,
+    ) -> impl 'agent + AsyncCall<((),)> {
+        #[derive(CandidType)]
+        struct In {
+            memo: Option<String>,
+        }
+        self.update_("wallet_receive")
+            .with_arg(memo.map(|memo| In { memo: Some(memo) }))
+            .build()
+    }
+
+    /// Wallet 64-bit API version 0.1.0 only accepts a single controller
+    pub fn wallet_create_canister64_v1<'canister: 'agent>(
         &'canister self,
         cycles: u64,
         controller: Option<Principal>,
@@ -399,8 +505,8 @@ impl<'agent> Canister<'agent, Wallet> {
             .map(|result: (Result<CreateResult, String>,)| (result.0,))
     }
 
-    /// Wallet API version >= 0.2.0 accepts multiple controllers
-    pub fn wallet_create_canister_v2<'canister: 'agent>(
+    /// Wallet 64-bit API version >= 0.2.0 accepts multiple controllers
+    pub fn wallet_create_canister64_v2<'canister: 'agent>(
         &'canister self,
         cycles: u64,
         controllers: Option<Vec<Principal>>,
@@ -427,9 +533,37 @@ impl<'agent> Canister<'agent, Wallet> {
             .map(|result: (Result<CreateResult, String>,)| (result.0,))
     }
 
-    /// Call wallet_create_canister_v1 or wallet_create_canister_v2, depending
+    /// Create a canister through the wallet.
+    pub fn wallet_create_canister<'canister: 'agent>(
+        &'canister self,
+        cycles: u128,
+        controllers: Option<Vec<Principal>>,
+        compute_allocation: Option<ComputeAllocation>,
+        memory_allocation: Option<MemoryAllocation>,
+        freezing_threshold: Option<FreezingThreshold>,
+    ) -> impl 'agent + AsyncCall<(Result<CreateResult, String>,)> {
+        #[derive(CandidType)]
+        struct In {
+            cycles: u128,
+            settings: CanisterSettings,
+        }
+
+        let settings = CanisterSettings {
+            controllers,
+            compute_allocation: compute_allocation.map(u8::from).map(Nat::from),
+            memory_allocation: memory_allocation.map(u64::from).map(Nat::from),
+            freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
+        };
+
+        self.update_("wallet_create_canister128")
+            .with_arg(In { cycles, settings })
+            .build()
+            .map(|result: (Result<CreateResult, String>,)| (result.0,))
+    }
+
+    /// Call wallet_create_canister64_v1 or wallet_create_canister64_v2, depending
     /// on the cycles wallet version.
-    pub async fn wallet_create_canister<'canister: 'agent>(
+    pub async fn wallet_create_canister64<'canister: 'agent>(
         &'canister self,
         cycles: u64,
         controllers: Option<Vec<Principal>>,
@@ -440,7 +574,7 @@ impl<'agent> Canister<'agent, Wallet> {
     ) -> Result<CreateResult, AgentError> {
         match self.wallet_api_version().call().await {
             Ok(_) => self
-                .wallet_create_canister_v2(
+                .wallet_create_canister64_v2(
                     cycles,
                     controllers,
                     compute_allocation,
@@ -469,7 +603,7 @@ impl<'agent> Canister<'agent, Wallet> {
                     )),
                     None => Ok(None),
                 }?;
-                self.wallet_create_canister_v1(
+                self.wallet_create_canister64_v1(
                     cycles,
                     controller,
                     compute_allocation,
@@ -485,8 +619,8 @@ impl<'agent> Canister<'agent, Wallet> {
         }
     }
 
-    /// Create a wallet canister
-    pub fn wallet_create_wallet_v1<'canister: 'agent>(
+    /// Create a wallet canister with the single-controller 64-bit API.
+    pub fn wallet_create_wallet64_v1<'canister: 'agent>(
         &'canister self,
         cycles: u64,
         controller: Option<Principal>,
@@ -513,8 +647,8 @@ impl<'agent> Canister<'agent, Wallet> {
             .map(|result: (Result<CreateResult, String>,)| (result.0,))
     }
 
-    /// Create a wallet canister
-    pub fn wallet_create_wallet_v2<'canister: 'agent>(
+    /// Create a wallet canister with the multi-controller 64-bit API.
+    pub fn wallet_create_wallet64_v2<'canister: 'agent>(
         &'canister self,
         cycles: u64,
         controllers: Option<Vec<Principal>>,
@@ -541,9 +675,37 @@ impl<'agent> Canister<'agent, Wallet> {
             .map(|result: (Result<CreateResult, String>,)| (result.0,))
     }
 
-    /// Call wallet_create_wallet_v1 or wallet_create_wallet_v2, depending
+    /// Create a wallet canister.
+    pub fn wallet_create_wallet<'canister: 'agent>(
+        &'canister self,
+        cycles: u128,
+        controllers: Option<Vec<Principal>>,
+        compute_allocation: Option<ComputeAllocation>,
+        memory_allocation: Option<MemoryAllocation>,
+        freezing_threshold: Option<FreezingThreshold>,
+    ) -> impl 'agent + AsyncCall<(Result<CreateResult, String>,)> {
+        #[derive(CandidType)]
+        struct In {
+            cycles: u128,
+            settings: CanisterSettings,
+        }
+
+        let settings = CanisterSettings {
+            controllers,
+            compute_allocation: compute_allocation.map(u8::from).map(Nat::from),
+            memory_allocation: memory_allocation.map(u64::from).map(Nat::from),
+            freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
+        };
+
+        self.update_("wallet_create_wallet128")
+            .with_arg(In { cycles, settings })
+            .build()
+            .map(|result: (Result<CreateResult, String>,)| (result.0,))
+    }
+
+    /// Call wallet_create_wallet64_v1 or wallet_create_wallet64_v2, depending
     /// on the cycles wallet version.
-    pub async fn wallet_create_wallet<'canister: 'agent>(
+    pub async fn wallet_create_wallet64<'canister: 'agent>(
         &'canister self,
         cycles: u64,
         controllers: Option<Vec<Principal>>,
@@ -554,7 +716,7 @@ impl<'agent> Canister<'agent, Wallet> {
     ) -> Result<CreateResult, AgentError> {
         match self.wallet_api_version().call().await {
             Ok(_) => self
-                .wallet_create_wallet_v2(
+                .wallet_create_wallet64_v2(
                     cycles,
                     controllers,
                     compute_allocation,
@@ -584,7 +746,7 @@ impl<'agent> Canister<'agent, Wallet> {
                     )),
                     None => Ok(None),
                 }?;
-                self.wallet_create_wallet_v1(
+                self.wallet_create_wallet64_v1(
                     cycles,
                     controller,
                     compute_allocation,
@@ -639,12 +801,12 @@ impl<'agent> Canister<'agent, Wallet> {
         self.update_("remove_address").with_arg(principal).build()
     }
 
-    /// Get a list of all transaction events this wallet remembers.
-    pub fn get_events<'canister: 'agent>(
+    /// Get a list of all transaction events this wallet remembers, using the 64-bit API. Fails if any events are 128-bit.
+    pub fn get_events64<'canister: 'agent>(
         &'canister self,
         from: Option<u32>,
         to: Option<u32>,
-    ) -> impl 'agent + SyncCall<(Vec<Event>,)> {
+    ) -> impl 'agent + SyncCall<(Vec<Event<u64>>,)> {
         #[derive(CandidType)]
         struct In {
             from: Option<u32>,
@@ -660,6 +822,47 @@ impl<'agent> Canister<'agent, Wallet> {
         self.query_("get_events").with_arg(arg).build()
     }
 
+    /// Get a list of all transaction events this wallet remembers.
+    pub fn get_events<'canister: 'agent>(
+        &'canister self,
+        from: Option<u32>,
+        to: Option<u32>,
+    ) -> impl 'agent + SyncCall<(Vec<Event>,)> {
+        #[derive(CandidType)]
+        struct In {
+            from: Option<u32>,
+            to: Option<u32>,
+        }
+        let arg = if from.is_none() && to.is_none() {
+            None
+        } else {
+            Some(In { from, to })
+        };
+        self.query_("get_events128").with_arg(arg).build()
+    }
+
+    /// Forward a call to another canister, including an amount of cycles
+    /// from the wallet, using the 64-bit API.
+    pub fn call64<'canister: 'agent, Out, M: Into<String>>(
+        &'canister self,
+        destination: &'canister Canister<'canister>,
+        method_name: M,
+        arg: Argument,
+        amount: u64,
+    ) -> CallForwarder<'agent, 'canister, Out, u64>
+    where
+        Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
+    {
+        CallForwarder {
+            wallet: self,
+            destination: *destination.canister_id_(),
+            method_name: method_name.into(),
+            amount,
+            arg,
+            phantom_out: std::marker::PhantomData,
+        }
+    }
+
     /// Forward a call to another canister, including an amount of cycles
     /// from the wallet.
     pub fn call<'canister: 'agent, Out, M: Into<String>>(
@@ -667,7 +870,7 @@ impl<'agent> Canister<'agent, Wallet> {
         destination: &'canister Canister<'canister>,
         method_name: M,
         arg: Argument,
-        amount: u64,
+        amount: u128,
     ) -> CallForwarder<'agent, 'canister, Out>
     where
         Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
@@ -684,8 +887,8 @@ impl<'agent> Canister<'agent, Wallet> {
 
     /// Forward a call using another call's builder. This takes an UpdateBuilder,
     /// marshalls it to a buffer, and sends it through the wallet canister, adding
-    /// a separate amount.
-    pub fn call_forward<'canister: 'agent, Out: 'agent>(
+    /// a separate amount, using the 64-bit API.
+    pub fn call_forward64<'canister: 'agent, Out: 'agent>(
         &'canister self,
         call: AsyncCaller<'agent, Out>,
         amount: u64,
@@ -711,5 +914,88 @@ impl<'agent> Canister<'agent, Wallet> {
             phantom_out: std::marker::PhantomData,
         }
         .build()
+    }
+
+    /// Forward a call using another call's builder. This takes an UpdateBuilder,
+    /// marshalls it to a buffer, and sends it through the wallet canister, adding
+    /// a separate amount.
+    pub fn call_forward<'canister: 'agent, Out: 'agent>(
+        &'canister self,
+        call: AsyncCaller<'agent, Out>,
+        amount: u128,
+    ) -> Result<impl 'agent + AsyncCall<Out>, AgentError>
+    where
+        Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
+    {
+        let UpdateBuilder {
+            canister_id,
+            method_name,
+            arg,
+            ..
+        } = call.build_call()?;
+        let mut argument = Argument::default();
+        argument.set_raw_arg(arg);
+
+        CallForwarder {
+            wallet: self,
+            destination: canister_id,
+            method_name,
+            amount,
+            arg: argument,
+            phantom_out: std::marker::PhantomData,
+        }
+        .build()
+    }
+
+    /// Gets the managed canisters the wallet knows about.
+    pub fn list_managed_canisters<'canister: 'agent>(
+        &'canister self,
+        from: Option<u32>,
+        to: Option<u32>,
+    ) -> impl 'agent + SyncCall<(Vec<ManagedCanisterInfo>, u32)> {
+        #[derive(CandidType)]
+        struct In {
+            from: Option<u32>,
+            to: Option<u32>,
+        }
+        self.query_("list_managed_canisters")
+            .with_arg((In { from, to },))
+            .build()
+    }
+
+    /// Gets the [`ManagedCanisterEvent`]s for a particular canister, if the wallet knows about that canister, using the 64-bit API.
+    pub fn get_managed_canister_events64<'canister: 'agent>(
+        &'canister self,
+        canister: Principal,
+        from: Option<u32>,
+        to: Option<u32>,
+    ) -> impl 'agent + SyncCall<(Option<Vec<ManagedCanisterEvent<u64>>>,)> {
+        #[derive(CandidType)]
+        struct In {
+            canister: Principal,
+            from: Option<u32>,
+            to: Option<u32>,
+        }
+        self.query_("get_managed_canister_events")
+            .with_arg((In { canister, from, to },))
+            .build()
+    }
+
+    /// Gets the [`ManagedCanisterEvent`]s for a particular canister, if the wallet knows about that canister.
+    pub fn get_managed_canister_events<'canister: 'agent>(
+        &'canister self,
+        canister: Principal,
+        from: Option<u32>,
+        to: Option<u32>,
+    ) -> impl 'agent + SyncCall<(Option<Vec<ManagedCanisterEvent>>,)> {
+        #[derive(CandidType)]
+        struct In {
+            canister: Principal,
+            from: Option<u32>,
+            to: Option<u32>,
+        }
+        self.query_("get_managed_canister_events128")
+            .with_arg((In { canister, from, to },))
+            .build()
     }
 }

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -622,7 +622,7 @@ mod management_canister {
             args.push_idl_arg(create_args);
 
             let (create_result,): (CreateResult,) = wallet
-                .call(&ic00, "create_canister", args, 0)
+                .call64(&ic00, "create_canister", args, 0)
                 .call_and_wait(create_waiter())
                 .await?;
             let canister_id = create_result.canister_id;
@@ -636,7 +636,7 @@ mod management_canister {
             args.push_idl_arg(status_args);
 
             let (result,): (StatusCallResult,) = wallet
-                .call(&ic00, "canister_status", args, 0)
+                .call64(&ic00, "canister_status", args, 0)
                 .call_and_wait(create_waiter())
                 .await?;
 
@@ -684,15 +684,15 @@ mod management_canister {
                 .with_canister_id(Principal::management_canister())
                 .build()?;
             let (rand_1,): (Vec<u8>,) = wallet
-                .call(&ic00, "raw_rand", Argument::default(), 0)
+                .call64(&ic00, "raw_rand", Argument::default(), 0)
                 .call_and_wait(create_waiter())
                 .await?;
             let (rand_2,): (Vec<u8>,) = wallet
-                .call(&ic00, "raw_rand", Argument::default(), 0)
+                .call64(&ic00, "raw_rand", Argument::default(), 0)
                 .call_and_wait(create_waiter())
                 .await?;
             let (rand_3,): (Vec<u8>,) = wallet
-                .call(&ic00, "raw_rand", Argument::default(), 0)
+                .call64(&ic00, "raw_rand", Argument::default(), 0)
                 .call_and_wait(create_waiter())
                 .await?;
 

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -319,10 +319,11 @@ fn wallet_create_wallet() {
             "Created child wallet two.\nChild wallet two canister id: {:?}",
             child_two_create_res.canister_id.to_text()
         );
-        let (child_wallet_two_balance,): (ic_utils::interfaces::wallet::BalanceResult<u64>,) = wallet
-            .call64(&child_wallet_two, "wallet_balance", Argument::default(), 0)
-            .call_and_wait(create_waiter())
-            .await?;
+        let (child_wallet_two_balance,): (ic_utils::interfaces::wallet::BalanceResult<u64>,) =
+            wallet
+                .call64(&child_wallet_two, "wallet_balance", Argument::default(), 0)
+                .call_and_wait(create_waiter())
+                .await?;
         eprintln!(
             "Child wallet two cycle balance: {}",
             child_wallet_two_balance.amount

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -130,7 +130,7 @@ fn wallet_canister_forward() {
             .build();
 
         let forward = wallet
-            .call_forward::<(String,)>(universal.update_("update").with_arg_raw(arg).build(), 0)?;
+            .call_forward64::<(String,)>(universal.update_("update").with_arg_raw(arg).build(), 0)?;
         let (result,) = forward.call_and_wait(create_waiter()).await.unwrap();
 
         assert_eq!(result, "Hello World");
@@ -175,7 +175,7 @@ fn wallet_canister_create_and_install() {
         args.push_idl_arg(install_config);
 
         wallet
-            .call(&ic00, "install_code", args, 0)
+            .call64(&ic00, "install_code", args, 0)
             .call_and_wait(create_waiter())
             .await?;
 
@@ -250,7 +250,7 @@ fn wallet_create_wallet() {
     with_wallet_canister(None, |agent, wallet_id| async move {
         eprintln!("Parent wallet canister id: {:?}", wallet_id.to_text());
         let wallet = Wallet::create(&agent, wallet_id);
-        let (wallet_initial_balance,) = wallet.wallet_balance().call().await?;
+        let (wallet_initial_balance,) = wallet.wallet_balance64().call().await?;
 
         // get the wallet wasm from the environment
         let wallet_wasm = get_wallet_wasm_from_env();
@@ -285,7 +285,7 @@ fn wallet_create_wallet() {
             .build()?;
 
         let (child_wallet_balance,): (ic_utils::interfaces::wallet::BalanceResult,) = wallet
-            .call(&child_wallet, "wallet_balance", Argument::default(), 0)
+            .call64(&child_wallet, "wallet_balance", Argument::default(), 0)
             .call_and_wait(create_waiter())
             .await?;
 
@@ -318,7 +318,7 @@ fn wallet_create_wallet() {
             child_two_create_res.canister_id.to_text()
         );
         let (child_wallet_two_balance,): (ic_utils::interfaces::wallet::BalanceResult,) = wallet
-            .call(&child_wallet_two, "wallet_balance", Argument::default(), 0)
+            .call64(&child_wallet_two, "wallet_balance", Argument::default(), 0)
             .call_and_wait(create_waiter())
             .await?;
         eprintln!(
@@ -329,7 +329,7 @@ fn wallet_create_wallet() {
         //
         // Get wallet intermediate balance
         //
-        let (wallet_intermediate_balance,) = wallet.wallet_balance().call().await?;
+        let (wallet_intermediate_balance,) = wallet.wallet_balance64().call().await?;
         eprintln!(
             "Parent wallet initial balance: {}\n      intermediate balance:  {}",
             wallet_initial_balance.amount, wallet_intermediate_balance.amount
@@ -357,7 +357,7 @@ fn wallet_create_wallet() {
 
         let (grandchild_create_res,): (Result<ic_utils::interfaces::wallet::CreateResult, String>,) =
             wallet
-                .call(&child_wallet_two, "wallet_create_wallet", args, 0)
+                .call64(&child_wallet_two, "wallet_create_wallet", args, 0)
                 .call_and_wait(create_waiter())
                 .await?;
         let grandchild_create_res = grandchild_create_res?;
@@ -367,7 +367,7 @@ fn wallet_create_wallet() {
             grandchild_create_res.canister_id.to_text()
         );
 
-        let (wallet_final_balance,) = wallet.wallet_balance().call().await?;
+        let (wallet_final_balance,) = wallet.wallet_balance64().call().await?;
         eprintln!(
             "Parent wallet initial balance: {}\n      final balance:  {}",
             wallet_initial_balance.amount, wallet_final_balance.amount
@@ -388,18 +388,18 @@ fn wallet_canister_funds() {
             create_wallet_canister(&agent, Some(provisional_amount)).await?,
         );
 
-        let (alice_previous_balance,) = alice.wallet_balance().call().await?;
-        let (bob_previous_balance,) = bob.wallet_balance().call().await?;
+        let (alice_previous_balance,) = alice.wallet_balance64().call().await?;
+        let (bob_previous_balance,) = bob.wallet_balance64().call().await?;
 
         alice
-            .wallet_send(&bob, 1_000_000)
+            .wallet_send64(&bob, 1_000_000)
             .call_and_wait(create_waiter())
             .await?
             .0?;
 
-        let (bob_balance,) = bob.wallet_balance().call().await?;
+        let (bob_balance,) = bob.wallet_balance64().call().await?;
 
-        let (alice_balance,) = alice.wallet_balance().call().await?;
+        let (alice_balance,) = alice.wallet_balance64().call().await?;
         eprintln!(
             "Alice previous: {}\n      current:  {}",
             alice_previous_balance.amount, alice_balance.amount

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -94,7 +94,7 @@ fn canister_reject_call() {
         let bob = Wallet::create(&agent, create_wallet_canister(&agent, None).await?);
 
         let result = alice
-            .wallet_send(&bob, 1_000_000)
+            .wallet_send64(&bob, 1_000_000)
             .call_and_wait(create_waiter())
             .await;
 
@@ -286,7 +286,7 @@ fn wallet_create_wallet() {
             .with_canister_id(child_create_res.canister_id)
             .build()?;
 
-        let (child_wallet_balance,): (ic_utils::interfaces::wallet::BalanceResult,) = wallet
+        let (child_wallet_balance,): (ic_utils::interfaces::wallet::BalanceResult<u64>,) = wallet
             .call64(&child_wallet, "wallet_balance", Argument::default(), 0)
             .call_and_wait(create_waiter())
             .await?;
@@ -319,7 +319,7 @@ fn wallet_create_wallet() {
             "Created child wallet two.\nChild wallet two canister id: {:?}",
             child_two_create_res.canister_id.to_text()
         );
-        let (child_wallet_two_balance,): (ic_utils::interfaces::wallet::BalanceResult,) = wallet
+        let (child_wallet_two_balance,): (ic_utils::interfaces::wallet::BalanceResult<u64>,) = wallet
             .call64(&child_wallet_two, "wallet_balance", Argument::default(), 0)
             .call_and_wait(create_waiter())
             .await?;

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -145,7 +145,7 @@ fn wallet_canister_create_and_install() {
         let wallet = Wallet::create(&agent, wallet_id);
 
         let (create_result,) = wallet
-            .wallet_create_canister_v2(1_000_000, None, None, None, None)
+            .wallet_create_canister64_v2(1_000_000, None, None, None, None)
             .call_and_wait(create_waiter())
             .await?;
 
@@ -206,7 +206,7 @@ fn wallet_create_and_set_controller() {
         eprintln!("Agent id: {:?}", other_agent_principal.to_text());
 
         let create_result = wallet
-            .wallet_create_wallet(
+            .wallet_create_wallet64(
                 1_000_000_000_000_u64,
                 Some(vec![other_agent_principal]),
                 None,
@@ -263,7 +263,7 @@ fn wallet_create_wallet() {
 
         // create a child wallet
         let child_create_res = wallet
-            .wallet_create_wallet(
+            .wallet_create_wallet64(
                 1_000_000_000_000_u64,
                 None,
                 None,
@@ -298,7 +298,7 @@ fn wallet_create_wallet() {
         // create a second child wallet
         //
         let child_two_create_res = wallet
-            .wallet_create_wallet(
+            .wallet_create_wallet64(
                 2_100_000_000_000_u64,
                 None,
                 None,

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -129,8 +129,10 @@ fn wallet_canister_forward() {
             .reply_data(b"DIDL\0\x01\x71\x0bHello World")
             .build();
 
-        let forward = wallet
-            .call_forward64::<(String,)>(universal.update_("update").with_arg_raw(arg).build(), 0)?;
+        let forward = wallet.call_forward64::<(String,)>(
+            universal.update_("update").with_arg_raw(arg).build(),
+            0,
+        )?;
         let (result,) = forward.call_and_wait(create_waiter()).await.unwrap();
 
         assert_eq!(result, "Hello World");


### PR DESCRIPTION
The default functions are changed to use the 128-bit canister functions, and the old canister functions are accessible under explicitly 64-bit functions (e.g. `.wallet_send` &rarr; `:wallet_send128`, `.wallet_send64` &rarr; `:wallet_send`).