### PR TITLE
fix: raise minimum reqwest version to avoid TLS backend error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Added `ReqwestHttpReplicaV2Transport::create_with_client`.
 
+Updated minimum version of reqwest to 0.11.7.  This is to avoid the following error, seen with reqwest 0.11.6:
+
+```
+Unknown TLS backend passed to use_preconfigured_tls
+```
+
 ## [0.15.0] - 2022-03-28
 
 Updated `ic_utils::interfaces::http_request` structures to use `&str` to reduce copying.

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -40,7 +40,7 @@ pkcs8 = { version = "0.8", features = ["std"] }
 sec1 = { version = "0.2", features = ["pem"]}
 
 [dependencies.reqwest]
-version = "0.11"
+version = "0.11.7"
 default-features = false
 features = [ "blocking", "json", "rustls-tls" ]
 optional = true


### PR DESCRIPTION
If consumers of ic-agent didn't update their reqwest dependency manually, agent construction would fail with this error:

```
Could not create HTTP client.: reqwest::Error { kind: Builder, 
  source: "Unknown TLS backend passed to use_preconfigured_tls" } 
```
Update the dependency requirement to be at least reqwest >= 0.11.7.
