### PR TITLE
chore: add dfx `0.11.1` to e2e GHAction

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ macos-latest, ubuntu-latest ]
         rust: [ '1.60.0' ]
-        dfx: [ '0.8.4', '0.9.2', '0.10.1' ]
+        dfx: [ '0.8.4', '0.9.2', '0.10.1', '0.11.1' ]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
# Description

Closes https://dfinity.atlassian.net/browse/SDK-626

# How Has This Been Tested?

Not tested, instead I'm counting on github action tests that will run for this PR

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
