### PR TITLE
feat: Improve wallet call forwarding API

### DIFF
--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -249,7 +249,7 @@ impl Argument {
 
 impl Default for Argument {
     fn default() -> Self {
-        Argument(Ok(ArgumentType::Idl(IDLBuilder::new())))
+        Self(Ok(ArgumentType::Idl(IDLBuilder::new())))
     }
 }
 

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -1,4 +1,5 @@
 use crate::call::{AsyncCaller, SyncCaller};
+use candid::utils::ArgumentEncoder;
 use candid::{parser::value::IDLValue, ser::IDLBuilder, utils::ArgumentDecoder, CandidType};
 use garcon::Waiter;
 use ic_agent::{ic_types::Principal, Agent, AgentError, RequestId};
@@ -222,6 +223,27 @@ impl Argument {
     /// Resets the argument to an empty builder.
     pub fn reset(&mut self) {
         *self = Default::default();
+    }
+
+    /// Creates an empty argument.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Creates an argument from an arbitrary blob. Equivalent to [`set_raw_arg`].
+    pub fn from_raw(raw: Vec<u8>) -> Self {
+        Self(Ok(ArgumentType::Raw(raw)))
+    }
+
+    /// Creates an argument from an existing Candid ArgumentEncoder.
+    pub fn from_candid(tuple: impl ArgumentEncoder) -> Self {
+        let mut builder = IDLBuilder::new();
+        Self(
+            tuple
+                .encode(&mut builder)
+                .map(|_| ArgumentType::Idl(builder))
+                .map_err(|e| AgentError::CandidError(Box::new(e))),
+        )
     }
 }
 

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -158,7 +158,7 @@ impl fmt::Debug for ArgumentType {
     }
 }
 
-/// A builder for a canister argument, allowing you to append elements to [`ArgumentType`] with chaining syntax.
+/// A builder for a canister argument, allowing you to append elements to an argument tuple with chaining syntax.
 #[derive(Debug)]
 pub struct Argument(Result<ArgumentType, AgentError>);
 

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -614,8 +614,7 @@ mod management_canister {
                 },
             };
 
-            let mut args = Argument::default();
-            args.push_idl_arg(create_args);
+            let args = Argument::from_candid((create_args,));
 
             let (create_result,): (CreateResult,) = wallet
                 .call(Principal::management_canister(), "create_canister", args, 0)
@@ -628,8 +627,7 @@ mod management_canister {
                 canister_id: Principal,
             }
             let status_args = In { canister_id };
-            let mut args = Argument::default();
-            args.push_idl_arg(status_args);
+            let args = Argument::from_candid((status_args,));
 
             let (result,): (StatusCallResult,) = wallet
                 .call(Principal::management_canister(), "canister_status", args, 0)

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -49,7 +49,7 @@ mod management_canister {
             wallet::CreateResult,
             ManagementCanister, WalletCanister,
         },
-        Argument, Canister,
+        Argument,
     };
     use openssl::sha::Sha256;
     use ref_tests::{
@@ -598,10 +598,6 @@ mod management_canister {
 
             // empty cycle balance on create
             let wallet = WalletCanister::create(&agent, wallet_id).await?;
-            let ic00 = Canister::builder()
-                .with_agent(&agent)
-                .with_canister_id(Principal::management_canister())
-                .build()?;
 
             #[derive(CandidType)]
             struct InCreate {
@@ -622,7 +618,7 @@ mod management_canister {
             args.push_idl_arg(create_args);
 
             let (create_result,): (CreateResult,) = wallet
-                .call(&ic00, "create_canister", args, 0)
+                .call(Principal::management_canister(), "create_canister", args, 0)
                 .call_and_wait(create_waiter())
                 .await?;
             let canister_id = create_result.canister_id;
@@ -636,7 +632,7 @@ mod management_canister {
             args.push_idl_arg(status_args);
 
             let (result,): (StatusCallResult,) = wallet
-                .call(&ic00, "canister_status", args, 0)
+                .call(Principal::management_canister(), "canister_status", args, 0)
                 .call_and_wait(create_waiter())
                 .await?;
 
@@ -679,20 +675,31 @@ mod management_canister {
     fn randomness() {
         with_wallet_canister(None, |agent, wallet_id| async move {
             let wallet = WalletCanister::create(&agent, wallet_id).await?;
-            let ic00 = Canister::builder()
-                .with_agent(&agent)
-                .with_canister_id(Principal::management_canister())
-                .build()?;
             let (rand_1,): (Vec<u8>,) = wallet
-                .call(&ic00, "raw_rand", Argument::default(), 0)
+                .call(
+                    Principal::management_canister(),
+                    "raw_rand",
+                    Argument::default(),
+                    0,
+                )
                 .call_and_wait(create_waiter())
                 .await?;
             let (rand_2,): (Vec<u8>,) = wallet
-                .call(&ic00, "raw_rand", Argument::default(), 0)
+                .call(
+                    Principal::management_canister(),
+                    "raw_rand",
+                    Argument::default(),
+                    0,
+                )
                 .call_and_wait(create_waiter())
                 .await?;
             let (rand_3,): (Vec<u8>,) = wallet
-                .call(&ic00, "raw_rand", Argument::default(), 0)
+                .call(
+                    Principal::management_canister(),
+                    "raw_rand",
+                    Argument::default(),
+                    0,
+                )
                 .call_and_wait(create_waiter())
                 .await?;
 

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -123,8 +123,7 @@ fn wallet_canister_forward() {
             .reply_data(b"DIDL\0\x01\x71\x0bHello World")
             .build();
 
-        let mut args = Argument::default();
-        args.set_raw_arg(arg);
+        let args = Argument::from_raw(arg);
 
         let (result,): (String,) = wallet
             .call(universal_id, "update", args, 0)
@@ -162,8 +161,7 @@ fn wallet_canister_create_and_install() {
             arg: Argument::default().serialize()?,
         };
 
-        let mut args = Argument::default();
-        args.push_idl_arg(install_config);
+        let args = Argument::from_candid((install_config,));
 
         wallet
             .call64(Principal::management_canister(), "install_code", args, 0)
@@ -345,8 +343,7 @@ fn wallet_create_wallet() {
                 freezing_threshold: None,
             },
         };
-        let mut args = Argument::default();
-        args.push_idl_arg(create_args);
+        let args = Argument::from_candid((create_args,));
 
         let (grandchild_create_res,): (Result<ic_utils::interfaces::wallet::CreateResult, String>,) =
             wallet


### PR DESCRIPTION
This makes a few consistency improvements towards wallet_call and friends.

- Argument is now constructible from values in a one-liner if you don't need builder syntax but are calling a function that requires one
- `WalletCanister::call`/`call64`/`call128` now take `Principal` instead of `Canister`. Every element of the canister's configuration was ignored except the principal, so this avoids misleading callers as well as not requiring constructing do-nothing canisters for cases like `Principal::management_canister`.
- `call_forward` is removed. Same story - all configuration is ignored, so wrapping the high-level abstraction makes no sense if it's not used. It also was not usable with interface functions in the first place, which is so centrally the use-case that I thought it couldn't be used at all not thinking to check `update_`.