### PR TITLE
feat: update candid v0.8.0, move hash_tree from ic-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.21.0] - 2022-10-03
 
+* Update `candid` to v0.8.0.
+* Move `hash_tree` from `ic-types` and no more re-export ic-types.
+
 ## [0.20.1] - 2022-09-27
 
 * Set `default-features = false` for `ic-agent` interdependencies to reduce unused nested dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2022-10-03
+
 ## [0.20.1] - 2022-09-27
 
 * Set `default-features = false` for `ic-agent` interdependencies to reduce unused nested dependencies.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base32",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "hex",
  "ic-agent",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,6 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "ic-types",
  "ic-verify-bls-signature",
  "k256",
  "leb128",
@@ -912,18 +911,6 @@ dependencies = [
  "sha2 0.10.2",
  "simple_asn1",
  "thiserror",
-]
-
-[[package]]
-name = "ic-types"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f71819838e87d73ff0bf7baf5dae44ba28e24eec4da68ed072e52ba16750d9"
-dependencies = [
- "hex",
- "serde",
- "serde_bytes",
- "sha2 0.10.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,17 +229,18 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "candid"
-version = "0.7.18"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d510cc32b8b991acc955dd3d5e0cb6f404069d1dccd9203ee90f5865557c9165"
+checksum = "b26cb1b42af9fc5ff99a6806710e7f83634e533f8ad9b801e6c5e40658da98b6"
 dependencies = [
  "anyhow",
  "binread",
  "byteorder",
  "candid_derive",
  "codespan-reporting",
+ "crc32fast",
+ "data-encoding",
  "hex",
- "ic-types",
  "lalrpop",
  "lalrpop-util",
  "leb128",
@@ -251,14 +252,15 @@ dependencies = [
  "pretty",
  "serde",
  "serde_bytes",
+ "sha2 0.10.2",
  "thiserror",
 ]
 
 [[package]]
 name = "candid_derive"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e02c03c4d547674a3f3f3109538fb49871fbe636216daa019f06a62faca9061"
+checksum = "58f1f4db7c7d04b87b70b3a35c5dc5c2c9dd73cef8bdf6760e2f18a0d45350dd"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -914,17 +916,14 @@ dependencies = [
 
 [[package]]
 name = "ic-types"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a17269dff0ec6ca4c3d04e18fca97d018ff53d809e6d92348fc22f9588e1a5"
+checksum = "55f71819838e87d73ff0bf7baf5dae44ba28e24eec4da68ed072e52ba16750d9"
 dependencies = [
- "crc32fast",
- "data-encoding",
  "hex",
  "serde",
  "serde_bytes",
  "sha2 0.10.2",
- "thiserror",
 ]
 
 [[package]]

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -26,7 +26,6 @@ http = "0.2.6"
 http-body = "0.4.5"
 hyper-rustls = { version = "0.23.0", features = [ "webpki-roots", "http2" ] }
 ic-verify-bls-signature = "0.1"
-ic-types = "0.6.0"
 k256 = { version = "0.11", features = ["pem"] }
 leb128 = "0.2.5"
 mime = "0.3.16"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-agent"
-version = "0.20.1"
+version = "0.21.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Agent library to communicate with the Internet Computer, following the Public Specification."

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -19,13 +19,14 @@ async-trait = "0.1.53"
 base32 = "0.4.0"
 base64 = "0.13.0"
 byteorder = "1.3.2"
+candid = "0.8.0"
 garcon = { version = "0.2", features = ["async"] }
 hex = "0.4.0"
 http = "0.2.6"
 http-body = "0.4.5"
 hyper-rustls = { version = "0.23.0", features = [ "webpki-roots", "http2" ] }
 ic-verify-bls-signature = "0.1"
-ic-types = "0.5.0"
+ic-types = "0.6.0"
 k256 = { version = "0.11", features = ["pem"] }
 leb128 = "0.2.5"
 mime = "0.3.16"
@@ -59,7 +60,6 @@ version = "1.0"
 optional = true
 
 [dev-dependencies]
-candid = "0.7.18"
 mockito = "0.31.0"
 proptest = "1.0.0"
 serde_json = "1.0.79"

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -22,7 +22,7 @@ use crate::{
         http_transport::{IC0_DOMAIN, IC0_SUB_DOMAIN},
         AgentFuture, ReplicaV2Transport,
     },
-    ic_types::Principal,
+    export::Principal,
     AgentError, RequestId,
 };
 

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -18,7 +18,7 @@ use crate::{
         http_transport::{IC0_DOMAIN, IC0_SUB_DOMAIN},
         AgentFuture, ReplicaV2Transport,
     },
-    ic_types::Principal,
+    export::Principal,
     AgentError, RequestId,
 };
 

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -165,7 +165,7 @@ pub enum PollResult {
 /// ```ignore
 /// # // This test is ignored because it requires an ic to be running. We run these
 /// # // in the ic-ref workflow.
-/// use ic_agent::{Agent, ic_types::Principal};
+/// use ic_agent::{Agent, export::Principal};
 /// use candid::{Encode, Decode, CandidType, Nat};
 /// use serde::Deserialize;
 ///

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -1,4 +1,4 @@
-use crate::{ic_types::Principal, AgentError, RequestId};
+use crate::{export::Principal, AgentError, RequestId};
 
 use crate::{
     agent::{replica_api::Certificate, Replied, RequestStatusResponse},

--- a/ic-agent/src/export.rs
+++ b/ic-agent/src/export.rs
@@ -1,2 +1,2 @@
 //! A module to re-export types that are visible through the ic-agent API.
-pub use crate::ic_types::{Principal, PrincipalError};
+pub use candid::types::principal::{Principal, PrincipalError};

--- a/ic-agent/src/hash_tree/mod.rs
+++ b/ic-agent/src/hash_tree/mod.rs
@@ -1,0 +1,587 @@
+//! cf https://sdk.dfinity.org/docs/interface-spec/index.html#certification-encoding
+
+use hex::FromHexError;
+use sha2::Digest;
+use std::borrow::Cow;
+
+/// Sha256 Digest: 32 bytes
+pub type Sha256Digest = [u8; 32];
+
+#[derive(Clone, Hash, Ord, PartialOrd, Eq, PartialEq, serde::Deserialize)]
+#[serde(from = "&serde_bytes::Bytes")]
+#[serde(into = "&serde_bytes::ByteBuf")]
+/// For labeled [HashTreeNode]
+pub struct Label(Vec<u8>);
+
+impl Label {
+    /// Returns this label as bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl From<Label> for serde_bytes::ByteBuf {
+    fn from(label: Label) -> serde_bytes::ByteBuf {
+        serde_bytes::ByteBuf::from(label.as_bytes().to_vec())
+    }
+}
+
+impl<T> From<T> for Label
+where
+    T: AsRef<[u8]>,
+{
+    fn from(s: T) -> Self {
+        Self(s.as_ref().to_owned())
+    }
+}
+
+impl std::fmt::Display for Label {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use std::fmt::Write;
+
+        // Try to print it as an UTF-8 string. If an error happens, print the bytes
+        // as hexadecimal.
+        match std::str::from_utf8(self.as_bytes()) {
+            Ok(s) if s.chars().all(|c| c.is_ascii_graphic()) => {
+                f.write_char('"')?;
+                f.write_str(s)?;
+                f.write_char('"')
+            }
+            _ => {
+                write!(f, "0x")?;
+                std::fmt::Debug::fmt(self, f)
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for Label {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_bytes()
+            .iter()
+            .try_for_each(|b| write!(f, "{:02X}", b))
+    }
+}
+
+impl serde::Serialize for Label {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if serializer.is_human_readable() {
+            format!("{:?}", self).serialize(serializer)
+        } else {
+            serializer.serialize_bytes(self.0.as_ref())
+        }
+    }
+}
+
+/// A result of looking up for a certificate.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum LookupResult<'tree> {
+    /// The value is guaranteed to be absent in the original state tree.
+    Absent,
+
+    /// This partial view does not include information about this path, and the original
+    /// tree may or may note include this value.
+    Unknown,
+
+    /// The value was found at the referenced node.
+    Found(&'tree [u8]),
+
+    /// The path does not make sense for this certificate.
+    Error,
+}
+
+/// A HashTree representing a full tree.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct HashTree<'a> {
+    root: HashTreeNode<'a>,
+}
+
+#[allow(dead_code)]
+impl<'a> HashTree<'a> {
+    /// Recomputes root hash of the full tree that this hash tree was constructed from.
+    #[inline]
+    pub fn digest(&self) -> Sha256Digest {
+        self.root.digest()
+    }
+
+    /// Given a (verified) tree, the client can fetch the value at a given path, which is a
+    /// sequence of labels (blobs).
+    pub fn lookup_path<'p, P>(&self, path: P) -> LookupResult<'_>
+    where
+        P: IntoIterator<Item = &'p Label>,
+    {
+        self.root.lookup_path(&mut path.into_iter())
+    }
+
+    /// List all paths in the [HashTree]
+    pub fn list_paths(&self) -> Vec<Vec<Label>> {
+        self.root.list_paths(&vec![])
+    }
+}
+
+impl<'a> AsRef<HashTreeNode<'a>> for HashTree<'a> {
+    fn as_ref(&self) -> &HashTreeNode<'a> {
+        &self.root
+    }
+}
+
+impl<'a> From<HashTree<'a>> for HashTreeNode<'a> {
+    fn from(tree: HashTree<'a>) -> HashTreeNode<'a> {
+        tree.root
+    }
+}
+
+impl serde::Serialize for HashTree<'_> {
+    fn serialize<S>(
+        &self,
+        serializer: S,
+    ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.root.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for HashTree<'_> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(HashTree {
+            root: HashTreeNode::deserialize(deserializer)?,
+        })
+    }
+}
+
+/// Create an empty hash tree.
+#[inline]
+pub fn empty() -> HashTree<'static> {
+    HashTree {
+        root: HashTreeNode::Empty(),
+    }
+}
+
+/// Create a forked tree from two trees or node.
+#[inline]
+pub fn fork<'a, 'l: 'a, 'r: 'a>(left: HashTree<'l>, right: HashTree<'r>) -> HashTree<'a> {
+    HashTree {
+        root: HashTreeNode::Fork(Box::new((left.root, right.root))),
+    }
+}
+
+/// Create a labeled hash tree.
+#[inline]
+pub fn label<'a, L: Into<Label>, N: Into<HashTree<'a>>>(label: L, node: N) -> HashTree<'a> {
+    HashTree {
+        root: HashTreeNode::Labeled(Cow::Owned(label.into()), Box::new(node.into().root)),
+    }
+}
+
+/// Create a leaf in the tree.
+#[inline]
+pub fn leaf<L: AsRef<[u8]>>(leaf: L) -> HashTree<'static> {
+    HashTree {
+        root: HashTreeNode::Leaf(Cow::Owned(leaf.as_ref().to_owned())),
+    }
+}
+
+/// Create a pruned tree node.
+#[inline]
+pub fn pruned<C: Into<Sha256Digest>>(content: C) -> HashTree<'static> {
+    HashTree {
+        root: HashTreeNode::Pruned(content.into()),
+    }
+}
+
+/// Create a pruned tree node, from a hex representation of the data. Useful for
+/// testing or hard coded values.
+#[inline]
+pub fn pruned_from_hex<C: AsRef<str>>(content: C) -> Result<HashTree<'static>, FromHexError> {
+    let mut decode: Sha256Digest = [0; 32];
+    hex::decode_to_slice(content.as_ref(), &mut decode)?;
+
+    Ok(pruned(decode))
+}
+
+/// Private type for label lookup result.
+#[derive(Debug)]
+enum LookupLabelResult<'node> {
+    /// The label is not part of this node's tree.
+    Absent,
+
+    /// Same as absent, but some leaves were pruned and so it's impossible to know.
+    Unknown,
+
+    /// The label was not found, but could still be to the left.
+    Less,
+
+    /// The label was not found, but could still be to the right.
+    Greater,
+
+    /// The label was found. Contains a reference to the [HashTreeNode].
+    Found(&'node HashTreeNode<'node>),
+}
+
+/// A Node in the HashTree.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) enum HashTreeNode<'a> {
+    Empty(),
+    Fork(Box<(HashTreeNode<'a>, HashTreeNode<'a>)>),
+    Labeled(Cow<'a, Label>, Box<HashTreeNode<'a>>),
+    Leaf(Cow<'a, [u8]>),
+    Pruned(Sha256Digest),
+}
+
+impl std::fmt::Debug for HashTreeNode<'_> {
+    // Shows a nicer view to debug than the default debugger.
+    // Example:
+    //
+    // ```
+    // HashTree {
+    //     root: Fork(
+    //         Fork(
+    //             Label("a", Fork(
+    //                 Pruned(1b4feff9bef8131788b0c9dc6dbad6e81e524249c879e9f10f71ce3749f5a638),
+    //                 Label("y", Leaf("world")),
+    //             )),
+    //             Label("b", Pruned(7b32ac0c6ba8ce35ac82c255fc7906f7fc130dab2a090f80fe12f9c2cae83ba6)),
+    //         ),
+    //         Fork(
+    //             Pruned(ec8324b8a1f1ac16bd2e806edba78006479c9877fed4eb464a25485465af601d),
+    //             Label("d", Leaf("morning")),
+    //         ),
+    //     ),
+    // }
+    // ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn readable_print(f: &mut std::fmt::Formatter<'_>, v: &[u8]) -> std::fmt::Result {
+            // If it's UTF-8 and all the characters are graphic ASCII, then show as a string.
+            // If it's short, show hex.
+            // Otherwise, show length.
+            match std::str::from_utf8(v) {
+                Ok(s) if s.chars().all(|c| c.is_ascii_graphic()) => {
+                    f.write_str("\"")?;
+                    f.write_str(s)?;
+                    f.write_str("\"")
+                }
+                _ if v.len() <= 32 => {
+                    f.write_str("0x")?;
+                    f.write_str(&hex::encode(v))
+                }
+                _ => {
+                    write!(f, "{} bytes", v.len())
+                }
+            }
+        }
+
+        match self {
+            HashTreeNode::Empty() => f.write_str("Empty"),
+            HashTreeNode::Fork(nodes) => f
+                .debug_tuple("Fork")
+                .field(&nodes.0)
+                .field(&nodes.1)
+                .finish(),
+            HashTreeNode::Leaf(v) => {
+                f.write_str("Leaf(")?;
+                readable_print(f, v)?;
+                f.write_str(")")
+            }
+            HashTreeNode::Labeled(l, node) => {
+                f.write_str("Label(")?;
+                readable_print(f, l.as_bytes())?;
+                f.write_str(", ")?;
+                node.fmt(f)?;
+                f.write_str(")")
+            }
+            HashTreeNode::Pruned(digest) => write!(f, "Pruned({})", hex::encode(digest.as_ref())),
+        }
+    }
+}
+
+impl<'a> HashTreeNode<'a> {
+    /// Update a hasher with the domain separator (byte(|s|) . s).
+    #[inline]
+    fn domain_sep(&self, hasher: &mut sha2::Sha256) {
+        let domain_sep = match self {
+            HashTreeNode::Empty() => "ic-hashtree-empty",
+            HashTreeNode::Fork(_) => "ic-hashtree-fork",
+            HashTreeNode::Labeled(_, _) => "ic-hashtree-labeled",
+            HashTreeNode::Leaf(_) => "ic-hashtree-leaf",
+            HashTreeNode::Pruned(_) => return,
+        };
+        hasher.update(&[domain_sep.len() as u8]);
+        hasher.update(domain_sep.as_bytes());
+    }
+
+    /// Calculate the digest of this node only.
+    #[inline]
+    pub fn digest(&self) -> Sha256Digest {
+        let mut hasher = sha2::Sha256::new();
+        self.domain_sep(&mut hasher);
+
+        match self {
+            HashTreeNode::Empty() => {}
+            HashTreeNode::Fork(nodes) => {
+                hasher.update(&nodes.0.digest());
+                hasher.update(&nodes.1.digest());
+            }
+            HashTreeNode::Labeled(label, node) => {
+                hasher.update(&label.as_bytes());
+                hasher.update(&node.digest());
+            }
+            HashTreeNode::Leaf(bytes) => {
+                hasher.update(bytes);
+            }
+            HashTreeNode::Pruned(digest) => {
+                return *digest;
+            }
+        }
+
+        hasher.finalize().into()
+    }
+
+    /// Lookup a single label, returning a reference to the labeled [HashTreeNode] node if found.
+    ///
+    /// This assumes a sorted hash tree, which is what the spec says the system should
+    /// return. It will stop when it finds a label that's greater than the one being looked
+    /// for.
+    ///
+    /// This function is implemented with flattening in mind, ie. flattening the forks
+    /// is not necessary.
+    fn lookup_label(&self, label: &Label) -> LookupLabelResult {
+        match self {
+            // If this node is a labeled node, check for the name.
+            HashTreeNode::Labeled(l, node) => match label.cmp(l) {
+                std::cmp::Ordering::Greater => LookupLabelResult::Greater,
+                std::cmp::Ordering::Equal => LookupLabelResult::Found(node.as_ref()),
+                // If this node has a smaller label than the one we're looking for, shortcut
+                // out of this search (sorted tree), we looked too far.
+                std::cmp::Ordering::Less => LookupLabelResult::Less,
+            },
+            HashTreeNode::Fork(nodes) => {
+                let left_label = nodes.0.lookup_label(label);
+                match left_label {
+                    // On greater or unknown, look on the right side of the fork.
+                    LookupLabelResult::Greater => {
+                        let right_label = nodes.1.lookup_label(label);
+                        match right_label {
+                            LookupLabelResult::Less => LookupLabelResult::Absent,
+                            result => result,
+                        }
+                    }
+                    LookupLabelResult::Unknown => {
+                        let right_label = nodes.1.lookup_label(label);
+                        match right_label {
+                            LookupLabelResult::Less => LookupLabelResult::Unknown,
+                            result => result,
+                        }
+                    }
+                    result => result,
+                }
+            }
+            HashTreeNode::Pruned(_) => LookupLabelResult::Unknown,
+            // Any other type of node and we need to look for more forks.
+            _ => LookupLabelResult::Absent,
+        }
+    }
+
+    /// Lookup the path for the current node only. If the node does not contain the label,
+    /// this will return [None], signifying that whatever process is recursively walking the
+    /// tree should continue with siblings of this node (if possible). If it returns
+    /// [Some] value, then it found an actual result and this may be propagated to the
+    /// original process doing the lookup.
+    ///
+    /// This assumes a sorted hash tree, which is what the spec says the system should return.
+    /// It will stop when it finds a label that's greater than the one being looked for.
+    fn lookup_path(&self, path: &mut dyn Iterator<Item = &Label>) -> LookupResult<'_> {
+        use HashTreeNode::*;
+        use LookupLabelResult as LLR;
+        use LookupResult::*;
+
+        match (path.next().map(|segment| self.lookup_label(segment)), self) {
+            (Some(LLR::Found(node)), _) => node.lookup_path(path),
+            (None, Leaf(v)) => Found(v.as_ref()),
+
+            (None, Empty()) => Absent,
+            (None, Pruned(_)) => Unknown,
+            (None, Labeled(_, _) | Fork(_)) => Error,
+
+            (Some(LLR::Unknown), _) => Unknown,
+            (Some(LLR::Absent | LLR::Greater | LLR::Less), _) => Absent,
+        }
+    }
+
+    fn list_paths(&self, path: &Vec<Label>) -> Vec<Vec<Label>> {
+        match self {
+            HashTreeNode::Empty() => vec![],
+            HashTreeNode::Fork(nodes) => {
+                [nodes.0.list_paths(path), nodes.1.list_paths(path)].concat()
+            }
+            HashTreeNode::Leaf(_) => vec![path.clone()],
+            HashTreeNode::Labeled(l, node) => {
+                let mut path = path.clone();
+                path.push(l.clone().into_owned());
+                node.list_paths(&path)
+            }
+            HashTreeNode::Pruned(_) => vec![],
+        }
+    }
+}
+
+impl serde::Serialize for HashTreeNode<'_> {
+    // Serialize a `MixedHashTree` per the CDDL of the public spec.
+    // See https://docs.dfinity.systems/public/certificates.cddl
+    fn serialize<S>(
+        &self,
+        serializer: S,
+    ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        use serde_bytes::Bytes;
+
+        match self {
+            HashTreeNode::Empty() => {
+                let mut seq = serializer.serialize_seq(Some(1))?;
+                seq.serialize_element(&0u8)?;
+                seq.end()
+            }
+            HashTreeNode::Fork(tree) => {
+                let mut seq = serializer.serialize_seq(Some(3))?;
+                seq.serialize_element(&1u8)?;
+                seq.serialize_element(&tree.0)?;
+                seq.serialize_element(&tree.1)?;
+                seq.end()
+            }
+            HashTreeNode::Labeled(label, tree) => {
+                let mut seq = serializer.serialize_seq(Some(3))?;
+                seq.serialize_element(&2u8)?;
+                seq.serialize_element(Bytes::new(label.as_bytes()))?;
+                seq.serialize_element(&tree)?;
+                seq.end()
+            }
+            HashTreeNode::Leaf(leaf_bytes) => {
+                let mut seq = serializer.serialize_seq(Some(2))?;
+                seq.serialize_element(&3u8)?;
+                seq.serialize_element(Bytes::new(leaf_bytes))?;
+                seq.end()
+            }
+            HashTreeNode::Pruned(digest) => {
+                let mut seq = serializer.serialize_seq(Some(2))?;
+                seq.serialize_element(&4u8)?;
+                seq.serialize_element(Bytes::new(digest))?;
+                seq.end()
+            }
+        }
+    }
+}
+
+impl<'de, 'tree: 'de> serde::Deserialize<'de> for HashTreeNode<'tree> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de;
+
+        struct SeqVisitor;
+
+        impl<'de> de::Visitor<'de> for SeqVisitor {
+            type Value = HashTreeNode<'static>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(
+                    "HashTree encoded as a sequence of the form \
+                     hash-tree ::= [0] | [1 hash-tree hash-tree] | [2 bytes hash-tree] | [3 bytes] | [4 hash]",
+                )
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::SeqAccess<'de>,
+            {
+                let tag: u8 = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+
+                match tag {
+                    0 => {
+                        if let Some(de::IgnoredAny) = seq.next_element()? {
+                            return Err(de::Error::invalid_length(2, &self));
+                        }
+
+                        Ok(HashTreeNode::Empty())
+                    }
+                    1 => {
+                        let left: HashTreeNode = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                        let right: HashTreeNode = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+
+                        if let Some(de::IgnoredAny) = seq.next_element()? {
+                            return Err(de::Error::invalid_length(4, &self));
+                        }
+
+                        Ok(HashTreeNode::Fork(Box::new((left, right))))
+                    }
+                    2 => {
+                        let label: Label = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                        let subtree: HashTreeNode = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+
+                        if let Some(de::IgnoredAny) = seq.next_element()? {
+                            return Err(de::Error::invalid_length(4, &self));
+                        }
+
+                        Ok(HashTreeNode::Labeled(Cow::Owned(label), Box::new(subtree)))
+                    }
+                    3 => {
+                        let bytes: serde_bytes::ByteBuf = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+
+                        if let Some(de::IgnoredAny) = seq.next_element()? {
+                            return Err(de::Error::invalid_length(3, &self));
+                        }
+
+                        Ok(HashTreeNode::Leaf(Cow::Owned(bytes.into_vec())))
+                    }
+                    4 => {
+                        let digest_bytes: serde_bytes::ByteBuf = seq
+                            .next_element()?
+                            .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+
+                        if let Some(de::IgnoredAny) = seq.next_element()? {
+                            return Err(de::Error::invalid_length(3, &self));
+                        }
+
+                        let digest = std::convert::TryFrom::try_from(digest_bytes.as_ref())
+                            .map_err(|_| {
+                                de::Error::invalid_length(
+                                    digest_bytes.len(),
+                                    &"Expected digest blob",
+                                )
+                            })?;
+
+                        Ok(HashTreeNode::Pruned(digest))
+                    }
+                    _ => Err(de::Error::custom(format!(
+                        "Unknown tag: {}, expected the tag to be one of {{0, 1, 2, 3, 4}}",
+                        tag
+                    ))),
+                }
+            }
+        }
+
+        deserializer.deserialize_seq(SeqVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/ic-agent/src/hash_tree/tests.rs
+++ b/ic-agent/src/hash_tree/tests.rs
@@ -1,0 +1,293 @@
+#![cfg(test)]
+use crate::hash_tree::{
+    empty, fork, label, leaf, pruned, pruned_from_hex, HashTree, Label, LookupResult,
+};
+
+fn lookup_path<'a, P: AsRef<[&'static str]>>(tree: &'a HashTree<'a>, path: P) -> LookupResult<'a> {
+    let path: Vec<Label> = path.as_ref().iter().map(|l| l.into()).collect();
+
+    tree.lookup_path(&path)
+}
+
+#[test]
+fn works_with_simple_tree() {
+    let tree = fork(
+        label("label 1", empty()),
+        fork(
+            pruned(*b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"),
+            leaf(&[1u8, 2, 3, 4, 5, 6]),
+        ),
+    );
+
+    assert_eq!(
+        hex::encode(tree.digest()),
+        "69cf325d0f20505b261821a7e77ff72fb9a8753a7964f0b587553bfb44e72532"
+    );
+}
+
+#[test]
+fn spec_example() {
+    // This is the example straight from the spec.
+    let tree = fork(
+        fork(
+            label(
+                "a",
+                fork(
+                    fork(label("x", leaf(b"hello")), empty()),
+                    label("y", leaf(b"world")),
+                ),
+            ),
+            label("b", leaf(b"good")),
+        ),
+        fork(label("c", empty()), label("d", leaf(b"morning"))),
+    );
+
+    // Check CBOR serialization.
+    assert_eq!(
+        hex::encode(serde_cbor::to_vec(&tree).unwrap()),
+        "8301830183024161830183018302417882034568656c6c6f810083024179820345776f726c6483024162820344676f6f648301830241638100830241648203476d6f726e696e67"
+    );
+
+    assert_eq!(
+        hex::encode(tree.digest()),
+        "eb5c5b2195e62d996b84c9bcc8259d19a83786a2f59e0878cec84c811f669aa0"
+    );
+}
+
+#[test]
+fn spec_example_pruned() {
+    // This is the example straight from the spec.
+    let tree = fork(
+        fork(
+            label(
+                "a",
+                fork(
+                    pruned_from_hex(
+                        "1b4feff9bef8131788b0c9dc6dbad6e81e524249c879e9f10f71ce3749f5a638",
+                    )
+                    .unwrap(),
+                    label("y", leaf(b"world")),
+                ),
+            ),
+            label(
+                "b",
+                pruned_from_hex("7b32ac0c6ba8ce35ac82c255fc7906f7fc130dab2a090f80fe12f9c2cae83ba6")
+                    .unwrap(),
+            ),
+        ),
+        fork(
+            pruned_from_hex("ec8324b8a1f1ac16bd2e806edba78006479c9877fed4eb464a25485465af601d")
+                .unwrap(),
+            label("d", leaf(b"morning")),
+        ),
+    );
+
+    assert_eq!(
+        hex::encode(tree.digest()),
+        "eb5c5b2195e62d996b84c9bcc8259d19a83786a2f59e0878cec84c811f669aa0"
+    );
+
+    assert_eq!(lookup_path(&tree, ["a", "a"]), LookupResult::Unknown);
+    assert_eq!(
+        lookup_path(&tree, ["a", "y"]),
+        LookupResult::Found(b"world")
+    );
+    assert_eq!(lookup_path(&tree, ["aa"]), LookupResult::Absent);
+    assert_eq!(lookup_path(&tree, ["ax"]), LookupResult::Absent);
+    assert_eq!(lookup_path(&tree, ["b"]), LookupResult::Unknown);
+    assert_eq!(lookup_path(&tree, ["bb"]), LookupResult::Unknown);
+    assert_eq!(lookup_path(&tree, ["d"]), LookupResult::Found(b"morning"));
+    assert_eq!(lookup_path(&tree, ["e"]), LookupResult::Absent);
+}
+
+#[test]
+fn can_lookup_paths_1() {
+    let tree = fork(
+        label("label 1", empty()),
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+    );
+
+    assert_eq!(tree.lookup_path(&["label 0".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 1".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Unknown);
+    assert_eq!(
+        tree.lookup_path(&["label 3".into()]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Absent);
+}
+
+#[test]
+fn can_lookup_paths_2() {
+    let tree = fork(
+        label("label 1", empty()),
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+    );
+
+    assert_eq!(tree.lookup_path(&["label 0".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 1".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Absent);
+    assert_eq!(
+        tree.lookup_path(&["label 3".into()]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Unknown);
+}
+
+#[test]
+fn can_lookup_paths_3() {
+    let tree = fork(
+        pruned([0; 32]),
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+    );
+
+    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Unknown);
+    assert_eq!(
+        tree.lookup_path(&["label 3".into()]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Absent);
+}
+
+#[test]
+fn can_lookup_paths_4() {
+    let tree = fork(
+        pruned([0; 32]),
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+    );
+
+    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Unknown);
+    assert_eq!(
+        tree.lookup_path(&["label 3".into()]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Unknown);
+}
+
+#[test]
+fn can_lookup_paths_5() {
+    let tree = fork(
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+        label("label 7", empty()),
+    );
+
+    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Unknown);
+    assert_eq!(
+        tree.lookup_path(&["label 3".into()]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 7".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 8".into()]), LookupResult::Absent);
+}
+
+#[test]
+fn can_lookup_paths_6() {
+    let tree = fork(
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+        label("label 7", empty()),
+    );
+
+    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Absent);
+    assert_eq!(
+        tree.lookup_path(&["label 3".into()]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path(&["label 7".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 8".into()]), LookupResult::Absent);
+}
+
+#[test]
+fn can_lookup_paths_7() {
+    let tree = fork(
+        fork(
+            pruned([1; 32]),
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+        ),
+        pruned([0; 32]),
+    );
+
+    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Unknown);
+    assert_eq!(
+        tree.lookup_path(&["label 3".into()]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Unknown);
+}
+
+#[test]
+fn can_lookup_paths_8() {
+    let tree = fork(
+        fork(
+            fork(
+                label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
+                label("label 5", empty()),
+            ),
+            pruned([1; 32]),
+        ),
+        pruned([0; 32]),
+    );
+
+    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Absent);
+    assert_eq!(
+        tree.lookup_path(&["label 3".into()]),
+        LookupResult::Found(&[1, 2, 3, 4, 5, 6])
+    );
+    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Unknown);
+}

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -29,7 +29,7 @@
 //! ```ignore
 //! # // This test is ignored because it requires an ic to be running. We run these
 //! # // in the ic-ref workflow.
-//! use ic_agent::{Agent, ic_types::Principal};
+//! use ic_agent::{Agent, export::Principal};
 //! use candid::{Encode, Decode, CandidType, Nat};
 //! use serde::Deserialize;
 //!
@@ -128,5 +128,4 @@ pub use agent::{
 pub use identity::{Identity, Signature};
 pub use request_id::{to_request_id, RequestId, RequestIdError};
 
-pub use crate::ic_types::hash_tree;
-pub use ic_types;
+pub use ic_types::hash_tree;

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -118,6 +118,7 @@ mod macros;
 
 pub mod agent;
 pub mod export;
+pub mod hash_tree;
 pub mod identity;
 pub mod request_id;
 
@@ -127,5 +128,3 @@ pub use agent::{
 };
 pub use identity::{Identity, Signature};
 pub use request_id::{to_request_id, RequestId, RequestIdError};
-
-pub use ic_types::hash_tree;

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-identity-hsm"
-version = "0.20.1"
+version = "0.21.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 description = "Identity implementation for HSM for the ic-agent package."
 homepage = "https://docs.rs/ic-identity-hsm"
@@ -16,7 +16,7 @@ rust-version = "1.60.0"
 
 [dependencies]
 hex = "0.4.2"
-ic-agent = { path = "../ic-agent", version = "0.20", features = [ "pem" ], default-features = false}
+ic-agent = { path = "../ic-agent", version = "0.21", features = [ "pem" ], default-features = false}
 num-bigint = "0.4.3"
 pkcs11 = "0.5.0"
 sha2 = "0.10"
@@ -24,4 +24,4 @@ simple_asn1 = "0.6.0"
 thiserror = "1.0.20"
 
 [dev-dependencies]
-ic-agent = { path = "../ic-agent", version = "0.20", features = ["reqwest"] }
+ic-agent = { path = "../ic-agent", version = "0.21", features = ["reqwest"] }

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -1,4 +1,4 @@
-use ic_agent::{ic_types::Principal, Identity, Signature};
+use ic_agent::{export::Principal, Identity, Signature};
 
 use pkcs11::{
     types::{

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.60.0"
 
 [dependencies]
 async-trait = "0.1.40"
-candid = "0.7.18"
+candid = "0.8.0"
 garcon = { version = "0.2", features = ["async"] }
 ic-agent = { path = "../ic-agent", version = "0.20", default-features = false }
 serde = "1.0.115"

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -33,6 +33,7 @@ semver = "1.0.7"
 once_cell = "1.10.0"
 
 [dev-dependencies]
+ic-agent = { path = "../ic-agent", version = "0.21" }
 ring = "0.16.11"
 tokio = { version = "1.14.0", features = ["full"] }
 

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-utils"
-version = "0.20.1"
+version = "0.21.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "Collection of utilities for Rust, on top of ic-agent, to communicate with the Internet Computer, following the Public Specification."
@@ -20,7 +20,7 @@ rust-version = "1.60.0"
 async-trait = "0.1.40"
 candid = "0.8.0"
 garcon = { version = "0.2", features = ["async"] }
-ic-agent = { path = "../ic-agent", version = "0.20", default-features = false }
+ic-agent = { path = "../ic-agent", version = "0.21", default-features = false }
 serde = "1.0.115"
 serde_bytes = "0.11"
 strum = "0.24"
@@ -33,7 +33,6 @@ semver = "1.0.7"
 once_cell = "1.10.0"
 
 [dev-dependencies]
-ic-agent = { path = "../ic-agent", version = "0.20" }
 ring = "0.16.11"
 tokio = { version = "1.14.0", features = ["full"] }
 

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -2,7 +2,7 @@ use crate::call::{AsyncCaller, SyncCaller};
 use candid::utils::ArgumentEncoder;
 use candid::{parser::value::IDLValue, ser::IDLBuilder, utils::ArgumentDecoder, CandidType};
 use garcon::Waiter;
-use ic_agent::{ic_types::Principal, Agent, AgentError, RequestId};
+use ic_agent::{export::Principal, Agent, AgentError, RequestId};
 use std::convert::TryInto;
 use std::fmt;
 use thiserror::Error;

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx-cert"
-version = "0.20.1"
+version = "0.21.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "CLI tool to download a document from the Internet Computer and pretty-print the contents of its IC-Certificate header."
@@ -22,7 +22,7 @@ base64 = "0.13"
 clap = { version = "3.1.8", features = ["derive", "cargo"] }
 chrono = "0.4.19"
 hex = "0.4.2"
-ic-agent = { path = "../ic-agent", version = "0.20", default-features = false }
+ic-agent = { path = "../ic-agent", version = "0.21", default-features = false }
 leb128 = "0.2.4"
 reqwest = { version = "0.11", features = [ "blocking", "rustls-tls" ] }
 sha2 = "0.10"

--- a/icx-cert/src/pprint.rs
+++ b/icx-cert/src/pprint.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use chrono::TimeZone;
-use ic_agent::ic_types::{hash_tree::LookupResult, HashTree};
+use ic_agent::hash_tree::{LookupResult, HashTree};
 use reqwest::header;
 use serde::{de::DeserializeOwned, Deserialize};
 use sha2::Digest;

--- a/icx-cert/src/pprint.rs
+++ b/icx-cert/src/pprint.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use chrono::TimeZone;
-use ic_agent::hash_tree::{LookupResult, HashTree};
+use ic_agent::hash_tree::{HashTree, LookupResult};
 use reqwest::header;
 use serde::{de::DeserializeOwned, Deserialize};
 use sha2::Digest;

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
-candid = "0.7.18"
+candid = "0.8.0"
 clap = { version = "3.0.14", features = ["derive", "cargo"] }
 garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.2"

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icx"
-version = "0.20.1"
+version = "0.21.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 description = "CLI tool to call canisters on the Internet Computer."
@@ -25,8 +25,8 @@ clap = { version = "3.0.14", features = ["derive", "cargo"] }
 garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.2"
 humantime = "2.0.1"
-ic-agent = { path = "../ic-agent", version = "0.20" }
-ic-utils = { path = "../ic-utils", version = "0.20" }
+ic-agent = { path = "../ic-agent", version = "0.21" }
+ic-utils = { path = "../ic-utils", version = "0.21" }
 pem = "1.0"
 ring = "0.16.11"
 serde = "1.0.115"

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-candid = "0.7.18"
+candid = "0.8.0"
 garcon = { version = "0.2.3", features = ["async"] }
 ic-agent = { path = "../ic-agent" }
 ic-identity-hsm = { path = "../ic-identity-hsm" }


### PR DESCRIPTION
# Description

No more depend on `ic-types` which will be retired after this change.

# How Has This Been Tested?

CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
