### PR TITLE
fix: add repository links to cargo manifest

### DIFF
--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 description = "Agent library to communicate with the Internet Computer, following the Public Specification."
 homepage = "https://docs.rs/ic-agent"
 documentation = "https://docs.rs/ic-agent"
+repository = "https://github.com/dfinity/agent-rs"
 license = "Apache-2.0"
 readme = "README.md"
 categories = ["api-bindings", "data-structures", "no-std"]

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 description = "Library for storing files in an asset canister."
 homepage = "https://docs.rs/ic-asset"
 documentation = "https://docs.rs/ic-asset"
+repository = "https://github.com/dfinity/agent-rs"
 license = "Apache-2.0"
 readme = "README.md"
 categories = ["api-bindings", "data-structures"]

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Identity implementation for HSM for the ic-agent package."
 homepage = "https://docs.rs/ic-identity-hsm"
 documentation = "https://docs.rs/ic-identity-hsm"
+repository = "https://github.com/dfinity/agent-rs"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 description = "Collection of utilities for Rust, on top of ic-agent, to communicate with the Internet Computer, following the Public Specification."
 homepage = "https://docs.rs/ic-utils"
 documentation = "https://docs.rs/ic-utils"
+repository = "https://github.com/dfinity/agent-rs"
 license = "Apache-2.0"
 readme = "README.md"
 categories = ["api-bindings", "data-structures", "no-std"]

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 description = "CLI tool to manage assets on an asset canister on the Internet Computer."
 homepage = "https://docs.rs/icx-asset"
 documentation = "https://docs.rs/icx-asset"
+repository = "https://github.com/dfinity/agent-rs"
 license = "Apache-2.0"
 readme = "README.md"
 categories = ["command-line-interface"]

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 description = "CLI tool to download a document from the Internet Computer and pretty-print the contents of its IC-Certificate header."
 homepage = "https://docs.rs/icx-cert"
 documentation = "https://docs.rs/icx-cert"
+repository = "https://github.com/dfinity/agent-rs"
 license = "Apache-2.0"
 readme = "README.md"
 categories = ["command-line-interface"]

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 description = "CLI tool to call canisters on the Internet Computer."
 homepage = "https://docs.rs/icx"
 documentation = "https://docs.rs/icx"
+repository = "https://github.com/dfinity/agent-rs"
 license = "Apache-2.0"
 readme = "README.md"
 categories = ["command-line-interface", "web-programming::http-client"]


### PR DESCRIPTION
So that crates.io links to the repo