### PR TITLE
feat: specifying effective canister id for canister creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added Agent::set_identity method (#379)
 * Updated lookup_request_status method to handle proofs of absent paths in certificates.
 
+### ic-utils
+
+* Make it possible to specify effective canister id in CreateCanisterBuilder
+
 ## [0.20.0] - 2022-07-14
 
 ### Breaking change: Updated to ic-types 0.4.0

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -43,6 +43,7 @@ pub struct CanisterSettings {
 #[derive(Debug)]
 pub struct CreateCanisterBuilder<'agent, 'canister: 'agent> {
     canister: &'canister Canister<'agent>,
+    effective_canister_id: Principal,
     controllers: Option<Result<Vec<Principal>, AgentError>>,
     compute_allocation: Option<Result<ComputeAllocation, AgentError>>,
     memory_allocation: Option<Result<MemoryAllocation, AgentError>>,
@@ -56,6 +57,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     pub fn builder(canister: &'canister Canister<'agent>) -> Self {
         Self {
             canister,
+            effective_canister_id: Principal::management_canister(),
             controllers: None,
             compute_allocation: None,
             memory_allocation: None,
@@ -77,6 +79,21 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
             is_provisional_create: true,
             amount,
             ..self
+        }
+    }
+
+    /// Pass in an effective canister id for the update call.
+    pub fn with_effective_canister_id<C, E>(self, effective_canister_id: C) -> Self
+    where
+        E: std::fmt::Display,
+        C: TryInto<Principal, Error = E>,
+    {
+        match effective_canister_id.try_into() {
+            Ok(effective_canister_id) => Self {
+                effective_canister_id: effective_canister_id,
+                ..self
+            },
+            Err(_) => self,
         }
     }
 
@@ -240,6 +257,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
             self.canister
                 .update_(MgmtMethod::ProvisionalCreateCanisterWithCycles.as_ref())
                 .with_arg(in_arg)
+                .with_effective_canister_id(self.effective_canister_id)
         } else {
             self.canister
                 .update_(MgmtMethod::CreateCanister.as_ref())
@@ -249,6 +267,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
                     memory_allocation,
                     freezing_threshold,
                 })
+                .with_effective_canister_id(self.effective_canister_id)
         };
 
         Ok(async_builder

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -90,7 +90,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     {
         match effective_canister_id.try_into() {
             Ok(effective_canister_id) => Self {
-                effective_canister_id: effective_canister_id,
+                effective_canister_id,
                 ..self
             },
             Err(_) => self,


### PR DESCRIPTION
This PR enables incremental changes in IC tests specifying an effective canister id when creating canisters. After all these changes are implemented, the special case of `provisional_create_canister_with_cycles` in checking certificate delegation can be removed.
