### PR TITLE
feat: wallet_send takes Principal instead of &Canister

### DIFF
--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -562,7 +562,7 @@ impl<'agent> WalletCanister<'agent> {
     /// Send cycles to another canister using the 64-bit API.
     pub fn wallet_send64<'canister: 'agent>(
         &'canister self,
-        destination: &'_ Canister<'_>,
+        destination: Principal,
         amount: u64,
     ) -> impl 'agent + AsyncCall<(Result<(), String>,)> {
         #[derive(CandidType)]
@@ -573,7 +573,7 @@ impl<'agent> WalletCanister<'agent> {
 
         self.update_("wallet_send")
             .with_arg(In {
-                canister: *destination.canister_id_(),
+                canister: destination,
                 amount,
             })
             .build()
@@ -582,7 +582,7 @@ impl<'agent> WalletCanister<'agent> {
     /// Send cycles to another canister using the 128-bit API.
     pub fn wallet_send128<'canister: 'agent>(
         &'canister self,
-        destination: &'_ Canister<'agent>,
+        destination: Principal,
         amount: u128,
     ) -> impl 'agent + AsyncCall<(Result<(), String>,)> {
         #[derive(CandidType)]
@@ -593,7 +593,7 @@ impl<'agent> WalletCanister<'agent> {
 
         self.update_("wallet_send128")
             .with_arg(In {
-                canister: *destination.canister_id_(),
+                canister: destination,
                 amount,
             })
             .build()
@@ -602,7 +602,7 @@ impl<'agent> WalletCanister<'agent> {
     /// Send cycles to another canister.
     pub async fn wallet_send<'canister: 'agent>(
         &'canister self,
-        destination: &'_ Canister<'agent>,
+        destination: Principal,
         amount: u128,
         waiter: Delay,
     ) -> Result<(), AgentError> {

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -94,7 +94,9 @@ fn canister_reject_call() {
         let bob =
             WalletCanister::create(&agent, create_wallet_canister(&agent, None).await?).await?;
 
-        let result = alice.wallet_send(&bob, 1_000_000, create_waiter()).await;
+        let result = alice
+            .wallet_send(*bob.canister_id_(), 1_000_000, create_waiter())
+            .await;
 
         assert_eq!(
             result,
@@ -387,7 +389,9 @@ fn wallet_canister_funds() {
         let alice_previous_balance = alice.wallet_balance().await?;
         let bob_previous_balance = bob.wallet_balance().await?;
 
-        alice.wallet_send(&bob, 1_000_000, create_waiter()).await?;
+        alice
+            .wallet_send(*bob.canister_id_(), 1_000_000, create_waiter())
+            .await?;
 
         let bob_balance = bob.wallet_balance().await?;
 


### PR DESCRIPTION
This should be the last major thorn in the wallet interface object.