### PR TITLE
feat: `ReqwestHttpReplicaV2Transport::create_with_client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Added `ReqwestHttpReplicaV2Transport::create_with_client`.
+
 ## [0.15.0] - 2022-03-28
 
 Updated `ic_utils::interfaces::http_request` structures to use `&str` to reduce copying.

--- a/ic-agent/src/agent/http_transport.rs
+++ b/ic-agent/src/agent/http_transport.rs
@@ -57,7 +57,7 @@ impl ReqwestHttpReplicaV2Transport {
         )
     }
 
-    /// Creates a replica transport from a HTTP URL and a `[reqwest::Client]`.
+    /// Creates a replica transport from a HTTP URL and a [`reqwest::Client`].
     pub fn create_with_client<U: Into<String>>(
         url: U,
         client: reqwest::Client,

--- a/ic-agent/src/agent/http_transport.rs
+++ b/ic-agent/src/agent/http_transport.rs
@@ -1,6 +1,8 @@
 //! A [ReplicaV2Transport] that connects using a reqwest client.
 #![cfg(feature = "reqwest")]
 
+pub use reqwest;
+
 use crate::{agent::agent_error::HttpErrorPayload, ic_types::Principal, AgentError, RequestId};
 use hyper_rustls::ConfigBuilderExt;
 use reqwest::Method;
@@ -46,8 +48,21 @@ impl ReqwestHttpReplicaV2Transport {
         // Advertise support for HTTP/2
         tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 
-        let url = url.into();
+        Self::create_with_client(
+            url,
+            reqwest::Client::builder()
+                .use_preconfigured_tls(tls_config)
+                .build()
+                .expect("Could not create HTTP client."),
+        )
+    }
 
+    /// Creates a replica transport from a HTTP URL and a `[reqwest::Client]`.
+    pub fn create_with_client<U: Into<String>>(
+        url: U,
+        client: reqwest::Client,
+    ) -> Result<Self, AgentError> {
+        let url = url.into();
         Ok(Self {
             url: reqwest::Url::parse(&url)
                 .and_then(|mut url| {
@@ -60,10 +75,7 @@ impl ReqwestHttpReplicaV2Transport {
                     url.join("api/v2/")
                 })
                 .map_err(|_| AgentError::InvalidReplicaUrl(url.clone()))?,
-            client: reqwest::Client::builder()
-                .use_preconfigured_tls(tls_config)
-                .build()
-                .expect("Could not create HTTP client."),
+            client,
             password_manager: None,
         })
     }


### PR DESCRIPTION
# Description

Adds `ReqwestHttpReplicaV2Transport::create_with_client`.
Also re-exports `reqwest` for ease of version matching.

This makes it much easier to do custom connection stuff (e.g. self-signed certs for farm IC testing).

# How Has This Been Tested?

Local testing with custom icx-proxy.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
