### PR TITLE
fix disable_range_check condition

### DIFF
--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1192,10 +1192,10 @@ pub struct UpdateBuilder<'agent> {
 impl<'agent> UpdateBuilder<'agent> {
     /// Creates a new query builder with an agent for a particular canister method.
     pub fn new(agent: &'agent Agent, canister_id: Principal, method_name: String) -> Self {
-        // When calling provisional_create_canister_with_cycles, every effective_canister_id is valid.
+        // When calling provisional_create_canister_with_cycles on the Management Canister, every effective_canister_id is valid.
         // Therefore we need to disable the check for valid canister_ranges in the certificate validation.
         // More info: https://docs.dfinity.systems/spec/public/#http-effective-canister-id
-        let disable_range_check = method_name == "provisional_create_canister_with_cycles";
+        let disable_range_check = canister_id == Principal::from_text("aaaaa-aa").unwrap() && method_name == "provisional_create_canister_with_cycles";
         Self {
             agent,
             effective_canister_id: canister_id,


### PR DESCRIPTION
The `disable_range_check` condition should check that the call is to the Management Canister, not to an application canister offering a method with the name `provisional_canister_create_with_cycles`.