### PR TITLE
feat: allow setting agent identity after construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Switched to `miracl_core_bls12381` crate for bls
 * Added new `hyper` transport `HyperReplicaV2Transport`
+* Added Agent::set_identity method (#379)
 
 ## [0.20.0] - 2022-07-14
 

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -279,6 +279,18 @@ impl Agent {
         self.transport = Arc::new(transport);
     }
 
+    /// Set the identity provider for signing messages.
+    ///
+    /// NOTE: if you change the identity while having update calls in
+    /// flight, you will not be able to [Agent::poll] the status of these
+    /// messages.
+    pub fn set_identity<I>(&mut self, identity: I)
+    where
+        I: 'static + Identity,
+    {
+        self.identity = Arc::new(identity);
+    }
+
     /// By default, the agent is configured to talk to the main Internet Computer, and verifies
     /// responses using a hard-coded public key.
     ///


### PR DESCRIPTION
# Description

This change adds the `Agent::set_identity` method modifying the
identity after constructing the agent.

Motivation: I am writing a test suite where I must send messages to
the same canister from different identities. Being able to
Agent::clone() followed by Agent::set_identity() would significantly
simplify (and speed up) my code.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
