### PR TITLE
fix: Remove use of the miracl_core_bls12381 crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ic-agent
 
-* Switched to `miracl_core_bls12381` crate for bls
+* Switched to `ic-verify-bls-signature` crate for verify BLS signatures
 * Added new `hyper` transport `HyperReplicaV2Transport`
 * Added Agent::set_identity method (#379)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,11 +179,34 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62250ece575fa9b22068b3a8d59586f01d426dd7785522efd97632959e71c986"
+dependencies = [
+ "digest 0.9.0",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -421,11 +444,20 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.2",
  "crypto-common",
  "subtle",
 ]
@@ -478,7 +510,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest",
+ "digest 0.10.3",
  "ff",
  "generic-array",
  "group",
@@ -666,6 +698,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
 dependencies = [
+ "byteorder",
  "ff",
  "rand_core",
  "subtle",
@@ -729,7 +762,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -842,10 +875,10 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "ic-types",
+ "ic-verify-bls-signature",
  "k256",
  "leb128",
  "mime",
- "miracl_core_bls12381",
  "mockito",
  "pem",
  "pkcs8",
@@ -859,7 +892,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
- "sha2",
+ "sha2 0.10.2",
  "simple_asn1",
  "thiserror",
  "tokio",
@@ -874,7 +907,7 @@ dependencies = [
  "ic-agent",
  "num-bigint 0.4.3",
  "pkcs11",
- "sha2",
+ "sha2 0.10.2",
  "simple_asn1",
  "thiserror",
 ]
@@ -890,7 +923,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.10.2",
  "thiserror",
 ]
 
@@ -914,6 +947,18 @@ dependencies = [
  "strum_macros",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "ic-verify-bls-signature"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583b1c03380cf86059160cc6c91dcbf56c7b5f141bf3a4f06bc79762d775fac4"
+dependencies = [
+ "bls12_381",
+ "lazy_static",
+ "pairing",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -951,7 +996,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "sha2",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -1023,7 +1068,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -1169,12 +1214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miracl_core_bls12381"
-version = "4.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07cbe42e2a8dd41df582fb8e00fc24d920b5561cc301fcb6d14e2e0434b500f"
-
-[[package]]
 name = "mockito"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1352,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl"
 version = "0.10.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,6 +1407,15 @@ name = "os_str_bytes"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
+
+[[package]]
+name = "pairing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+dependencies = [
+ "group",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1665,7 +1719,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_cbor",
- "sha2",
+ "sha2 0.10.2",
  "tokio",
 ]
 
@@ -1968,13 +2022,26 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1992,7 +2059,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
 dependencies = [
- "digest",
+ "digest 0.10.3",
  "rand_core",
 ]
 

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -24,11 +24,11 @@ hex = "0.4.0"
 http = "0.2.6"
 http-body = "0.4.5"
 hyper-rustls = { version = "0.23.0", features = [ "webpki-roots", "http2" ] }
+ic-verify-bls-signature = "0.1"
 ic-types = "0.4.0"
 k256 = { version = "0.11", features = ["pem"] }
 leb128 = "0.2.5"
 mime = "0.3.16"
-miracl_core_bls12381 = { version = "4.2.2", default-features = false, features = ["allow_alt_compress", "std"] }
 rand = "0.8.5"
 rustls = "0.20.4"
 ring = { version = "0.16.11", features = ["std"] }

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -33,11 +33,9 @@ use garcon::Waiter;
 use serde::Serialize;
 use status::Status;
 
-use crate::{
-    agent::response_authentication::{
-        extract_der, lookup_canister_info, lookup_canister_metadata,
-        lookup_request_status, lookup_value,
-    },
+use crate::agent::response_authentication::{
+    extract_der, lookup_canister_info, lookup_canister_metadata, lookup_request_status,
+    lookup_value,
 };
 use std::{
     convert::TryFrom,

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -2,25 +2,12 @@ use crate::{ic_types::Principal, AgentError, RequestId};
 
 use crate::{
     agent::{replica_api::Certificate, Replied, RequestStatusResponse},
-    bls::bls12381::bls,
     hash_tree::{Label, LookupResult},
 };
-use std::{str::from_utf8, sync::Once};
+use std::str::from_utf8;
 
 const DER_PREFIX: &[u8; 37] = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x01\x02\x01\x06\x0c\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x02\x01\x03\x61\x00";
 const KEY_LENGTH: usize = 96;
-
-static INIT_BLS: Once = Once::new();
-
-pub fn initialize_bls() -> Result<(), AgentError> {
-    let mut result = Ok(());
-    INIT_BLS.call_once(|| {
-        if bls::init() != bls::BLS_OK {
-            result = Err(AgentError::BlsInitializationFailure());
-        }
-    });
-    result
-}
 
 pub fn extract_der(buf: Vec<u8>) -> Result<Vec<u8>, AgentError> {
     let expected_length = DER_PREFIX.len() + KEY_LENGTH;

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -116,8 +116,6 @@
 #[macro_use]
 mod macros;
 
-pub use miracl_core_bls12381 as bls;
-
 pub mod agent;
 pub mod export;
 pub mod identity;


### PR DESCRIPTION
# Description

The `miracl_core_bls12381` crate was created for use in the IC however it has a number of performance and security issues which have caused us to remove all uses of it within the IC itself. Speaking on behalf of the DFINITY crypto team which up until now has maintained this crate, we would at this point much rather yank all versions and forget it ever existed.

This replaces the code that used `miracl_core_bls12381` with instead using a small crate that uses the `zkcrypto/bls12_381` library.

Fixes # (issue)

# How Has This Been Tested?

Just with `cargo test`. Not sure if there is anything else that is required/useful if so let me know.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation. (N/A)
