### PR TITLE
fix: strip quotes from custom-configured HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ic-asset
+
+* Fixed custom configured HTTP headers - no longer is the header's value wrapped with double quotes.
+
 ## [0.20.0] - 2022-07-14
 
 ### Breaking change: Updated to ic-types 0.4.0

--- a/ic-asset/src/asset_config.rs
+++ b/ic-asset/src/asset_config.rs
@@ -126,7 +126,7 @@ where
     match serde_json::value::Value::deserialize(deserializer)? {
         Value::Object(v) => Ok(Maybe::Value(
             v.into_iter()
-                .map(|(k, v)| (k, v.to_string()))
+                .map(|(k, v)| (k, v.to_string().trim_matches('"').to_string()))
                 .collect::<HashMap<String, String>>(),
         )),
         Value::Null => Ok(Maybe::Null),
@@ -427,22 +427,10 @@ mod with_tempdir {
         let expected_asset_config = AssetConfig {
             cache: Some(CacheConfig { max_age: Some(88) }),
             headers: Some(HashMap::from([
-                (
-                    "x-content-type-options".to_string(),
-                    String("nosniff".to_string()).to_string(),
-                ),
-                (
-                    "x-frame-options".to_string(),
-                    String("SAMEORIGIN".to_string()).to_string(),
-                ),
-                (
-                    "Some-Other-Policy".to_string(),
-                    String("add".to_string()).to_string(),
-                ),
-                (
-                    "Content-Security-Policy".to_string(),
-                    String("delete".to_string()).to_string(),
-                ),
+                ("x-content-type-options".to_string(), "nosniff".to_string()),
+                ("x-frame-options".to_string(), "SAMEORIGIN".to_string()),
+                ("Some-Other-Policy".to_string(), "add".to_string()),
+                ("Content-Security-Policy".to_string(), "delete".to_string()),
                 (
                     "x-xss-protection".to_string(),
                     Number(serde_json::Number::from(1)).to_string(),

--- a/ic-asset/src/sync.rs
+++ b/ic-asset/src/sync.rs
@@ -442,19 +442,15 @@ mod test_gathering_asset_descriptors_with_tempdir {
         let mut expected_asset_descriptors = vec![
             AssetDescriptor::default_from_path(&assets_dir, "file"),
             AssetDescriptor::default_from_path(&assets_dir, ".hidden-dir/.hfile")
-                .with_headers(HashMap::from([("B", "\"y\""), ("A", "\"z\"")])),
+                .with_headers(HashMap::from([("B", "y"), ("A", "z")])),
             AssetDescriptor::default_from_path(&assets_dir, ".hidden-dir/file"),
             AssetDescriptor::default_from_path(&assets_dir, ".hidden-dir/.hidden-dir-nested/file")
-                .with_headers(HashMap::from([("A", "\"z\""), ("C", "\"x\"")])),
+                .with_headers(HashMap::from([("A", "z"), ("C", "x")])),
             AssetDescriptor::default_from_path(
                 &assets_dir,
                 ".hidden-dir/.hidden-dir-nested/.hfile",
             )
-            .with_headers(HashMap::from([
-                ("D", "\"w\""),
-                ("A", "\"z\""),
-                ("C", "\"x\""),
-            ])),
+            .with_headers(HashMap::from([("D", "w"), ("A", "z"), ("C", "x")])),
         ];
 
         expected_asset_descriptors.sort_by_key(|v| v.source.clone());
@@ -499,7 +495,7 @@ mod test_gathering_asset_descriptors_with_tempdir {
             &assets_dir,
             ".hidden-dir/.hidden-dir-nested/.hfile",
         )
-        .with_headers(HashMap::from([("D", "\"w\"")]))];
+        .with_headers(HashMap::from([("D", "w")]))];
 
         expected_asset_descriptors.sort_by_key(|v| v.source.clone());
         asset_descriptors.sort_by_key(|v| v.source.clone());
@@ -670,30 +666,30 @@ mod test_gathering_asset_descriptors_with_tempdir {
 
         let mut expected_asset_descriptors = vec![
             AssetDescriptor::default_from_path(&assets_dir, ".hfile")
-                .with_headers(HashMap::from([("X-Content-Type-Options", "\"*\"")]))
+                .with_headers(HashMap::from([("X-Content-Type-Options", "*")]))
                 .with_cache(CacheConfig { max_age: Some(11) }),
             AssetDescriptor::default_from_path(&assets_dir, ".hidden-dir/.hfile")
-                .with_headers(HashMap::from([("X-Content-Type-Options", "\"*\"")]))
+                .with_headers(HashMap::from([("X-Content-Type-Options", "*")]))
                 .with_cache(CacheConfig { max_age: Some(11) }),
             AssetDescriptor::default_from_path(&assets_dir, ".hidden-dir/file")
-                .with_headers(HashMap::from([("X-Content-Type-Options", "\"nosniff\"")]))
+                .with_headers(HashMap::from([("X-Content-Type-Options", "nosniff")]))
                 .with_cache(CacheConfig { max_age: Some(11) }),
             AssetDescriptor::default_from_path(&assets_dir, ".hidden-dir-flat/file")
-                .with_headers(HashMap::from([("X-Content-Type-Options", "\"nosniff\"")]))
+                .with_headers(HashMap::from([("X-Content-Type-Options", "nosniff")]))
                 .with_headers(HashMap::from([(
                     "Cross-Origin-Resource-Policy",
-                    "\"same-origin\"",
+                    "same-origin",
                 )]))
                 .with_cache(CacheConfig { max_age: Some(11) }),
             AssetDescriptor::default_from_path(&assets_dir, "anotherdir/file")
                 .with_cache(CacheConfig { max_age: Some(42) }),
             AssetDescriptor::default_from_path(&assets_dir, "dir/file")
-                .with_headers(HashMap::from([("X-Content-Type-Options", "\"nosniff\"")]))
-                .with_headers(HashMap::from([("Access-Control-Allow-Origin", "\"null\"")]))
+                .with_headers(HashMap::from([("X-Content-Type-Options", "nosniff")]))
+                .with_headers(HashMap::from([("Access-Control-Allow-Origin", "null")]))
                 .with_cache(CacheConfig { max_age: Some(11) }),
             AssetDescriptor::default_from_path(&assets_dir, "file")
                 .with_cache(CacheConfig { max_age: Some(11) })
-                .with_headers(HashMap::from([("X-Content-Type-Options", "\"nosniff\"")])),
+                .with_headers(HashMap::from([("X-Content-Type-Options", "nosniff")])),
         ];
 
         expected_asset_descriptors.sort_by_key(|v| v.source.clone());


### PR DESCRIPTION
# Description

Currently, custom configured HTTP headers coming from `.ic-assets.json` have the value-part of the header surrounded with double-quotes, e.g.
```
Access-Control-Allow-Methods: "GET"
```
which is not desirable, since:
1. there is no way for an end developer to disable this
1.  most header values don't need to be wrapped with quotes ([example](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods))

This PR fixes that, so the header will end up looking like this:
```
Access-Control-Allow-Methods: GET
```

# How Has This Been Tested?

Passing unit tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
