### PR TITLE
feat: support for asset canister config files in `ic-assets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Added support for asset canister config files in `ic-assets`.
 - reads configuration from `.ic-assets.json` config files if placed inside assets directory, multiple config files can be used (nested in subdirectories)
 - runs successfully only if the config file is right format (valid JSON, valid glob pattern, JSON fields in correct format)
+- exmaple of `.ic-assets.json` file format 
+  ```
+  [
+      {
+          "match": "*",
+          "cache": {
+              "max_age": 20
+          },
+          "headers": {
+              "Access-Control-Allow-Origin": "*"
+          }
+      }
+  ]
+  ```
 
 ## [0.18.0] - 2022-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,11 @@ Added support for asset canister config files in `ic-assets`.
           "match": "*",
           "cache": {
               "max_age": 20
-          },
-          "headers": {
-              "Access-Control-Allow-Origin": "*"
           }
       }
   ]
   ```
 - works only during asset creation
-- currently, only `cache.max_age` field actually makes it to the asset canister (support for the `headers` is still in progress)
 - the config file is being taken into account only when calling `ic_asset::sync` (i.e. `dfx deploy` or `icx-asset sync`)
 
 ## [0.18.0] - 2022-06-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Added support for asset canister config files in `ic-assets`.
+- reads configuration from `.ic-assets.json` config files if placed inside assets directory, multiple config files can be used (nested in subdirectories)
+- runs successfully only if the config file is right format (valid JSON, valid glob pattern, JSON fields in correct format)
+
 ## [0.18.0] - 2022-06-23
 
 Breaking change: ic-asset::sync() now synchronizes from multiple source directories.
@@ -20,8 +24,6 @@ Also, ic-asset::sync:
 ## [0.17.1] - 2022-06-22
 
 [agent-rs/349](https://github.com/dfinity/agent-rs/pull/349) feat: add with_max_response_body_size to ReqwestHttpReplicaV2Transport
-
-Added support for asset canister config files in `ic-assets`.
 
 ## [0.17.0] - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Added support for asset canister config files in `ic-assets`.
 - reads configuration from `.ic-assets.json` config files if placed inside assets directory, multiple config files can be used (nested in subdirectories)
 - runs successfully only if the config file is right format (valid JSON, valid glob pattern, JSON fields in correct format)
-- exmaple of `.ic-assets.json` file format 
+- example of `.ic-assets.json` file format:
   ```
   [
       {
@@ -24,6 +24,9 @@ Added support for asset canister config files in `ic-assets`.
       }
   ]
   ```
+- works only during asset creation
+- currently, only `cache.max_age` field actually makes it to the asset canister (support for the `headers` is still in progress)
+- the config file is being taken into account only when calling `ic_asset::sync` (i.e. `dfx deploy` or `icx-asset sync`)
 
 ## [0.18.0] - 2022-06-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +980,7 @@ version = "0.17.1"
 dependencies = [
  "anyhow",
  "candid",
+ "derivative",
  "flate2",
  "futures",
  "futures-intrusive",

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -126,7 +126,7 @@ icx_asset_list() {
     echo "b_duplicate_contents" >multiple/b/duplicate
 
     assert_command_fail icx_asset_sync multiple/a multiple/b
-    assert_match "Asset with key '/duplicate' defined at $(pwd)/multiple/b/duplicate and $(pwd)/multiple/a/duplicate"
+    assert_match "Asset with key '/duplicate' defined at [^\0]+/multiple/b/duplicate and [^\0]+/multiple/a/duplicate"
 }
 
 @test "ignores filenames and directories starting with a dot" {

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -126,7 +126,7 @@ icx_asset_list() {
     echo "b_duplicate_contents" >multiple/b/duplicate
 
     assert_command_fail icx_asset_sync multiple/a multiple/b
-    assert_match "Asset with key '/duplicate' defined at [^\0]+/multiple/b/duplicate and [^\0]+/multiple/a/duplicate"
+    assert_match "Asset with key '/duplicate' defined at $(pwd)/multiple/b/duplicate and $(pwd)/multiple/a/duplicate"
 }
 
 @test "ignores filenames and directories starting with a dot" {

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -126,7 +126,7 @@ icx_asset_list() {
     echo "b_duplicate_contents" >multiple/b/duplicate
 
     assert_command_fail icx_asset_sync multiple/a multiple/b
-    assert_match "Asset with key '/duplicate' defined at $(pwd)/multiple/b/duplicate and $(pwd)/multiple/a/duplicate"
+    assert_match "Error: Asset with key '/duplicate' defined at [^\0]+/multiple/b/duplicate and [^\0]+/multiple/a/duplicate"
 }
 
 @test "ignores filenames and directories starting with a dot" {

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -126,7 +126,7 @@ icx_asset_list() {
     echo "b_duplicate_contents" >multiple/b/duplicate
 
     assert_command_fail icx_asset_sync multiple/a multiple/b
-    assert_match "Error: Asset with key '/duplicate' defined at [^\0]+/multiple/b/duplicate and [^\0]+/multiple/a/duplicate"
+    assert_match "[^\0]+Asset with key [^\0]+ defined at [^\0]+"
 }
 
 @test "ignores filenames and directories starting with a dot" {

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -126,7 +126,7 @@ icx_asset_list() {
     echo "b_duplicate_contents" >multiple/b/duplicate
 
     assert_command_fail icx_asset_sync multiple/a multiple/b
-    assert_match "Asset with key '/duplicate' defined at multiple/b/duplicate and multiple/a/duplicate"
+    assert_match "Asset with key '/duplicate' defined at $(pwd)/multiple/b/duplicate and $(pwd)/multiple/a/duplicate"
 }
 
 @test "ignores filenames and directories starting with a dot" {

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -126,7 +126,7 @@ icx_asset_list() {
     echo "b_duplicate_contents" >multiple/b/duplicate
 
     assert_command_fail icx_asset_sync multiple/a multiple/b
-    assert_match ".*Asset with key '/duplicate' defined at .*/e2e_project/multiple/b/duplicate and .*/e2e_project/multiple/a/duplicate"
+    assert_match "Asset with key '/duplicate' defined at .*/e2e_project/multiple/b/duplicate and .*/e2e_project/multiple/a/duplicate"
 }
 
 @test "ignores filenames and directories starting with a dot" {

--- a/e2e/bash/icx-asset.bash
+++ b/e2e/bash/icx-asset.bash
@@ -126,7 +126,7 @@ icx_asset_list() {
     echo "b_duplicate_contents" >multiple/b/duplicate
 
     assert_command_fail icx_asset_sync multiple/a multiple/b
-    assert_match "[^\0]+Asset with key [^\0]+ defined at [^\0]+"
+    assert_match ".*Asset with key '/duplicate' defined at .*/e2e_project/multiple/b/duplicate and .*/e2e_project/multiple/a/duplicate"
 }
 
 @test "ignores filenames and directories starting with a dot" {

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -34,6 +34,7 @@ serde_bytes = "0.11.2"
 serde_json = "1.0.81"
 sha2 = "0.10"
 walkdir = "2.2.9"
+derivative = "2.2.0"
 
 [dev-dependencies]
 mockito = "0.31.0"

--- a/ic-asset/src/asset_canister/protocol.rs
+++ b/ic-asset/src/asset_canister/protocol.rs
@@ -70,7 +70,7 @@ pub struct CreateAssetArguments {
     /// The MIME type of this asset
     pub content_type: String,
     /// The cache HTTP header Time To Live parameter
-    pub max_age: u64,
+    pub max_age: Option<u64>,
     // TODO: (SDK-473) serde_json::Value is not serializable into CandidType
     // /// The HTTP headers
     // pub headers: HeadersConfig,

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -71,23 +71,19 @@ impl AssetConfigFile {
         let mut file = File::open(filepath)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
-        match serde_json::from_str::<Vec<AssetConfigRule>>(&contents) {
-            Ok(mut config_maps) => {
-                config_maps.iter_mut().for_each(|c| {
-                    let glob_pattern = format!(
-                        "{}/{}",
-                        filepath.parent().unwrap().to_str().unwrap(),
-                        &c.r#match
-                    );
-                    c.r#match = glob_pattern;
-                });
-                Ok(Self {
-                    rules: config_maps,
-                    filepath: filepath.to_path_buf(),
-                })
-            }
-            Err(e) => Err(e.into()),
-        }
+        let mut rules = serde_json::from_str::<Vec<AssetConfigRule>>(&contents)?;
+        rules.iter_mut().for_each(|c| {
+            let glob_pattern = format!(
+                "{}/{}",
+                filepath.parent().unwrap().to_str().unwrap(),
+                &c.r#match
+            );
+            c.r#match = glob_pattern;
+        });
+        Ok(Self {
+            rules,
+            filepath: filepath.to_path_buf(),
+        })
     }
 }
 

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -213,7 +213,7 @@ mod with_tempdir {
 
     use super::*;
     use std::io::Write;
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     use std::os::unix::prelude::PermissionsExt;
     use std::{collections::BTreeMap, fs::File};
     use tempfile::{Builder, TempDir};
@@ -579,7 +579,7 @@ mod with_tempdir {
         Ok(())
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     #[test]
     fn no_read_permission() -> anyhow::Result<()> {
         let cfg = Some(HashMap::from([(

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -183,11 +183,12 @@ impl AssetConfigTreeNode {
             }
         }
 
-        let parent_ref = if rules.is_empty() && parent.is_some() {
-            parent.unwrap()
-        } else {
-            let config_tree = Self { parent, rules };
-            Arc::new(config_tree)
+        let parent_ref = match parent {
+            Some(p) if rules.is_empty() => p,
+            _ => {
+                let config_tree = Self { parent, rules };
+                Arc::new(config_tree)
+            }
         };
 
         configs.insert(dir.to_path_buf(), parent_ref.clone());

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -180,8 +180,13 @@ impl AssetConfigTreeNode {
             }
         }
 
-        let config_tree = Self { parent, rules };
-        let parent_ref = Arc::new(config_tree);
+        let parent_ref = if rules.is_empty() && parent.is_some() {
+            parent.unwrap().clone()
+        } else {
+            let config_tree = Self { parent, rules };
+            Arc::new(config_tree)
+        };
+
         configs.insert(dir.to_path_buf(), parent_ref.clone());
         for f in std::fs::read_dir(&dir)
             .with_context(|| format!("Unable to read directory {}", &dir.to_str().unwrap()))?

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -495,6 +495,7 @@ mod with_tempdir {
             (
                 "".to_string(),
                 r#"[
+        {"match": "**/*", "cache": {"max_age": 999}},
         {"match": "nested/**/*", "cache": {"max_age": 900}},
         {"match": "nested/deep/*", "cache": {"max_age": 800}},
         {"match": "nested/**/*.toml","cache": {"max_age": 700}}
@@ -523,7 +524,6 @@ mod with_tempdir {
         let assets_temp_dir = create_temporary_assets_directory(cfg, 7).unwrap();
         let assets_dir = assets_temp_dir.path().canonicalize()?;
 
-        println!("ff");
         let assets_config = dbg!(AssetSourceDirectoryConfiguration::load(&assets_dir))?;
         for f in [
             "index.html",
@@ -534,7 +534,10 @@ mod with_tempdir {
         ] {
             assert_eq!(
                 assets_config.get_asset_config(assets_dir.join(f).as_path())?,
-                AssetConfig::default()
+                AssetConfig {
+                    cache: Some(CacheConfig { max_age: Some(999) }),
+                    ..Default::default()
+                }
             );
         }
 

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -107,8 +107,8 @@ where
 }
 
 impl AssetConfigRule {
-    fn applies(&self, cannonical_path: &Path) -> bool {
-        self.r#match.is_match(cannonical_path)
+    fn applies(&self, canonical_path: &Path) -> bool {
+        self.r#match.is_match(canonical_path)
     }
 }
 

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -74,7 +74,7 @@ impl AssetSourceDirectoryConfiguration {
             bail!("root_dir paramenter is expected to be canonical path")
         }
         let mut config_map = HashMap::new();
-        AssetConfigTreeNode::load(None, &root_dir, &mut config_map)?;
+        AssetConfigTreeNode::load(None, root_dir, &mut config_map)?;
 
         Ok(Self { config_map })
     }

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -55,19 +55,10 @@ pub(crate) struct AssetSourceDirectoryConfiguration {
     config_map: ConfigMap,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize)]
+#[derive(Debug, Default, PartialEq, Eq, Serialize)]
 pub(crate) struct AssetConfig {
     pub(crate) cache: Option<CacheConfig>,
     pub(crate) headers: Option<HeadersConfig>,
-}
-
-impl Default for AssetConfig {
-    fn default() -> Self {
-        Self {
-            headers: None,
-            cache: None,
-        }
-    }
 }
 
 #[derive(Debug, Default)]

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -181,7 +181,7 @@ impl AssetConfigTreeNode {
         }
 
         let parent_ref = if rules.is_empty() && parent.is_some() {
-            parent.unwrap().clone()
+            parent.unwrap()
         } else {
             let config_tree = Self { parent, rules };
             Arc::new(config_tree)

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -213,6 +213,7 @@ mod with_tempdir {
 
     use super::*;
     use std::io::Write;
+    #[cfg(target_os = "linux")]
     use std::os::unix::prelude::PermissionsExt;
     use std::{collections::BTreeMap, fs::File};
     use tempfile::{Builder, TempDir};
@@ -578,6 +579,7 @@ mod with_tempdir {
         Ok(())
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn no_read_permission() -> anyhow::Result<()> {
         let cfg = Some(HashMap::from([(

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -432,61 +432,6 @@ mod with_tempdir {
         Ok(())
     }
 
-    //     #[test]
-    //     fn stringify_different_json_types_in_headers() -> anyhow::Result<()> {
-    //         let cfg = Some(HashMap::from([(
-    //             "".to_string(),
-    //             r#"
-    //         [
-    //           {
-    //             "match": "*",
-    //             "headers": {
-    //                 "map": {"homepage": "https://internetcomputer.org"},
-    //                 "null": null,
-    //                 "number": 3.14,
-    //                 "number-int": 888,
-    //                 "string": "well",
-    //                 "bool": true,
-    //                 "array": ["a", "b", "c"]
-    //             }
-    //           }
-    //         ]
-    //         "#
-    //             .to_string(),
-    //         )]));
-    //         let assets_temp_dir = create_temporary_assets_directory(cfg, 1).unwrap();
-    //         let assets_dir = assets_temp_dir.path();
-    //         let assets_config = AssetSourceDirectoryConfiguration::load(assets_dir)?;
-    //         let asset_config = assets_config.get_asset_config(assets_dir.join("index.html").as_path());
-
-    //         assert_eq!(
-    //             serde_json::to_string_pretty(&asset_config)?,
-    //             String::from(
-    //                 r#"{
-    //   "cache": {
-    //     "max_age": 0
-    //   },
-    //   "headers": {
-    //     "null": null,
-    //     "bool": true,
-    //     "map": {
-    //       "homepage": "https://internetcomputer.org"
-    //     },
-    //     "number": 3.14,
-    //     "number-int": 888,
-    //     "array": [
-    //       "a",
-    //       "b",
-    //       "c"
-    //     ],
-    //     "string": "well"
-    //   }
-    // }"#
-    //             )
-    //         );
-    //         Ok(())
-    //     }
-
     #[test]
     fn prioritization() -> anyhow::Result<()> {
         // 1. the most deeply nested config file takes precedens over the one in parent dir

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -17,7 +17,7 @@ type ConfigMap = HashMap<PathBuf, Arc<AssetConfigTreeNode>>;
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct CacheConfig {
-    pub(crate) max_age: u64,
+    pub(crate) max_age: Option<u64>,
 }
 
 #[derive(Derivative)]
@@ -275,7 +275,7 @@ mod with_tempdir {
             assert_eq!(
                 assets_config.get_asset_config(assets_dir.join(f).as_path())?,
                 AssetConfig {
-                    cache: Some(CacheConfig { max_age: 333 }),
+                    cache: Some(CacheConfig { max_age: Some(333) }),
                     ..Default::default()
                 }
             );
@@ -316,7 +316,7 @@ mod with_tempdir {
             assert_eq!(
                 assets_config.get_asset_config(assets_dir.join(f).as_path())?,
                 AssetConfig {
-                    cache: Some(CacheConfig { max_age: 111 }),
+                    cache: Some(CacheConfig { max_age: Some(111) }),
                     ..Default::default()
                 }
             );
@@ -331,7 +331,7 @@ mod with_tempdir {
             assert_eq!(
                 assets_config.get_asset_config(assets_dir.join(f).as_path())?,
                 AssetConfig {
-                    cache: Some(CacheConfig { max_age: 333 }),
+                    cache: Some(CacheConfig { max_age: Some(333) }),
                     ..Default::default()
                 }
             );
@@ -390,7 +390,7 @@ mod with_tempdir {
         let parsed_asset_config =
             assets_config.get_asset_config(assets_dir.join("index.html").as_path())?;
         let expected_asset_config = AssetConfig {
-            cache: Some(CacheConfig { max_age: 88 }),
+            cache: Some(CacheConfig { max_age: Some(88) }),
             headers: Some(HashMap::from([
                 (
                     "x-content-type-options".to_string(),
@@ -539,7 +539,7 @@ mod with_tempdir {
         assert_eq!(
             assets_config.get_asset_config(assets_dir.join("nested/the-thing.txt").as_path())?,
             AssetConfig {
-                cache: Some(CacheConfig { max_age: 400 }),
+                cache: Some(CacheConfig { max_age: Some(400) }),
                 ..Default::default()
             },
         );
@@ -547,7 +547,7 @@ mod with_tempdir {
             assets_config
                 .get_asset_config(assets_dir.join("nested/deep/the-next-thing.toml").as_path())?,
             AssetConfig {
-                cache: Some(CacheConfig { max_age: 100 }),
+                cache: Some(CacheConfig { max_age: Some(100) }),
                 ..Default::default()
             },
         );

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{bail, Context};
 use derivative::Derivative;
 use globset::{Glob, GlobMatcher};
 use serde::{Deserialize, Serialize};
@@ -68,9 +68,12 @@ struct AssetConfigTreeNode {
 }
 
 impl AssetSourceDirectoryConfiguration {
+    /// Constructs config tree for assets directory.
     pub(crate) fn load(root_dir: &Path) -> anyhow::Result<Self> {
+        if !root_dir.has_root() {
+            bail!("root_dir paramenter is expected to be canonical path")
+        }
         let mut config_map = HashMap::new();
-        let root_dir = root_dir.canonicalize()?;
         AssetConfigTreeNode::load(None, &root_dir, &mut config_map)?;
 
         Ok(Self { config_map })

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -79,7 +79,7 @@ struct AssetConfigTreeNode {
 impl AssetSourceDirectoryConfiguration {
     pub(crate) fn load(root_dir: &Path) -> anyhow::Result<Self> {
         let mut config_map = HashMap::new();
-        AssetConfigTreeNode::load(None, &root_dir, &mut config_map)?;
+        AssetConfigTreeNode::load(None, root_dir, &mut config_map)?;
         Ok(Self { config_map })
     }
 
@@ -191,7 +191,7 @@ impl AssetConfigTreeNode {
 
     fn get_config(&self, canonical_path: &Path) -> AssetConfig {
         let base_config = match &self.parent {
-            Some(parent) => parent.get_config(&canonical_path),
+            Some(parent) => parent.get_config(canonical_path),
             None => AssetConfig::default(),
         };
         self.rules
@@ -416,7 +416,7 @@ mod with_tempdir {
                 ),
                 (
                     "x-xss-protection".to_string(),
-                    Number(serde_json::Number::from(1).into()),
+                    Number(serde_json::Number::from(1)),
                 ),
             ])),
         };

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -199,7 +199,7 @@ impl AssetConfigTreeNode {
         let parent_ref = Arc::new(config_tree);
         configs.insert(dir.to_path_buf(), parent_ref.clone());
         for f in std::fs::read_dir(&dir)
-            .unwrap()
+            .with_context(|| format!("Unable to read directory {:?}", &dir))?
             .filter_map(|x| x.ok())
             .filter(|x| x.file_type().unwrap().is_dir())
         {

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -55,7 +55,7 @@ pub(crate) struct AssetSourceDirectoryConfiguration {
     config_map: ConfigMap,
 }
 
-#[derive(Debug, Default, PartialEq, Eq, Serialize)]
+#[derive(Debug, Default, PartialEq, Eq, Serialize, Clone)]
 pub(crate) struct AssetConfig {
     pub(crate) cache: Option<CacheConfig>,
     pub(crate) headers: Option<HeadersConfig>,

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -21,7 +21,7 @@ thread_local! {
 }
 
 pub(crate) type HeadersConfig = HashMap<String, Value>;
-type Map = HashMap<PathBuf, Arc<AssetConfigTreeNode>>;
+type ConfigMap = HashMap<PathBuf, Arc<AssetConfigTreeNode>>;
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct CacheConfig {
@@ -104,7 +104,7 @@ impl AssetConfigRule {
 
 #[derive(Debug)]
 pub(crate) struct AssetSourceDirectoryConfiguration {
-    config_map: Map,
+    config_map: ConfigMap,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize)]

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -77,17 +77,21 @@ impl AssetSourceDirectoryConfiguration {
     }
 
     pub(crate) fn get_asset_config(&self, canonical_path: &Path) -> anyhow::Result<AssetConfig> {
-        let parent_dir = canonical_path.parent().context(format!(
-            "unable to get the parent directory for asset path: {:?}",
-            canonical_path
-        ))?;
+        let parent_dir = canonical_path.parent().with_context(|| {
+            format!(
+                "unable to get the parent directory for asset path: {:?}",
+                canonical_path
+            )
+        })?;
         Ok(self
             .config_map
             .get(parent_dir)
-            .context(format!(
-                "unable to find default config for following path: {:?}",
-                parent_dir
-            ))?
+            .with_context(|| {
+                format!(
+                    "unable to find default config for following path: {:?}",
+                    parent_dir
+                )
+            })?
             .get_config(canonical_path))
     }
 }
@@ -134,9 +138,9 @@ impl AssetConfigRule {
             config_file_parent_dir
                 .join(&r#match)
                 .to_str()
-                .context(format!("{} is not a valid glob pattern", r#match))?,
+                .with_context(|| format!("{} is not a valid glob pattern", r#match))?,
         )
-        .context(format!("{} is not a valid glob pattern", r#match))?
+        .with_context(|| format!("{} is not a valid glob pattern", r#match))?
         .compile_matcher();
         Ok(Self {
             r#match: glob,

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -181,9 +181,9 @@ impl AssetConfigTreeNode {
         let parent_ref = Arc::new(config_tree);
         configs.insert(dir.to_path_buf(), parent_ref.clone());
         for f in std::fs::read_dir(&dir)
-            .with_context(|| format!("Unable to read directory {:?}", &dir))?
+            .with_context(|| format!("Unable to read directory {}", &dir.to_str().unwrap()))?
             .filter_map(|x| x.ok())
-            .filter(|x| x.file_type().unwrap().is_dir())
+            .filter(|x| x.file_type().map_or_else(|_e| false, |ft| ft.is_dir()))
         {
             Self::load(Some(parent_ref.clone()), &f.path(), configs)?;
         }

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -116,8 +116,8 @@ pub(crate) struct AssetConfig {
 impl Default for AssetConfig {
     fn default() -> Self {
         Self {
-            headers: Some(HashMap::new()),
-            cache: Some(CacheConfig::default()),
+            headers: None,
+            cache: None,
         }
     }
 }
@@ -286,7 +286,7 @@ mod with_tempdir {
                 assets_config.get_asset_config(assets_dir.join(f).as_path())?,
                 AssetConfig {
                     cache: Some(CacheConfig { max_age: 333 }),
-                    headers: Some(HashMap::new()),
+                    ..Default::default()
                 }
             );
         }
@@ -327,7 +327,7 @@ mod with_tempdir {
                 assets_config.get_asset_config(assets_dir.join(f).as_path())?,
                 AssetConfig {
                     cache: Some(CacheConfig { max_age: 111 }),
-                    headers: Some(HashMap::new()),
+                    ..Default::default()
                 }
             );
         }

--- a/ic-asset/src/http_headers_config.rs
+++ b/ic-asset/src/http_headers_config.rs
@@ -531,11 +531,18 @@ mod with_tempdir {
         let assets_temp_dir = create_temporary_assets_directory(cfg, 1).unwrap();
         let assets_dir = assets_temp_dir.path();
         let x = AssetsConfigMatcher::new(assets_dir).get_config().unwrap();
+        let tested = serde_json::to_string_pretty(&x).unwrap();
+
+        let filepath = tested
+            .lines()
+            .filter(|l| l.contains("\"filepath\": "))
+            .next()
+            .unwrap();
         assert_eq!(
-            serde_json::to_string_pretty(&x).unwrap(),
+            tested,
             r#"[
   {
-    "filepath": "{{path}}/index.html",
+{{filepath}}
     "relative_filepath": "index.html",
     "cache": null,
     "headers": {
@@ -563,7 +570,7 @@ mod with_tempdir {
   }
 ]"#
             .to_string()
-            .replace("{{path}}", assets_dir.to_str().unwrap())
+            .replace("{{filepath}}", filepath)
         );
         Ok(())
     }

--- a/ic-asset/src/http_headers_config.rs
+++ b/ic-asset/src/http_headers_config.rs
@@ -250,7 +250,7 @@ impl AssetsConfigMatcher {
                             })
                         }
                     } else {
-                        eprintln!(
+                        println!(
                             "malformed glob pattern '{}' in {:?}",
                             &configuration.r#match, cfg_file.filepath
                         );
@@ -337,7 +337,6 @@ mod with_tempdir {
         }
     }
 
-    // ---
     #[test]
     fn match_only_nested_files() -> anyhow::Result<()> {
         let cfg = HashMap::from([(
@@ -346,30 +345,32 @@ mod with_tempdir {
         )]);
         let assets_temp_dir = create_temporary_assets_directory(Some(cfg), 7).unwrap();
         let assets_dir = assets_temp_dir.path();
-        assert_eq!(
-            AssetsConfigMatcher::new(assets_dir).get_config()?,
-            vec![
-                AssetConfig::test_default_with_path(assets_dir, "index.html"),
-                AssetConfig::test_default_with_path(assets_dir, "css/main.css"),
-                AssetConfig::test_default_with_path(assets_dir, "css/stylish.css"),
-                AssetConfig::test_default_with_path(assets_dir, "js/index.js"),
-                AssetConfig::test_default_with_path(assets_dir, "js/index.map.js"),
-                AssetConfig {
-                    filepath: assets_dir.join("nested/the-thing.txt"),
-                    relative_filepath: PathBuf::from_str("nested/the-thing.txt").unwrap(),
-                    cache: Some(CacheConfig { max_age: 333 }),
-                    ..Default::default()
-                },
-                AssetConfig {
-                    filepath: assets_dir.join("nested/deep/the-next-thing.toml"),
-                    relative_filepath: PathBuf::from_str("nested/deep/the-next-thing.toml")
-                        .unwrap(),
-                    cache: Some(CacheConfig { max_age: 333 }),
-                    ..Default::default()
-                },
-            ]
-        );
-        assets_temp_dir.close().unwrap();
+
+        let mut tested = AssetsConfigMatcher::new(assets_dir).get_config()?;
+        let mut expected = vec![
+            AssetConfig::test_default_with_path(assets_dir, "index.html"),
+            AssetConfig::test_default_with_path(assets_dir, "css/main.css"),
+            AssetConfig::test_default_with_path(assets_dir, "css/stylish.css"),
+            AssetConfig::test_default_with_path(assets_dir, "js/index.js"),
+            AssetConfig::test_default_with_path(assets_dir, "js/index.map.js"),
+            AssetConfig {
+                filepath: assets_dir.join("nested/the-thing.txt"),
+                relative_filepath: PathBuf::from_str("nested/the-thing.txt").unwrap(),
+                cache: Some(CacheConfig { max_age: 333 }),
+                ..Default::default()
+            },
+            AssetConfig {
+                filepath: assets_dir.join("nested/deep/the-next-thing.toml"),
+                relative_filepath: PathBuf::from_str("nested/deep/the-next-thing.toml").unwrap(),
+                cache: Some(CacheConfig { max_age: 333 }),
+                ..Default::default()
+            },
+        ];
+        tested.sort_by_key(|c| c.filepath.clone());
+        expected.sort_by_key(|c| c.filepath.clone());
+
+        assert_eq!(tested, expected);
+
         Ok(())
     }
 
@@ -387,54 +388,57 @@ mod with_tempdir {
         ]));
         let assets_temp_dir = create_temporary_assets_directory(cfg, 7).unwrap();
         let assets_dir = assets_temp_dir.path();
-        assert_eq!(
-            AssetsConfigMatcher::new(assets_dir).get_config()?,
-            vec![
-                AssetConfig {
-                    filepath: assets_dir.join("index.html"),
-                    relative_filepath: PathBuf::from_str("index.html").unwrap(),
-                    cache: Some(CacheConfig { max_age: 333 },),
-                    ..Default::default()
-                },
-                AssetConfig {
-                    filepath: assets_dir.join("css/main.css"),
-                    relative_filepath: PathBuf::from_str("css/main.css").unwrap(),
-                    cache: Some(CacheConfig { max_age: 333 },),
-                    ..Default::default()
-                },
-                AssetConfig {
-                    filepath: assets_dir.join("css/stylish.css"),
-                    relative_filepath: PathBuf::from_str("css/stylish.css").unwrap(),
-                    cache: Some(CacheConfig { max_age: 333 },),
-                    ..Default::default()
-                },
-                AssetConfig {
-                    filepath: assets_dir.join("js/index.js"),
-                    relative_filepath: PathBuf::from_str("js/index.js").unwrap(),
-                    cache: Some(CacheConfig { max_age: 333 },),
-                    ..Default::default()
-                },
-                AssetConfig {
-                    filepath: assets_dir.join("js/index.map.js"),
-                    relative_filepath: PathBuf::from_str("js/index.map.js").unwrap(),
-                    cache: Some(CacheConfig { max_age: 333 },),
-                    ..Default::default()
-                },
-                AssetConfig {
-                    filepath: assets_dir.join("nested/the-thing.txt"),
-                    relative_filepath: PathBuf::from_str("nested/the-thing.txt").unwrap(),
-                    cache: Some(CacheConfig { max_age: 111 },),
-                    ..Default::default()
-                },
-                AssetConfig {
-                    filepath: assets_dir.join("nested/deep/the-next-thing.toml"),
-                    relative_filepath: PathBuf::from_str("nested/deep/the-next-thing.toml")
-                        .unwrap(),
-                    cache: Some(CacheConfig { max_age: 111 },),
-                    ..Default::default()
-                },
-            ],
-        );
+
+        let mut tested = AssetsConfigMatcher::new(assets_dir).get_config()?;
+        let mut expected = vec![
+            AssetConfig {
+                filepath: assets_dir.join("index.html"),
+                relative_filepath: PathBuf::from_str("index.html").unwrap(),
+                cache: Some(CacheConfig { max_age: 333 }),
+                ..Default::default()
+            },
+            AssetConfig {
+                filepath: assets_dir.join("css/main.css"),
+                relative_filepath: PathBuf::from_str("css/main.css").unwrap(),
+                cache: Some(CacheConfig { max_age: 333 }),
+                ..Default::default()
+            },
+            AssetConfig {
+                filepath: assets_dir.join("css/stylish.css"),
+                relative_filepath: PathBuf::from_str("css/stylish.css").unwrap(),
+                cache: Some(CacheConfig { max_age: 333 }),
+                ..Default::default()
+            },
+            AssetConfig {
+                filepath: assets_dir.join("js/index.js"),
+                relative_filepath: PathBuf::from_str("js/index.js").unwrap(),
+                cache: Some(CacheConfig { max_age: 333 }),
+                ..Default::default()
+            },
+            AssetConfig {
+                filepath: assets_dir.join("js/index.map.js"),
+                relative_filepath: PathBuf::from_str("js/index.map.js").unwrap(),
+                cache: Some(CacheConfig { max_age: 333 }),
+                ..Default::default()
+            },
+            AssetConfig {
+                filepath: assets_dir.join("nested/the-thing.txt"),
+                relative_filepath: PathBuf::from_str("nested/the-thing.txt").unwrap(),
+                cache: Some(CacheConfig { max_age: 111 }),
+                ..Default::default()
+            },
+            AssetConfig {
+                filepath: assets_dir.join("nested/deep/the-next-thing.toml"),
+                relative_filepath: PathBuf::from_str("nested/deep/the-next-thing.toml").unwrap(),
+                cache: Some(CacheConfig { max_age: 111 }),
+                ..Default::default()
+            },
+        ];
+        tested.sort_by_key(|c| c.filepath.clone());
+        expected.sort_by_key(|c| c.filepath.clone());
+
+        assert_eq!(tested, expected);
+
         Ok(())
     }
 
@@ -599,30 +603,32 @@ mod with_tempdir {
         ]));
         let assets_temp_dir = create_temporary_assets_directory(cfg, 7).unwrap();
         let assets_dir = assets_temp_dir.path();
-        assert_eq!(
-            AssetsConfigMatcher::new(assets_dir).get_config()?,
-            vec![
-                AssetConfig::test_default_with_path(assets_dir, "index.html"),
-                AssetConfig::test_default_with_path(assets_dir, "css/main.css"),
-                AssetConfig::test_default_with_path(assets_dir, "css/stylish.css"),
-                AssetConfig::test_default_with_path(assets_dir, "js/index.js"),
-                AssetConfig::test_default_with_path(assets_dir, "js/index.map.js"),
-                AssetConfig {
-                    filepath: assets_dir.join("nested/the-thing.txt"),
-                    relative_filepath: PathBuf::from_str("nested/the-thing.txt").unwrap(),
-                    cache: Some(CacheConfig { max_age: 400 }),
-                    ..Default::default()
-                },
-                AssetConfig {
-                    filepath: assets_dir.join("nested/deep/the-next-thing.toml"),
-                    relative_filepath: PathBuf::from_str("nested/deep/the-next-thing.toml")
-                        .unwrap(),
-                    cache: Some(CacheConfig { max_age: 100 }),
-                    ..Default::default()
-                },
-            ]
-        );
-        assets_temp_dir.close().unwrap();
+
+        let mut tested = AssetsConfigMatcher::new(assets_dir).get_config()?;
+        let mut expected = vec![
+            AssetConfig::test_default_with_path(assets_dir, "index.html"),
+            AssetConfig::test_default_with_path(assets_dir, "css/main.css"),
+            AssetConfig::test_default_with_path(assets_dir, "css/stylish.css"),
+            AssetConfig::test_default_with_path(assets_dir, "js/index.js"),
+            AssetConfig::test_default_with_path(assets_dir, "js/index.map.js"),
+            AssetConfig {
+                filepath: assets_dir.join("nested/the-thing.txt"),
+                relative_filepath: PathBuf::from_str("nested/the-thing.txt").unwrap(),
+                cache: Some(CacheConfig { max_age: 400 }),
+                ..Default::default()
+            },
+            AssetConfig {
+                filepath: assets_dir.join("nested/deep/the-next-thing.toml"),
+                relative_filepath: PathBuf::from_str("nested/deep/the-next-thing.toml").unwrap(),
+                cache: Some(CacheConfig { max_age: 100 }),
+                ..Default::default()
+            },
+        ];
+
+        tested.sort_by_key(|c| c.filepath.clone());
+        expected.sort_by_key(|c| c.filepath.clone());
+
+        assert_eq!(tested, expected);
         Ok(())
     }
 
@@ -637,19 +643,21 @@ mod with_tempdir {
         ]));
         let assets_temp_dir = create_temporary_assets_directory(cfg, 7).unwrap();
         let assets_dir = assets_temp_dir.path();
-        assert_eq!(
-            AssetsConfigMatcher::new(assets_dir).get_config()?,
-            vec![
-                AssetConfig::test_default_with_path(assets_dir, "index.html"),
-                AssetConfig::test_default_with_path(assets_dir, "css/main.css"),
-                AssetConfig::test_default_with_path(assets_dir, "css/stylish.css"),
-                AssetConfig::test_default_with_path(assets_dir, "js/index.js"),
-                AssetConfig::test_default_with_path(assets_dir, "js/index.map.js"),
-                AssetConfig::test_default_with_path(assets_dir, "nested/the-thing.txt"),
-                AssetConfig::test_default_with_path(assets_dir, "nested/deep/the-next-thing.toml"),
-            ]
-        );
-        assets_temp_dir.close().unwrap();
+        let mut tested = AssetsConfigMatcher::new(assets_dir).get_config()?;
+        let mut expected = vec![
+            AssetConfig::test_default_with_path(assets_dir, "index.html"),
+            AssetConfig::test_default_with_path(assets_dir, "css/main.css"),
+            AssetConfig::test_default_with_path(assets_dir, "css/stylish.css"),
+            AssetConfig::test_default_with_path(assets_dir, "js/index.js"),
+            AssetConfig::test_default_with_path(assets_dir, "js/index.map.js"),
+            AssetConfig::test_default_with_path(assets_dir, "nested/the-thing.txt"),
+            AssetConfig::test_default_with_path(assets_dir, "nested/deep/the-next-thing.toml"),
+        ];
+
+        tested.sort_by_key(|c| c.filepath.clone());
+        expected.sort_by_key(|c| c.filepath.clone());
+
+        assert_eq!(tested, expected);
         Ok(())
     }
 }

--- a/ic-asset/src/http_headers_config.rs
+++ b/ic-asset/src/http_headers_config.rs
@@ -535,8 +535,7 @@ mod with_tempdir {
 
         let filepath = tested
             .lines()
-            .filter(|l| l.contains("\"filepath\": "))
-            .next()
+            .find(|l| l.contains("\"filepath\": "))
             .unwrap();
         assert_eq!(
             tested,

--- a/ic-asset/src/lib.rs
+++ b/ic-asset/src/lib.rs
@@ -19,7 +19,7 @@
 //!     .with_canister_id(canister_id)
 //!     .with_agent(&agent)
 //!     .build()?;
-//! ic_asset::sync(&canister, concat!(env!("CARGO_MANIFEST_DIR"), "assets/").as_ref(), Duration::from_secs(60)).await?;
+//! ic_asset::sync(&canister, &[concat!(env!("CARGO_MANIFEST_DIR"), "assets/").as_ref()], Duration::from_secs(60)).await?;
 //! # Ok(())
 //! # }
 

--- a/ic-asset/src/lib.rs
+++ b/ic-asset/src/lib.rs
@@ -31,10 +31,10 @@
 )]
 
 mod asset_canister;
+mod asset_config;
 mod content;
 mod content_encoder;
 mod convenience;
-mod http_headers_config;
 mod operations;
 mod params;
 mod plumbing;

--- a/ic-asset/src/operations.rs
+++ b/ic-asset/src/operations.rs
@@ -56,12 +56,14 @@ pub(crate) fn create_new_assets(
 ) {
     for (key, project_asset) in project_assets {
         if !container_assets.contains_key(key) {
-            let max_age =
-                if let Some(cache_cfg) = project_asset.asset_descriptor.config.cache.as_ref() {
-                    cache_cfg.max_age
-                } else {
-                    None
-                };
+            let max_age = project_asset
+                .asset_descriptor
+                .config
+                .cache
+                .as_ref()
+                .and_then(|c| c.max_age)
+                .map(|c| c);
+
             operations.push(BatchOperationKind::CreateAsset(CreateAssetArguments {
                 key: key.clone(),
                 content_type: project_asset.media_type.to_string(),

--- a/ic-asset/src/operations.rs
+++ b/ic-asset/src/operations.rs
@@ -59,7 +59,13 @@ pub(crate) fn create_new_assets(
             operations.push(BatchOperationKind::CreateAsset(CreateAssetArguments {
                 key: key.clone(),
                 content_type: project_asset.media_type.to_string(),
-                max_age: project_asset.max_age,
+                max_age: project_asset
+                    .asset_descriptor
+                    .config
+                    .cache
+                    .as_ref()
+                    .unwrap() // TODO
+                    .max_age,
                 // headers: project_asset.headers,
             }));
         }

--- a/ic-asset/src/operations.rs
+++ b/ic-asset/src/operations.rs
@@ -61,8 +61,7 @@ pub(crate) fn create_new_assets(
                 .config
                 .cache
                 .as_ref()
-                .and_then(|c| c.max_age)
-                .map(|c| c);
+                .and_then(|c| c.max_age);
 
             operations.push(BatchOperationKind::CreateAsset(CreateAssetArguments {
                 key: key.clone(),

--- a/ic-asset/src/operations.rs
+++ b/ic-asset/src/operations.rs
@@ -56,16 +56,16 @@ pub(crate) fn create_new_assets(
 ) {
     for (key, project_asset) in project_assets {
         if !container_assets.contains_key(key) {
+            let max_age =
+                if let Some(cache_cfg) = project_asset.asset_descriptor.config.cache.as_ref() {
+                    cache_cfg.max_age
+                } else {
+                    None
+                };
             operations.push(BatchOperationKind::CreateAsset(CreateAssetArguments {
                 key: key.clone(),
                 content_type: project_asset.media_type.to_string(),
-                max_age: project_asset
-                    .asset_descriptor
-                    .config
-                    .cache
-                    .as_ref()
-                    .unwrap() // TODO
-                    .max_age,
+                max_age,
                 // headers: project_asset.headers,
             }));
         }

--- a/ic-asset/src/plumbing.rs
+++ b/ic-asset/src/plumbing.rs
@@ -226,7 +226,6 @@ async fn make_project_asset(
 }
 
 pub(crate) async fn make_project_assets(
-    // TODO: i think this is where I should pass the config
     canister_call_params: &CanisterCallParams<'_>,
     batch_id: &Nat,
     locs: Vec<AssetLocation>,

--- a/ic-asset/src/plumbing.rs
+++ b/ic-asset/src/plumbing.rs
@@ -6,6 +6,7 @@ use crate::params::CanisterCallParams;
 
 use crate::asset_canister::chunk::create_chunk;
 use crate::semaphores::Semaphores;
+use anyhow::Context;
 use candid::Nat;
 use futures::future::try_join_all;
 use futures::TryFutureExt;
@@ -216,7 +217,7 @@ async fn make_project_asset(
     )
     .await?;
 
-    let max_age = asset_config.cache.and_then(|cache|cache.max_age);
+    let max_age = asset_config.cache.map(|cache| cache.max_age);
 
     Ok(ProjectAsset {
         asset_location,
@@ -240,6 +241,7 @@ pub(crate) async fn make_project_assets(
         .iter()
         .map(|loc| {
             let asset_config = asset_configs
+                // TODO
                 .get_asset_config(std::path::Path::new("nfnf"))
                 .context("no")
                 .unwrap();

--- a/ic-asset/src/plumbing.rs
+++ b/ic-asset/src/plumbing.rs
@@ -37,9 +37,9 @@ pub(crate) struct ProjectAsset {
     pub(crate) asset_location: AssetLocation,
     pub(crate) media_type: Mime,
     pub(crate) encodings: HashMap<String, ProjectAssetEncoding>,
-    pub(crate) max_age: u64,
+    pub(crate) max_age: Option<u64>,
     #[allow(dead_code)]
-    pub(crate) headers: HeadersConfig,
+    pub(crate) headers: Option<HeadersConfig>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -216,12 +216,18 @@ async fn make_project_asset(
     )
     .await?;
 
+    let max_age = if let Some(cache) = asset_config.cache {
+        Some(cache.max_age)
+    } else {
+        None
+    };
+
     Ok(ProjectAsset {
         asset_location,
         media_type: content.media_type,
         encodings,
-        max_age: asset_config.cache.unwrap_or_default().max_age,
-        headers: asset_config.headers.unwrap_or_default(),
+        max_age,
+        headers: asset_config.headers,
     })
 }
 

--- a/ic-asset/src/plumbing.rs
+++ b/ic-asset/src/plumbing.rs
@@ -1,5 +1,5 @@
 use crate::asset_canister::protocol::AssetDetails;
-use crate::asset_config::{AssetConfig, HeadersConfig};
+use crate::asset_config::{AssetConfig, AssetSourceDirectoryConfiguration, HeadersConfig};
 use crate::content::Content;
 use crate::content_encoder::ContentEncoder;
 use crate::params::CanisterCallParams;
@@ -11,7 +11,7 @@ use futures::future::try_join_all;
 use futures::TryFutureExt;
 use mime::Mime;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 const CONTENT_ENCODING_IDENTITY: &str = "identity";
 
@@ -236,18 +236,14 @@ pub(crate) async fn make_project_assets(
     batch_id: &Nat,
     locs: Vec<AssetLocation>,
     container_assets: &HashMap<String, AssetDetails>,
-    assets_configs: Vec<AssetConfig>,
+    asset_configs: AssetSourceDirectoryConfiguration,
 ) -> anyhow::Result<HashMap<String, ProjectAsset>> {
     let semaphores = Semaphores::new();
 
     let project_asset_futures: Vec<_> = locs
         .iter()
         .map(|loc| {
-            let asset_config = assets_configs
-                .iter()
-                .find(|AssetConfig { filepath, .. }| Path::new(filepath).eq(&loc.source))
-                .unwrap_or(&AssetConfig::default().with_path(&loc.source, &loc.source))
-                .clone();
+            let asset_config = asset_configs.get_asset_config(std::path::Path::new("nfnf"));
 
             make_project_asset(
                 canister_call_params,

--- a/ic-asset/src/plumbing.rs
+++ b/ic-asset/src/plumbing.rs
@@ -1,7 +1,7 @@
 use crate::asset_canister::protocol::AssetDetails;
+use crate::asset_config::{AssetConfig, HeadersConfig};
 use crate::content::Content;
 use crate::content_encoder::ContentEncoder;
-use crate::http_headers_config::{AssetConfig, HeadersConfig};
 use crate::params::CanisterCallParams;
 
 use crate::asset_canister::chunk::create_chunk;

--- a/ic-asset/src/plumbing.rs
+++ b/ic-asset/src/plumbing.rs
@@ -239,7 +239,10 @@ pub(crate) async fn make_project_assets(
     let project_asset_futures: Vec<_> = locs
         .iter()
         .map(|loc| {
-            let asset_config = asset_configs.get_asset_config(std::path::Path::new("nfnf"));
+            let asset_config = asset_configs
+                .get_asset_config(std::path::Path::new("nfnf"))
+                .context("no")
+                .unwrap();
 
             make_project_asset(
                 canister_call_params,

--- a/ic-asset/src/plumbing.rs
+++ b/ic-asset/src/plumbing.rs
@@ -217,7 +217,7 @@ async fn make_project_asset(
     )
     .await?;
 
-    let max_age = asset_config.cache.map(|cache| cache.max_age);
+    let max_age = asset_config.cache.map(|cache| cache.max_age.unwrap()); // TODO
 
     Ok(ProjectAsset {
         asset_location,

--- a/ic-asset/src/plumbing.rs
+++ b/ic-asset/src/plumbing.rs
@@ -216,11 +216,7 @@ async fn make_project_asset(
     )
     .await?;
 
-    let max_age = if let Some(cache) = asset_config.cache {
-        Some(cache.max_age)
-    } else {
-        None
-    };
+    let max_age = asset_config.cache.and_then(|cache|cache.max_age);
 
     Ok(ProjectAsset {
         asset_location,

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -23,8 +23,6 @@ pub async fn sync(
 ) -> anyhow::Result<()> {
     let asset_descriptors = gather_asset_descriptors(dirs)?;
 
-    println!("{:?}", asset_descriptors);
-
     let canister_call_params = CanisterCallParams { canister, timeout };
 
     let container_assets = list_assets(&canister_call_params).await?;

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -24,7 +24,8 @@ pub async fn sync(
     let asset_locations = gather_asset_locations(dirs)?;
 
     println!("{:?}", asset_locations);
-    let configuration = AssetSourceDirectoryConfiguration::load(dir)?;
+    let dirs = Path::new("");
+    let configuration = AssetSourceDirectoryConfiguration::load(dirs)?;
 
     let canister_call_params = CanisterCallParams { canister, timeout };
 

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -69,7 +69,7 @@ fn gather_asset_descriptors(dirs: &[&Path]) -> anyhow::Result<Vec<AssetDescripto
             .filter_entry(|entry| !filename_starts_with_dot(entry))
             .filter_map(|r| {
                 r.ok().filter(|entry| entry.file_type().is_file()).map(|e| {
-                    let source = e.path().canonicalize().unwrap().to_path_buf();
+                    let source = e.path().canonicalize().unwrap();
                     let relative = source.strip_prefix(&dir).expect("cannot strip prefix");
                     let key = String::from("/") + relative.to_string_lossy().as_ref();
                     let config = configuration

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -1,7 +1,7 @@
 use crate::asset_canister::batch::{commit_batch, create_batch};
 use crate::asset_canister::list::list_assets;
 use crate::asset_canister::protocol::{AssetDetails, BatchOperationKind};
-use crate::http_headers_config::AssetsConfigMatcher;
+use crate::asset_config::AssetsConfigMatcher;
 use crate::params::CanisterCallParams;
 
 use crate::operations::{

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -62,7 +62,12 @@ fn filename_starts_with_dot(entry: &walkdir::DirEntry) -> bool {
 fn gather_asset_descriptors(dirs: &[&Path]) -> anyhow::Result<Vec<AssetDescriptor>> {
     let mut asset_descriptors: HashMap<String, AssetDescriptor> = HashMap::new();
     for dir in dirs {
-        let dir = dir.canonicalize().unwrap();
+        let dir = dir.canonicalize().with_context(|| {
+            format!(
+                "unable to canonicalize the following path: {}",
+                dir.display()
+            )
+        })?;
         let configuration = AssetSourceDirectoryConfiguration::load(&dir)?;
         let asset_descriptors_interim = WalkDir::new(&dir)
             .into_iter()

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -7,8 +7,8 @@ use crate::params::CanisterCallParams;
 use crate::operations::{
     create_new_assets, delete_obsolete_assets, set_encodings, unset_obsolete_encodings,
 };
-use crate::plumbing::{make_project_assets, AssetLocation, ProjectAsset};
-use anyhow::bail;
+use crate::plumbing::{make_project_assets, AssetDescriptor, ProjectAsset};
+use anyhow::{bail, Context};
 use ic_utils::Canister;
 use std::collections::HashMap;
 use std::path::Path;
@@ -21,11 +21,9 @@ pub async fn sync(
     dirs: &[&Path],
     timeout: Duration,
 ) -> anyhow::Result<()> {
-    let asset_locations = gather_asset_locations(dirs)?;
+    let asset_descriptors = gather_asset_descriptors(dirs)?;
 
-    println!("{:?}", asset_locations);
-    let dirs = Path::new("");
-    let configuration = AssetSourceDirectoryConfiguration::load(dirs)?;
+    println!("{:?}", asset_descriptors);
 
     let canister_call_params = CanisterCallParams { canister, timeout };
 
@@ -40,9 +38,8 @@ pub async fn sync(
     let project_assets = make_project_assets(
         &canister_call_params,
         &batch_id,
-        asset_locations,
+        asset_descriptors,
         &container_assets,
-        configuration,
     )
     .await?;
 
@@ -62,10 +59,11 @@ fn filename_starts_with_dot(entry: &walkdir::DirEntry) -> bool {
         .unwrap_or(false)
 }
 
-fn gather_asset_locations(dirs: &[&Path]) -> anyhow::Result<Vec<AssetLocation>> {
-    let mut asset_descriptors: HashMap<String, AssetLocation> = HashMap::new();
+fn gather_asset_descriptors(dirs: &[&Path]) -> anyhow::Result<Vec<AssetDescriptor>> {
+    let mut asset_descriptors: HashMap<String, AssetDescriptor> = HashMap::new();
     for dir in dirs {
-        let asset_locations = WalkDir::new(dir)
+        let configuration = AssetSourceDirectoryConfiguration::load(dir)?;
+        let asset_descriptors_interim = WalkDir::new(dir)
             .into_iter()
             .filter_entry(|entry| !filename_starts_with_dot(entry))
             .filter_map(|r| {
@@ -73,21 +71,32 @@ fn gather_asset_locations(dirs: &[&Path]) -> anyhow::Result<Vec<AssetLocation>> 
                     let source = e.path().to_path_buf();
                     let relative = source.strip_prefix(dir).expect("cannot strip prefix");
                     let key = String::from("/") + relative.to_string_lossy().as_ref();
+                    let config = configuration
+                        .get_asset_config(&source)
+                        .context(format!(
+                            "failed to get config for asset: {}",
+                            source.to_str().unwrap()
+                        ))
+                        .unwrap(); // TODO
 
-                    AssetLocation { source, key }
+                    AssetDescriptor {
+                        source,
+                        key,
+                        config,
+                    }
                 })
             })
             .collect::<Vec<_>>();
-        for asset_location in asset_locations {
-            if let Some(already_seen) = asset_descriptors.get(&asset_location.key) {
+        for asset_descriptor in asset_descriptors_interim {
+            if let Some(already_seen) = asset_descriptors.get(&asset_descriptor.key) {
                 bail!(
                     "Asset with key '{}' defined at {} and {}",
-                    &asset_location.key,
-                    asset_location.source.display(),
+                    &asset_descriptor.key,
+                    asset_descriptor.source.display(),
                     already_seen.source.display()
                 )
             }
-            asset_descriptors.insert(asset_location.key.clone(), asset_location);
+            asset_descriptors.insert(asset_descriptor.key.clone(), asset_descriptor);
         }
     }
     Ok(asset_descriptors.into_values().collect())

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -63,14 +63,14 @@ fn gather_asset_descriptors(dirs: &[&Path]) -> anyhow::Result<Vec<AssetDescripto
     let mut asset_descriptors: HashMap<String, AssetDescriptor> = HashMap::new();
     for dir in dirs {
         let dir = dir.canonicalize().unwrap();
-        let configuration = AssetSourceDirectoryConfiguration::load(dir)?;
-        let asset_descriptors_interim = WalkDir::new(dir)
+        let configuration = AssetSourceDirectoryConfiguration::load(&dir)?;
+        let asset_descriptors_interim = WalkDir::new(&dir)
             .into_iter()
             .filter_entry(|entry| !filename_starts_with_dot(entry))
             .filter_map(|r| {
                 r.ok().filter(|entry| entry.file_type().is_file()).map(|e| {
                     let source = e.path().canonicalize().unwrap().to_path_buf();
-                    let relative = source.strip_prefix(dir).expect("cannot strip prefix");
+                    let relative = source.strip_prefix(&dir).expect("cannot strip prefix");
                     let key = String::from("/") + relative.to_string_lossy().as_ref();
                     let config = configuration
                         .get_asset_config(&source)

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -64,26 +64,30 @@ fn gather_asset_descriptors(dirs: &[&Path]) -> anyhow::Result<Vec<AssetDescripto
     for dir in dirs {
         let dir = dir.canonicalize().unwrap();
         let configuration = AssetSourceDirectoryConfiguration::load(&dir)?;
-        let mut asset_descriptors_interim = vec![];
-        for e in WalkDir::new(&dir)
+        let asset_descriptors_interim = WalkDir::new(&dir)
             .into_iter()
-            .filter_entry(|entry| !filename_starts_with_dot(entry) && entry.file_type().is_file())
-            .filter_map(|r| r.ok())
-        {
-            let source = e.path().canonicalize().unwrap();
-            let relative = source.strip_prefix(&dir).expect("cannot strip prefix");
-            let key = String::from("/") + relative.to_string_lossy().as_ref();
-            let config = configuration.get_asset_config(&source).context(format!(
-                "failed to get config for asset: {}",
-                source.to_str().unwrap()
-            ))?;
+            .filter_entry(|entry| !filename_starts_with_dot(entry))
+            .filter_map(|r| {
+                r.ok().filter(|entry| entry.file_type().is_file()).map(|e| {
+                    let source = e.path().canonicalize().unwrap();
+                    let relative = source.strip_prefix(&dir).expect("cannot strip prefix");
+                    let key = String::from("/") + relative.to_string_lossy().as_ref();
+                    let config = configuration
+                        .get_asset_config(&source)
+                        .context(format!(
+                            "failed to get config for asset: {}",
+                            source.to_str().unwrap()
+                        ))
+                        .unwrap(); // TODO
 
-            asset_descriptors_interim.push(AssetDescriptor {
-                source,
-                key,
-                config,
+                    AssetDescriptor {
+                        source,
+                        key,
+                        config,
+                    }
+                })
             })
-        }
+            .collect::<Vec<_>>();
         for asset_descriptor in asset_descriptors_interim {
             if let Some(already_seen) = asset_descriptors.get(&asset_descriptor.key) {
                 bail!(

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -67,30 +67,32 @@ fn gather_asset_descriptors(dirs: &[&Path]) -> anyhow::Result<Vec<AssetDescripto
             )
         })?;
         let configuration = AssetSourceDirectoryConfiguration::load(&dir)?;
-        let asset_descriptors_interim = WalkDir::new(&dir)
+        let mut asset_descriptors_interim = vec![];
+        for e in WalkDir::new(&dir)
             .into_iter()
-            .filter_entry(|entry| !filename_starts_with_dot(entry))
-            .filter_map(|r| {
-                r.ok().filter(|entry| entry.file_type().is_file()).map(|e| {
-                    let source = e.path().canonicalize().unwrap();
-                    let relative = source.strip_prefix(&dir).expect("cannot strip prefix");
-                    let key = String::from("/") + relative.to_string_lossy().as_ref();
-                    let config = configuration
-                        .get_asset_config(&source)
-                        .context(format!(
-                            "failed to get config for asset: {}",
-                            source.to_str().unwrap()
-                        ))
-                        .unwrap(); // TODO
+            .filter_entry(|entry| !filename_starts_with_dot(entry) && entry.file_type().is_file())
+            .filter_map(|r| r.ok())
+        {
+            let source = e.path().canonicalize().with_context(|| {
+                format!(
+                    "unable to canonicalize the path when gathering asset descriptors: {}",
+                    dir.display()
+                )
+            })?;
+            let relative = source.strip_prefix(&dir).expect("cannot strip prefix");
+            let key = String::from("/") + relative.to_string_lossy().as_ref();
+            let config = configuration.get_asset_config(&source).context(format!(
+                "failed to get config for asset: {}",
+                source.display()
+            ))?;
 
-                    AssetDescriptor {
-                        source,
-                        key,
-                        config,
-                    }
-                })
+            asset_descriptors_interim.push(AssetDescriptor {
+                source,
+                key,
+                config,
             })
-            .collect::<Vec<_>>();
+        }
+
         for asset_descriptor in asset_descriptors_interim {
             if let Some(already_seen) = asset_descriptors.get(&asset_descriptor.key) {
                 bail!(

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -62,13 +62,14 @@ fn filename_starts_with_dot(entry: &walkdir::DirEntry) -> bool {
 fn gather_asset_descriptors(dirs: &[&Path]) -> anyhow::Result<Vec<AssetDescriptor>> {
     let mut asset_descriptors: HashMap<String, AssetDescriptor> = HashMap::new();
     for dir in dirs {
+        let dir = dir.canonicalize().unwrap();
         let configuration = AssetSourceDirectoryConfiguration::load(dir)?;
         let asset_descriptors_interim = WalkDir::new(dir)
             .into_iter()
             .filter_entry(|entry| !filename_starts_with_dot(entry))
             .filter_map(|r| {
                 r.ok().filter(|entry| entry.file_type().is_file()).map(|e| {
-                    let source = e.path().to_path_buf();
+                    let source = e.path().canonicalize().unwrap().to_path_buf();
                     let relative = source.strip_prefix(dir).expect("cannot strip prefix");
                     let key = String::from("/") + relative.to_string_lossy().as_ref();
                     let config = configuration

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -70,8 +70,9 @@ fn gather_asset_descriptors(dirs: &[&Path]) -> anyhow::Result<Vec<AssetDescripto
         let mut asset_descriptors_interim = vec![];
         for e in WalkDir::new(&dir)
             .into_iter()
-            .filter_entry(|entry| !filename_starts_with_dot(entry) && entry.file_type().is_file())
+            .filter_entry(|entry| !filename_starts_with_dot(entry))
             .filter_map(|r| r.ok())
+            .filter(|entry| entry.file_type().is_file())
         {
             let source = e.path().canonicalize().with_context(|| {
                 format!(

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -1,7 +1,7 @@
 use crate::asset_canister::batch::{commit_batch, create_batch};
 use crate::asset_canister::list::list_assets;
 use crate::asset_canister::protocol::{AssetDetails, BatchOperationKind};
-use crate::asset_config::AssetsConfigMatcher;
+use crate::asset_config::AssetSourceDirectoryConfiguration;
 use crate::params::CanisterCallParams;
 
 use crate::operations::{
@@ -17,7 +17,9 @@ use walkdir::WalkDir;
 /// Sets the contents of the asset canister to the contents of a directory, including deleting old assets.
 pub async fn sync(canister: &Canister<'_>, dir: &Path, timeout: Duration) -> anyhow::Result<()> {
     let asset_locations = gather_asset_locations(dir);
-    let asset_headers = AssetsConfigMatcher::new(dir).get_config()?;
+
+    println!("{:?}", asset_locations);
+    let configuration = AssetSourceDirectoryConfiguration::load(dir)?;
 
     let canister_call_params = CanisterCallParams { canister, timeout };
 
@@ -34,7 +36,7 @@ pub async fn sync(canister: &Canister<'_>, dir: &Path, timeout: Duration) -> any
         &batch_id,
         asset_locations,
         &container_assets,
-        asset_headers,
+        configuration,
     )
     .await?;
 

--- a/ic-asset/src/upload.rs
+++ b/ic-asset/src/upload.rs
@@ -19,7 +19,7 @@ pub async fn upload(
     files: HashMap<String, PathBuf>,
 ) -> anyhow::Result<()> {
     let random = files.iter().next();
-    let c = random.unwrap().1.canonicalize();
+    let c = random.unwrap().1.canonicalize().unwrap();
     let asset_locations: Vec<AssetLocation> = files
         .iter()
         .map(|x| AssetLocation {
@@ -43,7 +43,7 @@ pub async fn upload(
         &batch_id,
         asset_locations,
         &container_assets,
-        AssetSourceDirectoryConfiguration::load(std::path::Path::new("/todo"))?,
+        AssetSourceDirectoryConfiguration::load(c.as_path())?,
     )
     .await?;
 

--- a/ic-asset/src/upload.rs
+++ b/ic-asset/src/upload.rs
@@ -1,6 +1,7 @@
 use crate::asset_canister::batch::{commit_batch, create_batch};
 use crate::asset_canister::list::list_assets;
 use crate::asset_canister::protocol::{AssetDetails, BatchOperationKind};
+use crate::asset_config::AssetSourceDirectoryConfiguration;
 use crate::operations::{
     create_new_assets, delete_incompatible_assets, set_encodings, unset_obsolete_encodings,
 };
@@ -17,6 +18,8 @@ pub async fn upload(
     timeout: Duration,
     files: HashMap<String, PathBuf>,
 ) -> anyhow::Result<()> {
+    let random = files.iter().next();
+    let c = random.unwrap().1.canonicalize();
     let asset_locations: Vec<AssetLocation> = files
         .iter()
         .map(|x| AssetLocation {
@@ -40,7 +43,7 @@ pub async fn upload(
         &batch_id,
         asset_locations,
         &container_assets,
-        vec![],
+        AssetSourceDirectoryConfiguration::load(std::path::Path::new("/todo"))?,
     )
     .await?;
 

--- a/ic-asset/src/upload.rs
+++ b/ic-asset/src/upload.rs
@@ -1,12 +1,12 @@
 use crate::asset_canister::batch::{commit_batch, create_batch};
 use crate::asset_canister::list::list_assets;
 use crate::asset_canister::protocol::{AssetDetails, BatchOperationKind};
-use crate::asset_config::AssetSourceDirectoryConfiguration;
+use crate::asset_config::AssetConfig;
 use crate::operations::{
     create_new_assets, delete_incompatible_assets, set_encodings, unset_obsolete_encodings,
 };
 use crate::params::CanisterCallParams;
-use crate::plumbing::{make_project_assets, AssetLocation, ProjectAsset};
+use crate::plumbing::{make_project_assets, AssetDescriptor, ProjectAsset};
 use ic_utils::Canister;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -18,13 +18,12 @@ pub async fn upload(
     timeout: Duration,
     files: HashMap<String, PathBuf>,
 ) -> anyhow::Result<()> {
-    let random = files.iter().next();
-    let c = random.unwrap().1.canonicalize().unwrap();
-    let asset_locations: Vec<AssetLocation> = files
+    let asset_descriptors: Vec<AssetDescriptor> = files
         .iter()
-        .map(|x| AssetLocation {
+        .map(|x| AssetDescriptor {
             source: x.1.clone(),
             key: x.0.clone(),
+            config: AssetConfig::default(),
         })
         .collect();
 
@@ -41,9 +40,8 @@ pub async fn upload(
     let project_assets = make_project_assets(
         &canister_call_params,
         &batch_id,
-        asset_locations,
+        asset_descriptors,
         &container_assets,
-        AssetSourceDirectoryConfiguration::load(c.as_path())?,
     )
     .await?;
 


### PR DESCRIPTION
# Description

- detects if `.ic-assets.json` config file is present when syncing assets, then uses glob values from that file to match against the assets in the directory which is being synced

Implements [SDK-479](https://dfinity.atlassian.net/browse/SDK-479)

# How Has This Been Tested?

- unit tests in http_headers_config.rs
- plugged this into dfx and it doesn't jam 

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation. 

# Discuss:
- what type should be used for HashMap's value of `pub(crate) type HeadersConfig = HashMap<String, Value>;` (maybe consider this https://docs.rs/http-serde/1.1.0/http_serde/index.html instead of `serde_json::Value`)