### PR TITLE
fix: lookup request status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Switched to `miracl_core_bls12381` crate for bls
 * Added new `hyper` transport `HyperReplicaV2Transport`
 * Added Agent::set_identity method (#379)
+* Updated lookup_request_status method to handle proofs of absent paths in certificates.
 
 ## [0.20.0] - 2022-07-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,9 +206,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "candid"
-version = "0.7.15"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f5cdd24185c6d6edba09bcfe06cf9c1e7fd579cbe5e4ae2dffba9c474a5a7f"
+checksum = "f5e129401e8480393ca7060debaf75e07f0b150aa05ef043325515f5353ced57"
 dependencies = [
  "anyhow",
  "binread",
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "ic-types"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a67e4edc28c09d29ab97b50410245c91d71756eaf3956212e3488cd6eb75fda4"
+checksum = "79a17269dff0ec6ca4c3d04e18fca97d018ff53d809e6d92348fc22f9588e1a5"
 dependencies = [
  "crc32fast",
  "data-encoding",
@@ -1236,6 +1236,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -24,7 +24,7 @@ hex = "0.4.0"
 http = "0.2.6"
 http-body = "0.4.5"
 hyper-rustls = { version = "0.23.0", features = [ "webpki-roots", "http2" ] }
-ic-types = { git = "https://github.com/mraszyk/ic-types" }
+ic-types = "0.5.0"
 k256 = { version = "0.11", features = ["pem"] }
 leb128 = "0.2.5"
 mime = "0.3.16"
@@ -59,7 +59,7 @@ version = "1.0"
 optional = true
 
 [dev-dependencies]
-candid = { git = "https://github.com/mraszyk/candid" }
+candid = "0.7.17"
 mockito = "0.31.0"
 proptest = "1.0.0"
 serde_json = "1.0.79"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -24,7 +24,7 @@ hex = "0.4.0"
 http = "0.2.6"
 http-body = "0.4.5"
 hyper-rustls = { version = "0.23.0", features = [ "webpki-roots", "http2" ] }
-ic-types = "0.4.0"
+ic-types = { git = "https://github.com/mraszyk/ic-types" }
 k256 = { version = "0.11", features = ["pem"] }
 leb128 = "0.2.5"
 mime = "0.3.16"
@@ -59,7 +59,7 @@ version = "1.0"
 optional = true
 
 [dev-dependencies]
-candid = "0.7.15"
+candid = { git = "https://github.com/mraszyk/candid" }
 mockito = "0.31.0"
 proptest = "1.0.0"
 serde_json = "1.0.79"

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -78,7 +78,7 @@ pub(crate) fn lookup_request_status(
     ];
     match certificate.tree.lookup_path(&path_status) {
         LookupResult::Absent => Ok(RequestStatusResponse::Unknown),
-        LookupResult::Unknown => Err(LookupPathUnknown(path_status.into())),
+        LookupResult::Unknown => Ok(RequestStatusResponse::Unknown),
         LookupResult::Found(status) => match from_utf8(status)? {
             "done" => Ok(RequestStatusResponse::Done),
             "processing" => Ok(RequestStatusResponse::Processing),

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -78,7 +78,7 @@ pub(crate) fn lookup_request_status(
     ];
     match certificate.tree.lookup_path(&path_status) {
         LookupResult::Absent => Ok(RequestStatusResponse::Unknown),
-        LookupResult::Unknown => Ok(RequestStatusResponse::Unknown),
+        LookupResult::Unknown => Err(LookupPathUnknown(path_status.into())),
         LookupResult::Found(status) => match from_utf8(status)? {
             "done" => Ok(RequestStatusResponse::Done),
             "processing" => Ok(RequestStatusResponse::Processing),

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -77,7 +77,7 @@ pub(crate) fn lookup_request_status(
         "status".into(),
     ];
     match certificate.tree.lookup_path(&path_status) {
-        LookupResult::Absent => Err(LookupPathAbsent(path_status.into())),
+        LookupResult::Absent => Ok(RequestStatusResponse::Unknown),
         LookupResult::Unknown => Ok(RequestStatusResponse::Unknown),
         LookupResult::Found(status) => match from_utf8(status)? {
             "done" => Ok(RequestStatusResponse::Done),


### PR DESCRIPTION
This PR fixes the method `lookup_request_status` to handle proofs of absence introduced in this [MR](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/7661).

The case
```
LookupResult::Unknown => Err(LookupPathUnknown(path_status.into())),
```
will be updated in the function `lookup_request_status` after this [MR](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/7661) is merged.