### PR TITLE
fix: potential Panic in Secp256k1 Signature Generation (NCC-DITY002-016)

### DIFF
--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -87,7 +87,7 @@ impl Identity for Secp256k1Identity {
             .map_err(|err| format!("Cannot create secp256k1 signature: {}", err))?;
         let r = ecdsa_sig.r().as_ref().to_bytes();
         let s = ecdsa_sig.s().as_ref().to_bytes();
-        let mut bytes = [0; 64];
+        let mut bytes = [0u8; 64];
         if r.len() > 32 || s.len() > 64 {
             return Err(format!(
                 "Cannot create secp256k1 signature: {}",

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -89,10 +89,7 @@ impl Identity for Secp256k1Identity {
         let s = ecdsa_sig.s().as_ref().to_bytes();
         let mut bytes = [0u8; 64];
         if r.len() > 32 || s.len() > 64 {
-            return Err(format!(
-                "Cannot create secp256k1 signature: {}",
-                "signature too long."
-            ));
+            return Err("Cannot create secp256k1 signature: malformed signature.".to_string());
         }
         bytes[(32 - r.len())..32].clone_from_slice(&r);
         bytes[(64 - s.len())..64].clone_from_slice(&s);

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -88,6 +88,12 @@ impl Identity for Secp256k1Identity {
         let r = ecdsa_sig.r().as_ref().to_bytes();
         let s = ecdsa_sig.s().as_ref().to_bytes();
         let mut bytes = [0; 64];
+        if r.len() > 32 || s.len() > 64 {
+            return Err(format!(
+                "Cannot create secp256k1 signature: {}",
+                "signature too long."
+            ));
+        }
         bytes[(32 - r.len())..32].clone_from_slice(&r);
         bytes[(64 - s.len())..64].clone_from_slice(&s);
         let signature = Some(bytes.to_vec());


### PR DESCRIPTION
# Description

from SDK Cryptography Review done by NCC (issue identifier: NCC-DITY002-016)
> An ECDSA signature over a 256-bit curve consists of a pair of values (r, s), each 32 bytes
in length. The sign() function in secp256k1.rs implements such signature generation for
Secp256k1Identity leveraging OpenSSL’s EcdsaSig::sign() function:
> The values r and s are concatenated and passed on for encoding. The highlighted lines
compute array offsets based on the length of r and s, and may cause this function to panic if
the length of r or s is greater than 32 bytes (due to negative index), or to silently proceed with
incorrect data if either is less than 32 bytes. These values are generated by OpenSSL, and will
almost certainly be the expected lengths if the signing operation is successful; however, the
code proceeds to compute indexes based on the returned lengths, rather than assuming or
verifying the lengths are correct.
> In general, it is safest to validate sensitive parameters before relying on them. If the behavior
of the external library changes, or the library is replaced in the future, potential issues will be
explicitly detected by such checks.
> It was also observed that the array bytes is instantiated with the value `0`, which
defaults to `i32` in Rust, when the intended datatype appears to be `u8`.


Fixes [SDK-468](https://dfinity.atlassian.net/browse/SDK-468)

# How Has This Been Tested?

`cargo test`

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly. **(not sure if its needed in this case)**
- [ ] I have made corresponding changes to the documentation. **(no changes required)**
