### PR TITLE
feat: support for custom HTTP headers asset canister configuration in ic-assets 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ Added support for asset canister config files in `ic-assets`.
   ```
 - works only during asset creation
 - the config file is being taken into account only when calling `ic_asset::sync` (i.e. `dfx deploy` or `icx-asset sync`)
-- `headers` from multiple applicable rules are being stacked/concatenated, unless `null` is specified, which resets/empties the headers. Both `"headers": {}` and absence of `headers` don't have any effect on end result.
 
 ## [0.18.0] - 2022-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Added support for configuring HTTP headers for assets in asset canister (via `.ic-assets.json` config file):
+- example of `.ic-assets.json` file format:
+  ```
+  [
+      {
+          "match": "*",
+          "cache": {
+              "max_age": 20
+          },
+          "headers": {
+              "X-Content-Type-Options": "nosniff"
+          }
+      },
+      {
+          "match": "**/*",
+          "headers": null
+      },
+  ]
+  ```
+- `headers` from multiple applicable rules are being stacked/concatenated, unless `null` is specified, which resets/empties the headers. Both `"headers": {}` and absence of `headers` don't have any effect on end result.
+
 ## [0.19.0] - 2022-07-06
 
 Added support for asset canister config files in `ic-assets`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,15 +40,8 @@ Added support for asset canister config files in `ic-assets`.
           "match": "*",
           "cache": {
               "max_age": 20
-          },
-          "headers": {
-              "X-Content-Type-Options": "nosniff"
           }
-      },
-      {
-          "match": "**/*",
-          "headers": null
-      },
+      }
   ]
   ```
 - works only during asset creation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,20 @@ Added support for asset canister config files in `ic-assets`.
           "match": "*",
           "cache": {
               "max_age": 20
+          },
+          "headers": {
+              "X-Content-Type-Options": "nosniff"
           }
-      }
+      },
+      {
+          "match": "**/*",
+          "headers": null
+      },
   ]
   ```
 - works only during asset creation
 - the config file is being taken into account only when calling `ic_asset::sync` (i.e. `dfx deploy` or `icx-asset sync`)
+- `headers` from multiple applicable rules are being stacked/concatenated, unless `null` is specified, which resets/empties the headers. Both `"headers": {}` and absence of `headers` don't have any effect on end result.
 
 ## [0.18.0] - 2022-06-23
 

--- a/ic-asset/src/asset_canister/protocol.rs
+++ b/ic-asset/src/asset_canister/protocol.rs
@@ -1,7 +1,6 @@
+use crate::asset_config::HeadersConfig;
 use candid::{CandidType, Nat};
 use serde::Deserialize;
-
-// use crate::http_headers_config::HeadersConfig;
 
 /// Create a new batch, which will expire after some time period.
 /// This expiry is extended by any call to create_chunk().
@@ -71,9 +70,8 @@ pub struct CreateAssetArguments {
     pub content_type: String,
     /// The cache HTTP header Time To Live parameter
     pub max_age: Option<u64>,
-    // TODO: (SDK-473) serde_json::Value is not serializable into CandidType
-    // /// The HTTP headers
-    // pub headers: HeadersConfig,
+    /// The HTTP headers
+    pub headers: Option<HeadersConfig>,
 }
 
 /// Set the data for a particular content encoding for the given asset.

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -12,7 +12,7 @@ use std::{
 
 const ASSETS_CONFIG_FILENAME: &str = ".ic-assets.json";
 
-pub(crate) type HeadersConfig = HashMap<String, Value>;
+pub(crate) type HeadersConfig = HashMap<String, String>;
 type ConfigMap = HashMap<PathBuf, Arc<AssetConfigTreeNode>>;
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq)]
@@ -119,7 +119,9 @@ where
 {
     match serde_json::value::Value::deserialize(deserializer)? {
         Value::Object(v) => Ok(Maybe::Value(
-            v.into_iter().collect::<HashMap<String, Value>>(),
+            v.into_iter()
+                .map(|(k, v)| (k, v.to_string()))
+                .collect::<HashMap<String, String>>(),
         )),
         Value::Null => Ok(Maybe::Null),
         _ => Err(serde::de::Error::custom(
@@ -418,20 +420,23 @@ mod with_tempdir {
             headers: Some(HashMap::from([
                 (
                     "x-content-type-options".to_string(),
-                    String("nosniff".to_string()),
+                    String("nosniff".to_string()).to_string(),
                 ),
                 (
                     "x-frame-options".to_string(),
-                    String("SAMEORIGIN".to_string()),
+                    String("SAMEORIGIN".to_string()).to_string(),
                 ),
-                ("Some-Other-Policy".to_string(), String("add".to_string())),
+                (
+                    "Some-Other-Policy".to_string(),
+                    String("add".to_string()).to_string(),
+                ),
                 (
                     "Content-Security-Policy".to_string(),
-                    String("delete".to_string()),
+                    String("delete".to_string()).to_string(),
                 ),
                 (
                     "x-xss-protection".to_string(),
-                    Number(serde_json::Number::from(1)),
+                    Number(serde_json::Number::from(1)).to_string(),
                 ),
             ])),
         };

--- a/ic-asset/src/operations.rs
+++ b/ic-asset/src/operations.rs
@@ -63,11 +63,13 @@ pub(crate) fn create_new_assets(
                 .as_ref()
                 .and_then(|c| c.max_age);
 
+            let headers = project_asset.asset_descriptor.config.clone().headers;
+
             operations.push(BatchOperationKind::CreateAsset(CreateAssetArguments {
                 key: key.clone(),
                 content_type: project_asset.media_type.to_string(),
                 max_age,
-                // headers: project_asset.headers,
+                headers,
             }));
         }
     }


### PR DESCRIPTION
# Description

Adds support for `headers` field in `.ic-assets.json` file

Implements https://dfinity.atlassian.net/browse/SDK-473

# How Has This Been Tested?

Already been tested

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
