### PR TITLE
feat: Remove parameterized canister pattern

### DIFF
--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -23,7 +23,7 @@ pub enum CanisterBuilderError {
 }
 
 /// A canister builder, which can be used to create a canister abstraction.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CanisterBuilder<'agent> {
     agent: Option<&'agent Agent>,
     canister_id: Option<Result<Principal, CanisterBuilderError>>,
@@ -70,19 +70,7 @@ impl<'agent> CanisterBuilder<'agent> {
         let agent = self
             .agent
             .ok_or(CanisterBuilderError::MustSpecifyAnAgent())?;
-        Ok(Canister {
-            agent,
-            canister_id,
-        })
-    }
-}
-
-impl Default for CanisterBuilder<'static> {
-    fn default() -> Self {
-        CanisterBuilder {
-            agent: None,
-            canister_id: None,
-        }
+        Ok(Canister { agent, canister_id })
     }
 }
 
@@ -272,10 +260,7 @@ impl<'agent, 'canister: 'agent> SyncCallBuilder<'agent, 'canister> {
 impl<'agent, 'canister: 'agent> SyncCallBuilder<'agent, 'canister> {
     /// Add an argument to the candid argument list. This requires Candid arguments, if
     /// there is a raw argument set (using [with_arg_raw]), this will fail.
-    pub fn with_arg<Argument>(
-        mut self,
-        arg: Argument,
-    ) -> SyncCallBuilder<'agent, 'canister>
+    pub fn with_arg<Argument>(mut self, arg: Argument) -> SyncCallBuilder<'agent, 'canister>
     where
         Argument: CandidType + Sync + Send,
     {
@@ -286,10 +271,7 @@ impl<'agent, 'canister: 'agent> SyncCallBuilder<'agent, 'canister> {
     /// Add an argument to the candid argument list. This requires Candid arguments, if
     /// there is a raw argument set (using [with_arg_raw]), this will fail.
     /// TODO: make this method unnecessary https://github.com/dfinity/agent-rs/issues/132
-    pub fn with_value_arg(
-        mut self,
-        arg: IDLValue,
-    ) -> SyncCallBuilder<'agent, 'canister> {
+    pub fn with_value_arg(mut self, arg: IDLValue) -> SyncCallBuilder<'agent, 'canister> {
         self.arg.push_value_arg(arg);
         self
     }
@@ -357,10 +339,7 @@ impl<'agent, 'canister: 'agent> AsyncCallBuilder<'agent, 'canister> {
 impl<'agent, 'canister: 'agent> AsyncCallBuilder<'agent, 'canister> {
     /// Add an argument to the candid argument list. This requires Candid arguments, if
     /// there is a raw argument set (using [with_arg_raw]), this will fail.
-    pub fn with_arg<Argument>(
-        mut self,
-        arg: Argument,
-    ) -> AsyncCallBuilder<'agent, 'canister>
+    pub fn with_arg<Argument>(mut self, arg: Argument) -> AsyncCallBuilder<'agent, 'canister>
     where
         Argument: CandidType + Sync + Send,
     {
@@ -431,11 +410,13 @@ mod tests {
             .unwrap();
         agent.fetch_root_key().await.unwrap();
 
-        let management_canister = ManagementCanister::from_canister(Canister::builder()
-            .with_agent(&agent)
-            .with_canister_id("aaaaa-aa")
-            .build()
-            .unwrap());
+        let management_canister = ManagementCanister::from_canister(
+            Canister::builder()
+                .with_agent(&agent)
+                .with_canister_id("aaaaa-aa")
+                .build()
+                .unwrap(),
+        );
 
         let (new_canister_id,) = management_canister
             .create_canister()

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -24,13 +24,17 @@ pub enum CanisterBuilderError {
 
 /// A canister builder, which can be used to create a canister abstraction.
 #[derive(Debug)]
-pub struct CanisterBuilder<'agent, T = ()> {
+pub struct CanisterBuilder<'agent> {
     agent: Option<&'agent Agent>,
     canister_id: Option<Result<Principal, CanisterBuilderError>>,
-    interface: T,
 }
 
-impl<'agent, T> CanisterBuilder<'agent, T> {
+impl<'agent> CanisterBuilder<'agent> {
+    /// Create a canister builder with no value.
+    pub fn new() -> CanisterBuilder<'static> {
+        Default::default()
+    }
+
     /// Attach a canister ID to this canister.
     pub fn with_canister_id<E, P>(self, canister_id: P) -> Self
     where
@@ -56,7 +60,7 @@ impl<'agent, T> CanisterBuilder<'agent, T> {
     }
 
     /// Create this canister abstraction after passing in all the necessary state.
-    pub fn build(self) -> Result<Canister<'agent, T>, CanisterBuilderError> {
+    pub fn build(self) -> Result<Canister<'agent>, CanisterBuilderError> {
         let canister_id = if let Some(cid) = self.canister_id {
             cid?
         } else {
@@ -69,34 +73,15 @@ impl<'agent, T> CanisterBuilder<'agent, T> {
         Ok(Canister {
             agent,
             canister_id,
-            interface: self.interface,
         })
     }
 }
 
-impl Default for CanisterBuilder<'static, ()> {
+impl Default for CanisterBuilder<'static> {
     fn default() -> Self {
         CanisterBuilder {
             agent: None,
             canister_id: None,
-            interface: (),
-        }
-    }
-}
-
-impl<'agent> CanisterBuilder<'agent, ()> {
-    /// Create a canister builder with no value.
-    pub fn new() -> CanisterBuilder<'static, ()> {
-        Default::default()
-    }
-
-    /// Apply an interface to this canister. An interface can add methods to the canister's
-    /// type. For example, see the Management Canister.
-    pub fn with_interface<T>(self, interface: T) -> CanisterBuilder<'agent, T> {
-        CanisterBuilder {
-            agent: self.agent,
-            canister_id: self.canister_id,
-            interface,
         }
     }
 }
@@ -107,30 +92,23 @@ impl<'agent> CanisterBuilder<'agent, ()> {
 ///
 /// This is the higher level construct for talking to a canister on the Internet
 /// Computer.
-#[derive(Debug)]
-pub struct Canister<'agent, T = ()> {
+#[derive(Debug, Clone)]
+pub struct Canister<'agent> {
     pub(super) agent: &'agent Agent,
     pub(super) canister_id: Principal,
-    interface: T,
 }
 
-impl<'agent, T> Canister<'agent, T> {
+impl<'agent> Canister<'agent> {
     /// Get the canister ID of this canister.
     pub fn canister_id_<'canister: 'agent>(&'canister self) -> &Principal {
         &self.canister_id
-    }
-
-    /// Get the interface object from this canister. Sometimes those interfaces might have
-    /// custom methods that are useful.
-    pub fn interface_<'canister: 'agent>(&'canister self) -> &T {
-        &self.interface
     }
 
     /// Create an AsyncCallBuilder to do an update call.
     pub fn update_<'canister: 'agent>(
         &'canister self,
         method_name: &str,
-    ) -> AsyncCallBuilder<'agent, 'canister, T> {
+    ) -> AsyncCallBuilder<'agent, 'canister> {
         AsyncCallBuilder::new(self, method_name)
     }
 
@@ -138,7 +116,7 @@ impl<'agent, T> Canister<'agent, T> {
     pub fn query_<'canister: 'agent>(
         &'canister self,
         method_name: &str,
-    ) -> SyncCallBuilder<'agent, 'canister, T> {
+    ) -> SyncCallBuilder<'agent, 'canister> {
         SyncCallBuilder::new(self, method_name)
     }
 
@@ -156,25 +134,17 @@ impl<'agent, T> Canister<'agent, T> {
             .wait(request_id, self.canister_id, disable_range_check, waiter)
             .await
     }
-}
 
-impl<'agent, T> Canister<'agent, T>
-where
-    T: Clone,
-{
     /// Creates a copy of this canister, changing the canister ID to the provided principal.
     pub fn clone_with_(&self, id: Principal) -> Self {
         Self {
             agent: self.agent,
             canister_id: id,
-            interface: self.interface.clone(),
         }
     }
-}
 
-impl<'agent> Canister<'agent, ()> {
     /// Create a CanisterBuilder instance to build a canister abstraction.
-    pub fn builder() -> CanisterBuilder<'agent, ()> {
+    pub fn builder() -> CanisterBuilder<'agent> {
         Default::default()
     }
 }
@@ -277,17 +247,17 @@ impl Default for Argument {
 ///
 /// See [SyncCaller] for a description of this structure once built.
 #[derive(Debug)]
-pub struct SyncCallBuilder<'agent, 'canister: 'agent, T> {
-    canister: &'canister Canister<'agent, T>,
+pub struct SyncCallBuilder<'agent, 'canister: 'agent> {
+    canister: &'canister Canister<'agent>,
     method_name: String,
     effective_canister_id: Principal,
     arg: Argument,
 }
 
-impl<'agent, 'canister: 'agent, T> SyncCallBuilder<'agent, 'canister, T> {
+impl<'agent, 'canister: 'agent> SyncCallBuilder<'agent, 'canister> {
     /// Create a new instance of an AsyncCallBuilder.
     pub(super) fn new<M: Into<String>>(
-        canister: &'canister Canister<'agent, T>,
+        canister: &'canister Canister<'agent>,
         method_name: M,
     ) -> Self {
         Self {
@@ -299,13 +269,13 @@ impl<'agent, 'canister: 'agent, T> SyncCallBuilder<'agent, 'canister, T> {
     }
 }
 
-impl<'agent, 'canister: 'agent, Interface> SyncCallBuilder<'agent, 'canister, Interface> {
+impl<'agent, 'canister: 'agent> SyncCallBuilder<'agent, 'canister> {
     /// Add an argument to the candid argument list. This requires Candid arguments, if
     /// there is a raw argument set (using [with_arg_raw]), this will fail.
     pub fn with_arg<Argument>(
         mut self,
         arg: Argument,
-    ) -> SyncCallBuilder<'agent, 'canister, Interface>
+    ) -> SyncCallBuilder<'agent, 'canister>
     where
         Argument: CandidType + Sync + Send,
     {
@@ -319,14 +289,14 @@ impl<'agent, 'canister: 'agent, Interface> SyncCallBuilder<'agent, 'canister, In
     pub fn with_value_arg(
         mut self,
         arg: IDLValue,
-    ) -> SyncCallBuilder<'agent, 'canister, Interface> {
+    ) -> SyncCallBuilder<'agent, 'canister> {
         self.arg.push_value_arg(arg);
         self
     }
 
     /// Replace the argument with raw argument bytes. This will overwrite the current
     /// argument set, so calling this method twice will discard the first argument.
-    pub fn with_arg_raw(mut self, arg: Vec<u8>) -> SyncCallBuilder<'agent, 'canister, Interface> {
+    pub fn with_arg_raw(mut self, arg: Vec<u8>) -> SyncCallBuilder<'agent, 'canister> {
         self.arg.set_raw_arg(arg);
         self
     }
@@ -335,7 +305,7 @@ impl<'agent, 'canister: 'agent, Interface> SyncCallBuilder<'agent, 'canister, In
     pub fn with_effective_canister_id(
         mut self,
         canister_id: Principal,
-    ) -> SyncCallBuilder<'agent, 'canister, Interface> {
+    ) -> SyncCallBuilder<'agent, 'canister> {
         self.effective_canister_id = canister_id;
         self
     }
@@ -362,19 +332,19 @@ impl<'agent, 'canister: 'agent, Interface> SyncCallBuilder<'agent, 'canister, In
 ///
 /// See [AsyncCaller] for a description of this structure.
 #[derive(Debug)]
-pub struct AsyncCallBuilder<'agent, 'canister: 'agent, T> {
-    canister: &'canister Canister<'agent, T>,
+pub struct AsyncCallBuilder<'agent, 'canister: 'agent> {
+    canister: &'canister Canister<'agent>,
     method_name: String,
     effective_canister_id: Principal,
     arg: Argument,
 }
 
-impl<'agent, 'canister: 'agent, T> AsyncCallBuilder<'agent, 'canister, T> {
+impl<'agent, 'canister: 'agent> AsyncCallBuilder<'agent, 'canister> {
     /// Create a new instance of an AsyncCallBuilder.
     pub(super) fn new(
-        canister: &'canister Canister<'agent, T>,
+        canister: &'canister Canister<'agent>,
         method_name: &str,
-    ) -> AsyncCallBuilder<'agent, 'canister, T> {
+    ) -> AsyncCallBuilder<'agent, 'canister> {
         Self {
             canister,
             method_name: method_name.to_string(),
@@ -384,13 +354,13 @@ impl<'agent, 'canister: 'agent, T> AsyncCallBuilder<'agent, 'canister, T> {
     }
 }
 
-impl<'agent, 'canister: 'agent, Interface> AsyncCallBuilder<'agent, 'canister, Interface> {
+impl<'agent, 'canister: 'agent> AsyncCallBuilder<'agent, 'canister> {
     /// Add an argument to the candid argument list. This requires Candid arguments, if
     /// there is a raw argument set (using [with_arg_raw]), this will fail.
     pub fn with_arg<Argument>(
         mut self,
         arg: Argument,
-    ) -> AsyncCallBuilder<'agent, 'canister, Interface>
+    ) -> AsyncCallBuilder<'agent, 'canister>
     where
         Argument: CandidType + Sync + Send,
     {
@@ -400,7 +370,7 @@ impl<'agent, 'canister: 'agent, Interface> AsyncCallBuilder<'agent, 'canister, I
 
     /// Replace the argument with raw argument bytes. This will overwrite the current
     /// argument set, so calling this method twice will discard the first argument.
-    pub fn with_arg_raw(mut self, arg: Vec<u8>) -> AsyncCallBuilder<'agent, 'canister, Interface> {
+    pub fn with_arg_raw(mut self, arg: Vec<u8>) -> AsyncCallBuilder<'agent, 'canister> {
         self.arg.set_raw_arg(arg);
         self
     }
@@ -409,7 +379,7 @@ impl<'agent, 'canister: 'agent, Interface> AsyncCallBuilder<'agent, 'canister, I
     pub fn with_effective_canister_id(
         mut self,
         canister_id: Principal,
-    ) -> AsyncCallBuilder<'agent, 'canister, Interface> {
+    ) -> AsyncCallBuilder<'agent, 'canister> {
         self.effective_canister_id = canister_id;
         self
     }
@@ -461,12 +431,11 @@ mod tests {
             .unwrap();
         agent.fetch_root_key().await.unwrap();
 
-        let management_canister = Canister::builder()
+        let management_canister = ManagementCanister::from_canister(Canister::builder()
             .with_agent(&agent)
             .with_canister_id("aaaaa-aa")
-            .with_interface(ManagementCanister)
             .build()
-            .unwrap();
+            .unwrap());
 
         let (new_canister_id,) = management_canister
             .create_canister()

--- a/ic-utils/src/interfaces.rs
+++ b/ic-utils/src/interfaces.rs
@@ -4,4 +4,4 @@ pub mod wallet;
 
 pub use http_request::HttpRequestCanister;
 pub use management_canister::ManagementCanister;
-pub use wallet::Wallet;
+pub use wallet::WalletCanister;

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -370,11 +370,13 @@ impl CandidType for ArgToken {
 impl<'agent> HttpRequestCanister<'agent> {
     /// Create an instance of a `HttpRequestCanister` interface pointing to the specified Canister ID.
     pub fn create(agent: &'agent Agent, canister_id: Principal) -> Self {
-        Self(Canister::builder()
-            .with_agent(agent)
-            .with_canister_id(canister_id)
-            .build()
-            .unwrap())
+        Self(
+            Canister::builder()
+                .with_agent(agent)
+                .with_canister_id(canister_id)
+                .build()
+                .unwrap(),
+        )
     }
 
     /// Create a `HttpRequestCanister` interface from an existing canister object.

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     call::{AsyncCall, SyncCall},
-    canister::CanisterBuilder,
     Canister,
 };
 use candid::{
@@ -23,8 +22,15 @@ use std::{
 };
 
 /// A canister that can serve a HTTP request.
-#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
-pub struct HttpRequestCanister;
+#[derive(Debug, Clone)]
+pub struct HttpRequestCanister<'agent>(Canister<'agent>);
+
+impl<'agent> Deref for HttpRequestCanister<'agent> {
+    type Target = Canister<'agent>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// A key-value pair for a HTTP header.
 #[derive(Debug, CandidType, Clone, Deserialize)]
@@ -361,28 +367,23 @@ impl CandidType for ArgToken {
     }
 }
 
-impl HttpRequestCanister {
-    /// Create an instance of a [Canister] implementing the [HttpRequestCanister] interface
-    /// and pointing to the right Canister ID.
-    pub fn create(agent: &Agent, canister_id: Principal) -> Canister<HttpRequestCanister> {
-        Canister::builder()
+impl<'agent> HttpRequestCanister<'agent> {
+    /// Create an instance of a `HttpRequestCanister` interface pointing to the specified Canister ID.
+    pub fn create(agent: &'agent Agent, canister_id: Principal) -> Self {
+        Self(Canister::builder()
             .with_agent(agent)
             .with_canister_id(canister_id)
-            .with_interface(HttpRequestCanister)
             .build()
-            .unwrap()
+            .unwrap())
     }
 
-    /// Creating a CanisterBuilder with the right interface and Canister Id. This can
-    /// be useful, for example, for providing additional Builder information.
-    pub fn with_agent(agent: &Agent) -> CanisterBuilder<HttpRequestCanister> {
-        Canister::builder()
-            .with_agent(agent)
-            .with_interface(HttpRequestCanister)
+    /// Create a `HttpRequestCanister` interface from an existing canister object.
+    pub fn from_canister(canister: Canister<'agent>) -> Self {
+        Self(canister)
     }
 }
 
-impl<'agent> Canister<'agent, HttpRequestCanister> {
+impl<'agent> HttpRequestCanister<'agent> {
     /// Performs a HTTP request, receiving a HTTP response.
     pub fn http_request<'canister: 'agent>(
         &'canister self,

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -57,11 +57,13 @@ pub enum MgmtMethod {
 impl<'agent> ManagementCanister<'agent> {
     /// Create an instance of a `ManagementCanister` interface pointing to the specified Canister ID.
     pub fn create(agent: &'agent Agent) -> Self {
-        Self(Canister::builder()
-            .with_agent(agent)
-            .with_canister_id(Principal::management_canister())
-            .build()
-            .unwrap())
+        Self(
+            Canister::builder()
+                .with_agent(agent)
+                .with_canister_id(Principal::management_canister())
+                .build()
+                .unwrap(),
+        )
     }
 
     /// Create a `ManagementCanister` interface from an existing canister object.

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -411,9 +411,7 @@ impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
 }
 
 #[async_trait]
-impl<'agent, 'canister: 'agent> AsyncCall<()>
-    for InstallCodeBuilder<'agent, 'canister>
-{
+impl<'agent, 'canister: 'agent> AsyncCall<()> for InstallCodeBuilder<'agent, 'canister> {
     async fn call(self) -> Result<RequestId, AgentError> {
         self.build()?.call().await
     }
@@ -625,9 +623,7 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
 }
 
 #[async_trait]
-impl<'agent, 'canister: 'agent> AsyncCall<()>
-    for UpdateCanisterBuilder<'agent, 'canister>
-{
+impl<'agent, 'canister: 'agent> AsyncCall<()> for UpdateCanisterBuilder<'agent, 'canister> {
     async fn call(self) -> Result<RequestId, AgentError> {
         self.build()?.call().await
     }

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -41,8 +41,8 @@ pub struct CanisterSettings {
 
 /// A builder for a `create_canister` call.
 #[derive(Debug)]
-pub struct CreateCanisterBuilder<'agent, 'canister: 'agent, T> {
-    canister: &'canister Canister<'agent, T>,
+pub struct CreateCanisterBuilder<'agent, 'canister: 'agent> {
+    canister: &'canister Canister<'agent>,
     controllers: Option<Result<Vec<Principal>, AgentError>>,
     compute_allocation: Option<Result<ComputeAllocation, AgentError>>,
     memory_allocation: Option<Result<MemoryAllocation, AgentError>>,
@@ -51,9 +51,9 @@ pub struct CreateCanisterBuilder<'agent, 'canister: 'agent, T> {
     amount: Option<u128>,
 }
 
-impl<'agent, 'canister: 'agent, T> CreateCanisterBuilder<'agent, 'canister, T> {
+impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// Create an CreateCanister builder, which is also an AsyncCall implementation.
-    pub fn builder(canister: &'canister Canister<'agent, T>) -> Self {
+    pub fn builder(canister: &'canister Canister<'agent>) -> Self {
         Self {
             canister,
             controllers: None,
@@ -271,8 +271,8 @@ impl<'agent, 'canister: 'agent, T> CreateCanisterBuilder<'agent, 'canister, T> {
 }
 
 #[async_trait]
-impl<'agent, 'canister: 'agent, T: Sync> AsyncCall<(Principal,)>
-    for CreateCanisterBuilder<'agent, 'canister, T>
+impl<'agent, 'canister: 'agent> AsyncCall<(Principal,)>
+    for CreateCanisterBuilder<'agent, 'canister>
 {
     async fn call(self) -> Result<RequestId, AgentError> {
         self.build()?.call().await
@@ -332,18 +332,18 @@ impl FromStr for InstallMode {
 
 /// A builder for an `install_code` call.
 #[derive(Debug)]
-pub struct InstallCodeBuilder<'agent, 'canister: 'agent, T> {
-    canister: &'canister Canister<'agent, T>,
+pub struct InstallCodeBuilder<'agent, 'canister: 'agent> {
+    canister: &'canister Canister<'agent>,
     canister_id: Principal,
     wasm: &'canister [u8],
     arg: Argument,
     mode: Option<InstallMode>,
 }
 
-impl<'agent, 'canister: 'agent, T> InstallCodeBuilder<'agent, 'canister, T> {
+impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
     /// Create an InstallCode builder, which is also an AsyncCall implementation.
     pub fn builder(
-        canister: &'canister Canister<'agent, T>,
+        canister: &'canister Canister<'agent>,
         canister_id: &Principal,
         wasm: &'canister [u8],
     ) -> Self {
@@ -361,13 +361,13 @@ impl<'agent, 'canister: 'agent, T> InstallCodeBuilder<'agent, 'canister, T> {
     pub fn with_arg<Argument: CandidType + Sync + Send>(
         mut self,
         arg: Argument,
-    ) -> InstallCodeBuilder<'agent, 'canister, T> {
+    ) -> InstallCodeBuilder<'agent, 'canister> {
         self.arg.push_idl_arg(arg);
         self
     }
 
     /// Override the argument passed in to the canister with raw bytes.
-    pub fn with_raw_arg(mut self, arg: Vec<u8>) -> InstallCodeBuilder<'agent, 'canister, T> {
+    pub fn with_raw_arg(mut self, arg: Vec<u8>) -> InstallCodeBuilder<'agent, 'canister> {
         self.arg.set_raw_arg(arg);
         self
     }
@@ -411,8 +411,8 @@ impl<'agent, 'canister: 'agent, T> InstallCodeBuilder<'agent, 'canister, T> {
 }
 
 #[async_trait]
-impl<'agent, 'canister: 'agent, T: Sync> AsyncCall<()>
-    for InstallCodeBuilder<'agent, 'canister, T>
+impl<'agent, 'canister: 'agent> AsyncCall<()>
+    for InstallCodeBuilder<'agent, 'canister>
 {
     async fn call(self) -> Result<RequestId, AgentError> {
         self.build()?.call().await
@@ -428,8 +428,8 @@ impl<'agent, 'canister: 'agent, T: Sync> AsyncCall<()>
 
 /// A builder for an `update_settings` call.
 #[derive(Debug)]
-pub struct UpdateCanisterBuilder<'agent, 'canister: 'agent, T> {
-    canister: &'canister Canister<'agent, T>,
+pub struct UpdateCanisterBuilder<'agent, 'canister: 'agent> {
+    canister: &'canister Canister<'agent>,
     canister_id: Principal,
     controllers: Option<Result<Vec<Principal>, AgentError>>,
     compute_allocation: Option<Result<ComputeAllocation, AgentError>>,
@@ -437,9 +437,9 @@ pub struct UpdateCanisterBuilder<'agent, 'canister: 'agent, T> {
     freezing_threshold: Option<Result<FreezingThreshold, AgentError>>,
 }
 
-impl<'agent, 'canister: 'agent, T> UpdateCanisterBuilder<'agent, 'canister, T> {
+impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// Create an UpdateCanister builder, which is also an AsyncCall implementation.
-    pub fn builder(canister: &'canister Canister<'agent, T>, canister_id: &Principal) -> Self {
+    pub fn builder(canister: &'canister Canister<'agent>, canister_id: &Principal) -> Self {
         Self {
             canister,
             canister_id: *canister_id,
@@ -625,8 +625,8 @@ impl<'agent, 'canister: 'agent, T> UpdateCanisterBuilder<'agent, 'canister, T> {
 }
 
 #[async_trait]
-impl<'agent, 'canister: 'agent, T: Sync> AsyncCall<()>
-    for UpdateCanisterBuilder<'agent, 'canister, T>
+impl<'agent, 'canister: 'agent> AsyncCall<()>
+    for UpdateCanisterBuilder<'agent, 'canister>
 {
     async fn call(self) -> Result<RequestId, AgentError> {
         self.build()?.call().await

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -454,7 +454,7 @@ impl<'agent> WalletCanister<'agent> {
     /// Send cycles to another (hopefully Wallet) canister.
     pub fn wallet_send<'canister: 'agent>(
         &'canister self,
-        destination: &'_ Canister<'agent, Wallet>,
+        destination: &'_ Canister<'agent>,
         amount: u128,
     ) -> impl 'agent + AsyncCall<(Result<(), String>,)> {
         #[derive(CandidType)]

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -263,11 +263,13 @@ pub struct CallResult {
 impl<'agent> WalletCanister<'agent> {
     /// Create an instance of a `WalletCanister` interface pointing to the given Canister ID.
     pub fn create(agent: &'agent Agent, canister_id: Principal) -> Self {
-        Self(Canister::builder()
-            .with_agent(agent)
-            .with_canister_id(canister_id)
-            .build()
-            .unwrap())
+        Self(
+            Canister::builder()
+                .with_agent(agent)
+                .with_canister_id(canister_id)
+                .build()
+                .unwrap(),
+        )
     }
 
     /// Create a `WalletCanister` interface from an existing canister object.

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -47,7 +47,7 @@ mod management_canister {
                 CanisterStatus, StatusCallResult,
             },
             wallet::CreateResult,
-            ManagementCanister, Wallet,
+            ManagementCanister, WalletCanister,
         },
         Argument, Canister,
     };
@@ -597,7 +597,7 @@ mod management_canister {
             let default_canister_balance: u128 = 100_000_000_000_000;
 
             // empty cycle balance on create
-            let wallet = Wallet::create(&agent, wallet_id);
+            let wallet = WalletCanister::create(&agent, wallet_id);
             let ic00 = Canister::builder()
                 .with_agent(&agent)
                 .with_canister_id(Principal::management_canister())
@@ -678,7 +678,7 @@ mod management_canister {
     #[test]
     fn randomness() {
         with_wallet_canister(None, |agent, wallet_id| async move {
-            let wallet = Wallet::create(&agent, wallet_id);
+            let wallet = WalletCanister::create(&agent, wallet_id);
             let ic00 = Canister::builder()
                 .with_agent(&agent)
                 .with_canister_id(Principal::management_canister())

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -8,7 +8,7 @@ use ic_utils::{
     call::{AsyncCall, SyncCall},
     interfaces::{
         management_canister::builders::{CanisterSettings, InstallMode},
-        Wallet,
+        WalletCanister,
     },
     Argument, Canister,
 };
@@ -90,8 +90,8 @@ fn canister_reject_call() {
     // try to call a wallet method, but on the universal canister.
     // this lets us look up the reject code and reject message in the certificate.
     with_universal_canister(|agent, wallet_id| async move {
-        let alice = Wallet::create(&agent, wallet_id);
-        let bob = Wallet::create(&agent, create_wallet_canister(&agent, None).await?);
+        let alice = WalletCanister::create(&agent, wallet_id);
+        let bob = WalletCanister::create(&agent, create_wallet_canister(&agent, None).await?);
 
         let result = alice
             .wallet_send(&bob, 1_000_000)
@@ -114,7 +114,7 @@ fn canister_reject_call() {
 #[test]
 fn wallet_canister_forward() {
     with_wallet_canister(None, |agent, wallet_id| async move {
-        let wallet = Wallet::create(&agent, wallet_id);
+        let wallet = WalletCanister::create(&agent, wallet_id);
 
         let universal_id = create_universal_canister(&agent).await?;
         let universal = Canister::builder()
@@ -142,7 +142,7 @@ fn wallet_canister_forward() {
 #[test]
 fn wallet_canister_create_and_install() {
     with_wallet_canister(None, |agent, wallet_id| async move {
-        let wallet = Wallet::create(&agent, wallet_id);
+        let wallet = WalletCanister::create(&agent, wallet_id);
 
         let (create_result,) = wallet
             .wallet_create_canister_v2(1_000_000, None, None, None, None)
@@ -188,7 +188,7 @@ fn wallet_canister_create_and_install() {
 fn wallet_create_and_set_controller() {
     with_wallet_canister(None, |agent, wallet_id| async move {
         eprintln!("Parent wallet canister id: {:?}", wallet_id.to_text());
-        let wallet = Wallet::create(&agent, wallet_id);
+        let wallet = WalletCanister::create(&agent, wallet_id);
         // get the wallet wasm from the environment
         let wallet_wasm = get_wallet_wasm_from_env();
         // store the wasm into the wallet
@@ -222,11 +222,10 @@ fn wallet_create_and_set_controller() {
         );
 
         eprintln!("...build child_wallet");
-        let child_wallet = Canister::builder()
+        let child_wallet = WalletCanister::from_canister(Canister::builder()
             .with_agent(&other_agent)
             .with_canister_id(create_result.canister_id)
-            .with_interface(Wallet)
-            .build()?;
+            .build()?);
 
         eprintln!("...child_wallet.get_controllers");
         let (controller_list,) = child_wallet.get_controllers().call().await?;
@@ -249,7 +248,7 @@ fn wallet_create_and_set_controller() {
 fn wallet_create_wallet() {
     with_wallet_canister(None, |agent, wallet_id| async move {
         eprintln!("Parent wallet canister id: {:?}", wallet_id.to_text());
-        let wallet = Wallet::create(&agent, wallet_id);
+        let wallet = WalletCanister::create(&agent, wallet_id);
         let (wallet_initial_balance,) = wallet.wallet_balance().call().await?;
 
         // get the wallet wasm from the environment
@@ -382,8 +381,8 @@ fn wallet_create_wallet() {
 fn wallet_canister_funds() {
     let provisional_amount = 1 << 40;
     with_wallet_canister(Some(provisional_amount), |agent, wallet_id| async move {
-        let alice = Wallet::create(&agent, wallet_id);
-        let bob = Wallet::create(
+        let alice = WalletCanister::create(&agent, wallet_id);
+        let bob = WalletCanister::create(
             &agent,
             create_wallet_canister(&agent, Some(provisional_amount)).await?,
         );
@@ -425,7 +424,7 @@ fn wallet_canister_funds() {
 fn wallet_helper_functions() {
     with_wallet_canister(None, |agent, wallet_id| async move {
         // name
-        let wallet = Wallet::create(&agent, wallet_id);
+        let wallet = WalletCanister::create(&agent, wallet_id);
         let (name,) = wallet.name().call().await?;
         assert!(name.is_none(), "Name should be none.");
 

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -222,10 +222,12 @@ fn wallet_create_and_set_controller() {
         );
 
         eprintln!("...build child_wallet");
-        let child_wallet = WalletCanister::from_canister(Canister::builder()
-            .with_agent(&other_agent)
-            .with_canister_id(create_result.canister_id)
-            .build()?);
+        let child_wallet = WalletCanister::from_canister(
+            Canister::builder()
+                .with_agent(&other_agent)
+                .with_canister_id(create_result.canister_id)
+                .build()?,
+        );
 
         eprintln!("...child_wallet.get_controllers");
         let (controller_list,) = child_wallet.get_controllers().call().await?;


### PR DESCRIPTION
The existing system of `Canister<Interface>` has several problems:

- The documentation is in an unfindable location

- You can't make intra-rustdoc links to the methods

- Crates other than ic-utils are unable to `impl` directly for Canister in this way

- All the generic types involved cart around an extra type parameter just to hold the canister container

This inverts the relationship to `InterfaceCanister(Canister)`, with a Deref impl to preserve existing convenience, solving all the above problems.