### PR TITLE
chore(tests): remove dfx `0.7.2` from test matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ macos-latest, ubuntu-latest ]
         rust: [ '1.60.0' ]
-        dfx: [ '0.7.2', '0.8.4', '0.9.2', '0.10.1' ]
+        dfx: [ '0.8.4', '0.9.2', '0.10.1' ]
 
     steps:
       - uses: actions/checkout@v1
@@ -42,7 +42,7 @@ jobs:
           INSTALL_DFX_VERSION: ${{ matrix.dfx }}
       - name: Setup for dfx version differences
         run: |
-          if [[ "${{ matrix.dfx }}" == "0.7.2" ]] || [[ "${{ matrix.dfx }}" == "0.8.4" ]]; then
+          if [[ "${{ matrix.dfx }}" == "0.8.4" ]]; then
               echo "DFX_NO_WALLET=--no-wallet" >> "$GITHUB_ENV"
           fi
 


### PR DESCRIPTION
# Description

e2e tests often get stuck or take forever and fail on timeout for dfx == `0.7.2`. Since the version is quite old, we're dropping it from our CI.

# How Has This Been Tested?


# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] (n/a) I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
