### PR TITLE
chore: cleanup ic-agent

### DIFF
--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -30,7 +30,7 @@ impl AgentBuilder {
         self.with_arc_transport(Arc::new(transport))
     }
 
-    /// Same as [with_transport], but provides a `Arc` boxed implementation instead
+    /// Same as [Self::with_transport], but provides a `Arc` boxed implementation instead
     /// of a direct type.
     pub fn with_arc_transport(mut self, transport: Arc<dyn ReplicaV2Transport>) -> Self {
         self.config.transport = Some(transport);
@@ -42,7 +42,7 @@ impl AgentBuilder {
         self.with_nonce_generator(nonce_factory)
     }
 
-    /// Same as [with_nonce_factory], but for any `NonceGenerator` type
+    /// Same as [Self::with_nonce_factory], but for any `NonceGenerator` type
     pub fn with_nonce_generator<N: 'static + NonceGenerator>(
         self,
         nonce_factory: N,
@@ -50,7 +50,7 @@ impl AgentBuilder {
         self.with_arc_nonce_generator(Arc::new(nonce_factory))
     }
 
-    /// Same as [with_nonce_generator], but provides a `Arc` boxed implementation instead
+    /// Same as [Self::with_nonce_generator], but provides a `Arc` boxed implementation instead
     /// of a direct type.
     pub fn with_arc_nonce_generator(
         mut self,
@@ -68,13 +68,13 @@ impl AgentBuilder {
         self.with_arc_identity(Arc::new(identity))
     }
 
-    /// Same as [with_identity], but provides a boxed implementation instead
+    /// Same as [Self::with_identity], but provides a boxed implementation instead
     /// of a direct type.
     pub fn with_boxed_identity(self, identity: Box<dyn Identity>) -> Self {
         self.with_arc_identity(Arc::from(identity))
     }
 
-    /// Same as [with_identity], but provides a `Arc` boxed implementation instead
+    /// Same as [Self::with_identity], but provides a `Arc` boxed implementation instead
     /// of a direct type.
     pub fn with_arc_identity(mut self, identity: Arc<dyn Identity>) -> Self {
         self.config.identity = identity;

--- a/ic-agent/src/agent/http_transport.rs
+++ b/ic-agent/src/agent/http_transport.rs
@@ -3,11 +3,19 @@
 
 pub use reqwest;
 
-use crate::{agent::agent_error::HttpErrorPayload, ic_types::Principal, AgentError, RequestId};
 use futures_util::StreamExt;
 use hyper_rustls::ConfigBuilderExt;
-use reqwest::Method;
-use std::{future::Future, pin::Pin, sync::Arc};
+use reqwest::{
+    header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE},
+    Body, Client, Method, Request, StatusCode, Url,
+};
+use std::sync::Arc;
+
+use crate::{
+    agent::{agent_error::HttpErrorPayload, AgentFuture, ReplicaV2Transport},
+    ic_types::Principal,
+    AgentError, RequestId,
+};
 
 /// Implemented by the Agent environment to cache and update an HTTP Auth password.
 /// It returns a tuple of `(username, password)`.
@@ -30,8 +38,8 @@ impl_debug_empty!(dyn PasswordManager);
 /// A [ReplicaV2Transport] using Reqwest to make HTTP calls to the internet computer.
 #[derive(Debug)]
 pub struct ReqwestHttpReplicaV2Transport {
-    url: reqwest::Url,
-    client: reqwest::Client,
+    url: Url,
+    client: Client,
     password_manager: Option<Arc<dyn PasswordManager>>,
     max_response_body_size: Option<usize>,
 }
@@ -52,7 +60,7 @@ impl ReqwestHttpReplicaV2Transport {
 
         Self::create_with_client(
             url,
-            reqwest::Client::builder()
+            Client::builder()
                 .use_preconfigured_tls(tls_config)
                 .build()
                 .expect("Could not create HTTP client."),
@@ -60,13 +68,10 @@ impl ReqwestHttpReplicaV2Transport {
     }
 
     /// Creates a replica transport from a HTTP URL and a [`reqwest::Client`].
-    pub fn create_with_client<U: Into<String>>(
-        url: U,
-        client: reqwest::Client,
-    ) -> Result<Self, AgentError> {
+    pub fn create_with_client<U: Into<String>>(url: U, client: Client) -> Result<Self, AgentError> {
         let url = url.into();
         Ok(Self {
-            url: reqwest::Url::parse(&url)
+            url: Url::parse(&url)
                 .and_then(|mut url| {
                     // rewrite *.ic0.app to ic0.app
                     if let Some(domain) = url.domain() {
@@ -91,7 +96,7 @@ impl ReqwestHttpReplicaV2Transport {
         }
     }
 
-    /// Same as [`with_password_manager`], but providing the Arc so one does not have to be created.
+    /// Same as [`Self::with_password_manager`], but providing the Arc so one does not have to be created.
     pub fn with_arc_password_manager(self, password_manager: Arc<dyn PasswordManager>) -> Self {
         ReqwestHttpReplicaV2Transport {
             password_manager: Some(password_manager),
@@ -114,7 +119,7 @@ impl ReqwestHttpReplicaV2Transport {
 
     fn maybe_add_authorization(
         &self,
-        http_request: &mut reqwest::Request,
+        http_request: &mut Request,
         cached: bool,
     ) -> Result<(), AgentError> {
         if let Some(pm) = &self.password_manager {
@@ -126,10 +131,9 @@ impl ReqwestHttpReplicaV2Transport {
 
             if let Some((u, p)) = maybe_user_pass.map_err(AgentError::AuthenticationError)? {
                 let auth = base64::encode(&format!("{}:{}", u, p));
-                http_request.headers_mut().insert(
-                    reqwest::header::AUTHORIZATION,
-                    format!("Basic {}", auth).parse().unwrap(),
-                );
+                http_request
+                    .headers_mut()
+                    .insert(AUTHORIZATION, format!("Basic {}", auth).parse().unwrap());
             }
         }
         Ok(())
@@ -137,8 +141,8 @@ impl ReqwestHttpReplicaV2Transport {
 
     async fn request(
         &self,
-        http_request: reqwest::Request,
-    ) -> Result<(reqwest::StatusCode, reqwest::header::HeaderMap, Vec<u8>), AgentError> {
+        http_request: Request,
+    ) -> Result<(StatusCode, HeaderMap, Vec<u8>), AgentError> {
         let response = self
             .client
             .execute(
@@ -189,15 +193,14 @@ impl ReqwestHttpReplicaV2Transport {
         body: Option<Vec<u8>>,
     ) -> Result<Vec<u8>, AgentError> {
         let url = self.url.join(endpoint)?;
-        let mut http_request = reqwest::Request::new(method, url);
-        http_request.headers_mut().insert(
-            reqwest::header::CONTENT_TYPE,
-            "application/cbor".parse().unwrap(),
-        );
+        let mut http_request = Request::new(method, url);
+        http_request
+            .headers_mut()
+            .insert(CONTENT_TYPE, "application/cbor".parse().unwrap());
 
         self.maybe_add_authorization(&mut http_request, true)?;
 
-        *http_request.body_mut() = body.map(reqwest::Body::from);
+        *http_request.body_mut() = body.map(Body::from);
 
         let mut status;
         let mut headers;
@@ -210,7 +213,7 @@ impl ReqwestHttpReplicaV2Transport {
 
             // If the server returned UNAUTHORIZED, and it is the first time we replay the call,
             // check if we can get the username/password for the HTTP Auth.
-            if status == reqwest::StatusCode::UNAUTHORIZED {
+            if status == StatusCode::UNAUTHORIZED {
                 if self.url.scheme() == "https" || self.url.host_str() == Some("localhost") {
                     // If there is a password manager, get the username and password from it.
                     self.maybe_add_authorization(&mut http_request, false)?;
@@ -226,7 +229,7 @@ impl ReqwestHttpReplicaV2Transport {
             Err(AgentError::HttpError(HttpErrorPayload {
                 status: status.into(),
                 content_type: headers
-                    .get(reqwest::header::CONTENT_TYPE)
+                    .get(CONTENT_TYPE)
                     .and_then(|value| value.to_str().ok())
                     .map(|x| x.to_string()),
                 content: body,
@@ -237,68 +240,41 @@ impl ReqwestHttpReplicaV2Transport {
     }
 }
 
-impl super::ReplicaV2Transport for ReqwestHttpReplicaV2Transport {
-    fn call<'a>(
-        &'a self,
+impl ReplicaV2Transport for ReqwestHttpReplicaV2Transport {
+    fn call(
+        &self,
         effective_canister_id: Principal,
         envelope: Vec<u8>,
         _request_id: RequestId,
-    ) -> Pin<Box<dyn Future<Output = Result<(), AgentError>> + Send + 'a>> {
-        async fn run(
-            s: &ReqwestHttpReplicaV2Transport,
-            effective_canister_id: Principal,
-            envelope: Vec<u8>,
-        ) -> Result<(), AgentError> {
+    ) -> AgentFuture<()> {
+        Box::pin(async move {
             let endpoint = format!("canister/{}/call", effective_canister_id.to_text());
-            s.execute(Method::POST, &endpoint, Some(envelope)).await?;
+            self.execute(Method::POST, &endpoint, Some(envelope))
+                .await?;
             Ok(())
-        }
-
-        Box::pin(run(self, effective_canister_id, envelope))
+        })
     }
 
-    fn read_state<'a>(
-        &'a self,
+    fn read_state(
+        &self,
         effective_canister_id: Principal,
         envelope: Vec<u8>,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>> {
-        async fn run(
-            s: &ReqwestHttpReplicaV2Transport,
-            effective_canister_id: Principal,
-            envelope: Vec<u8>,
-        ) -> Result<Vec<u8>, AgentError> {
+    ) -> AgentFuture<Vec<u8>> {
+        Box::pin(async move {
             let endpoint = format!("canister/{}/read_state", effective_canister_id.to_text());
-            s.execute(Method::POST, &endpoint, Some(envelope)).await
-        }
-
-        Box::pin(run(self, effective_canister_id, envelope))
+            self.execute(Method::POST, &endpoint, Some(envelope)).await
+        })
     }
 
-    fn query<'a>(
-        &'a self,
-        effective_canister_id: Principal,
-        envelope: Vec<u8>,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>> {
-        async fn run(
-            s: &ReqwestHttpReplicaV2Transport,
-            effective_canister_id: Principal,
-            envelope: Vec<u8>,
-        ) -> Result<Vec<u8>, AgentError> {
+    fn query(&self, effective_canister_id: Principal, envelope: Vec<u8>) -> AgentFuture<Vec<u8>> {
+        Box::pin(async move {
             let endpoint = format!("canister/{}/query", effective_canister_id.to_text());
-            s.execute(Method::POST, &endpoint, Some(envelope)).await
-        }
-
-        Box::pin(run(self, effective_canister_id, envelope))
+            self.execute(Method::POST, &endpoint, Some(envelope)).await
+        })
     }
 
-    fn status<'a>(
-        &'a self,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>> {
-        async fn run(s: &ReqwestHttpReplicaV2Transport) -> Result<Vec<u8>, AgentError> {
-            s.execute(Method::GET, "status", None).await
-        }
-
-        Box::pin(run(self))
+    fn status(&self) -> AgentFuture<Vec<u8>> {
+        Box::pin(async move { self.execute(Method::GET, "status", None).await })
     }
 }
 

--- a/ic-agent/src/agent/replica_api.rs
+++ b/ic-agent/src/agent/replica_api.rs
@@ -108,7 +108,7 @@ pub struct ReadStateResponse {
     pub certificate: Vec<u8>,
 }
 
-/// A `Certificate` as defined in https://smartcontracts.org/docs/interface-spec/index.html#_certificate
+/// A `Certificate` as defined in <https://smartcontracts.org/docs/interface-spec/index.html#_certificate>
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 pub struct Certificate<'a> {
     /// The hash tree.

--- a/ic-agent/src/agent/status.rs
+++ b/ic-agent/src/agent/status.rs
@@ -9,7 +9,7 @@ use std::{collections::BTreeMap, fmt::Debug};
 pub enum Value {
     /// See [`Null`](serde_cbor::Value::Null).
     Null,
-    /// See [`String`](serde_cbor::Value::String).
+    /// See [`String`](serde_cbor::Value::Text).
     String(String),
     /// See [`Integer`](serde_cbor::Value::Integer).
     Integer(i64),
@@ -17,7 +17,7 @@ pub enum Value {
     Bool(bool),
     /// See [`Bytes`](serde_cbor::Value::Bytes).
     Bytes(Vec<u8>),
-    /// See [`Vec`](serde_cbor::Value::Vec).
+    /// See [`Vec`](serde_cbor::Value::Array).
     Vec(Vec<Value>),
     /// See [`Map`](serde_cbor::Value::Map).
     Map(BTreeMap<String, Box<Value>>),
@@ -38,7 +38,7 @@ impl std::fmt::Display for Value {
     }
 }
 
-/// The structure returned by [`ic_agent::Agent::status`], containing the information returned
+/// The structure returned by [`super::Agent::status`], containing the information returned
 /// by the status endpoint of a replica.
 #[derive(Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct Status {

--- a/ic-agent/src/request_id/mod.rs
+++ b/ic-agent/src/request_id/mod.rs
@@ -659,7 +659,7 @@ impl<'a> ser::SerializeStructVariant for &'a mut RequestIdSerializer {
 
 /// Derive the request ID from a serializable data structure.
 ///
-/// See https://hydra.dfinity.systems//build/268411/download/1/dfinity/spec/public/index.html#api-request-id
+/// See <https://hydra.dfinity.systems//build/268411/download/1/dfinity/spec/public/index.html#api-request-id>
 ///
 /// # Warnings
 ///


### PR DESCRIPTION
# Description

These are all no-impact changes. Nothing seems worthy of `CHANGELOG` since there are no changes to the public interface or functionality.

* Cleanup imports
* fix doc comments
* Introduce private `AgentFuture` alias to improve readability
* Switch to `async` blocks instead of private `run` helpers

# How Has This Been Tested?

`cargo test && cargo clippy && cargo doc`

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
