### PR TITLE
chore: Upgrade to candid 0.7.15 and ic-types 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,15 +185,6 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
@@ -230,9 +221,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "candid"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba9e536514a3c655568e23e36e68cbef20ee6595f641719ade03a849a13ed0ac"
+checksum = "a4f5cdd24185c6d6edba09bcfe06cf9c1e7fd579cbe5e4ae2dffba9c474a5a7f"
 dependencies = [
  "anyhow",
  "binread",
@@ -421,6 +412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
 name = "delay"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,20 +453,11 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
@@ -522,7 +510,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.3",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -839,7 +827,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest",
 ]
 
 [[package]]
@@ -967,7 +955,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
- "sha2 0.10.2",
+ "sha2",
  "simple_asn1",
  "thiserror",
  "tokio",
@@ -988,7 +976,6 @@ dependencies = [
  "globset",
  "hex",
  "ic-agent",
- "ic-types",
  "ic-utils",
  "mime",
  "mime_guess",
@@ -998,7 +985,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2 0.10.2",
+ "sha2",
  "tempfile",
  "walkdir",
 ]
@@ -1011,23 +998,23 @@ dependencies = [
  "ic-agent",
  "num-bigint 0.4.3",
  "pkcs11",
- "sha2 0.10.2",
+ "sha2",
  "simple_asn1",
  "thiserror",
 ]
 
 [[package]]
 name = "ic-types"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e78ec6f58886cdc252d6f912dc794211bd6bbc39ddc9dcda434b2dc16c335b3"
+checksum = "a67e4edc28c09d29ab97b50410245c91d71756eaf3956212e3488cd6eb75fda4"
 dependencies = [
- "base32",
  "crc32fast",
+ "data-encoding",
  "hex",
  "serde",
  "serde_bytes",
- "sha2 0.9.9",
+ "sha2",
  "thiserror",
 ]
 
@@ -1086,7 +1073,6 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-asset",
- "ic-types",
  "ic-utils",
  "libflate",
  "num-traits",
@@ -1114,7 +1100,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "sha2 0.10.2",
+ "sha2",
 ]
 
 [[package]]
@@ -1186,7 +1172,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.2",
+ "sha2",
 ]
 
 [[package]]
@@ -1497,12 +1483,6 @@ name = "once_cell"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -1879,7 +1859,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_cbor",
- "sha2 0.10.2",
+ "sha2",
  "tokio",
 ]
 
@@ -2189,26 +2169,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest",
 ]
 
 [[package]]
@@ -2226,7 +2193,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 dependencies = [
- "digest 0.10.3",
+ "digest",
  "rand_core",
 ]
 

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -24,7 +24,7 @@ hex = "0.4.0"
 http = "0.2.6"
 http-body = "0.4.5"
 hyper-rustls = { version = "0.23.0", features = [ "webpki-roots" ] }
-ic-types = "0.3.0"
+ic-types = "0.4.0"
 k256 = { version = "0.11", features = ["pem"] }
 leb128 = "0.2.5"
 mime = "0.3.16"
@@ -53,7 +53,7 @@ version = "1.0"
 optional = true
 
 [dev-dependencies]
-candid = "0.7.14"
+candid = "0.7.15"
 mockito = "0.31.0"
 proptest = "1.0.0"
 serde_json = "1.0.79"

--- a/ic-agent/src/agent/signed.rs
+++ b/ic-agent/src/agent/signed.rs
@@ -78,11 +78,11 @@ mod tests {
     fn test_query_serde() {
         let query = SignedQuery {
             ingress_expiry: 1,
-            sender: Principal::from_slice(&[0; 29]),
-            canister_id: Principal::from_slice(&[0; 29]),
+            sender: Principal::management_canister(),
+            canister_id: Principal::management_canister(),
             method_name: "greet".to_string(),
             arg: vec![0, 1],
-            effective_canister_id: Principal::from_slice(&[0; 29]),
+            effective_canister_id: Principal::management_canister(),
             signed_query: vec![0, 1, 2, 3],
         };
         let serialized = serde_json::to_string(&query).unwrap();
@@ -95,11 +95,11 @@ mod tests {
         let update = SignedUpdate {
             nonce: None,
             ingress_expiry: 1,
-            sender: Principal::from_slice(&[0; 29]),
-            canister_id: Principal::from_slice(&[0; 29]),
+            sender: Principal::management_canister(),
+            canister_id: Principal::management_canister(),
             method_name: "greet".to_string(),
             arg: vec![0, 1],
-            effective_canister_id: Principal::from_slice(&[0; 29]),
+            effective_canister_id: Principal::management_canister(),
             signed_update: vec![0, 1, 2, 3],
             request_id: RequestId::new(&[0; 32]),
         };
@@ -112,8 +112,8 @@ mod tests {
     fn test_request_status_serde() {
         let request_status = SignedRequestStatus {
             ingress_expiry: 1,
-            sender: Principal::from_slice(&[0; 29]),
-            effective_canister_id: Principal::from_slice(&[0; 29]),
+            sender: Principal::management_canister(),
+            effective_canister_id: Principal::management_canister(),
             request_id: RequestId::new(&[0; 32]),
             signed_request_status: vec![0, 1, 2, 3],
         };

--- a/ic-asset/Cargo.toml
+++ b/ic-asset/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.58.1"
 
 [dependencies]
 anyhow = "1.0"
-candid = "0.7.14"
+candid = "0.7.15"
 flate2 = "1.0.22"
 futures = "0.3.21"
 futures-intrusive = "0.4.0"
@@ -24,7 +24,6 @@ garcon = { version = "0.2", features = ["async"] }
 globset = "0.4.9"
 hex = {version = "0.4.2", features = ["serde"] }
 ic-agent = { path = "../ic-agent", version = "0.19", features = [ "pem" ] }
-ic-types = "0.3.0"
 ic-utils = { path = "../ic-utils", version = "0.19" }
 mime = "0.3.16"
 mime_guess = "2.0.4"

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.58.1"
 
 [dependencies]
 async-trait = "0.1.40"
-candid = "0.7.14"
+candid = "0.7.15"
 garcon = { version = "0.2", features = ["async"] }
 ic-agent = { path = "../ic-agent", version = "0.19" }
 serde = "1.0.115"

--- a/icx-asset/Cargo.toml
+++ b/icx-asset/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.58.1"
 
 [dependencies]
 anyhow = "1.0.34"
-candid = "0.7.14"
+candid = "0.7.15"
 chrono = "0.4.19"
 clap = { version = "3.0.14", features = ["derive", "cargo"] }
 delay = "0.3.1"
@@ -26,7 +26,6 @@ garcon = "0.2.2"
 humantime = "2.0.1"
 ic-agent = { path = "../ic-agent", version = "0.19" }
 ic-asset = { path = "../ic-asset", version = "0.19" }
-ic-types = "0.3.0"
 ic-utils = { path = "../ic-utils", version = "0.19" }
 libflate = "1.2.0"
 num-traits = "0.2"

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
-candid = "0.7.14"
+candid = "0.7.15"
 clap = { version = "3.0.14", features = ["derive", "cargo"] }
 garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.2"

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-candid = "0.7.14"
+candid = "0.7.15"
 garcon = { version = "0.2.3", features = ["async"] }
 ic-agent = { path = "../ic-agent" }
 ic-identity-hsm = { path = "../ic-identity-hsm" }


### PR DESCRIPTION
# Description

ic-types 0.4.0 contains an important performance fix. 


# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
