### PR TITLE
feat: Replace garcon with backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Remove `garcon` from API.
+
 ## [0.22.0] - 2022-10-17
 
 * Drop `disable_range_check` flag from certificate delegation checking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Remove `garcon` from API.
+* Remove `garcon` from API. Callers can remove the dependency and any usages of it; all waiting functions no longer take a waiter parameter.
 
 ## [0.22.0] - 2022-10-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom",
+ "instant",
+ "rand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,15 +680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "garcon"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83fb8961dcd3c26123863998521ae4d07e5e5aa8fb50b503380448f2e0ea069"
-dependencies = [
- "futures-util",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,12 +890,12 @@ name = "ic-agent"
 version = "0.22.0"
 dependencies = [
  "async-trait",
+ "backoff",
  "base32",
  "base64",
  "byteorder",
  "candid",
  "futures-util",
- "garcon",
  "hex",
  "http",
  "http-body",
@@ -942,7 +944,6 @@ version = "0.22.0"
 dependencies = [
  "async-trait",
  "candid",
- "garcon",
  "ic-agent",
  "leb128",
  "num-bigint 0.4.3",
@@ -977,7 +978,6 @@ dependencies = [
  "anyhow",
  "candid",
  "clap",
- "garcon",
  "hex",
  "humantime",
  "ic-agent",
@@ -1706,7 +1706,6 @@ name = "ref-tests"
 version = "0.0.0"
 dependencies = [
  "candid",
- "garcon",
  "ic-agent",
  "ic-identity-hsm",
  "ic-utils",

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -66,6 +66,7 @@ serde_json = "1.0.79"
 tokio = { version = "1.17.0", features = ["full"] }
 
 [features]
-default = ["pem", "reqwest", "dep:hyper-rustls"]
+default = ["pem", "reqwest"]
+reqwest = ["dep:reqwest", "dep:hyper-rustls"]
 hyper = ["dep:hyper", "dep:hyper-rustls"]
 ic_ref_tests = ["default"] # Used to separate integration tests for ic-ref which need a server running.

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -16,15 +16,16 @@ rust-version = "1.60.0"
 
 [dependencies]
 async-trait = "0.1.53"
+backoff = "0.4.0"
 base32 = "0.4.0"
 base64 = "0.13.0"
 byteorder = "1.3.2"
 candid = "0.8.0"
-garcon = { version = "0.2", features = ["async"] }
+futures-util = "0.3.21"
 hex = "0.4.0"
 http = "0.2.6"
 http-body = "0.4.5"
-hyper-rustls = { version = "0.23.0", features = [ "webpki-roots", "http2" ] }
+hyper-rustls = { version = "0.23.0", features = [ "webpki-roots", "http2" ], optional = true }
 ic-verify-bls-signature = "0.1"
 k256 = { version = "0.11", features = ["pem"] }
 leb128 = "0.2.5"
@@ -38,10 +39,10 @@ serde_cbor = "0.11.2"
 sha2 = "0.10"
 simple_asn1 = "0.6.1"
 thiserror = "1.0.30"
+tokio = { version = "1.21.2", features = ["time"] }
 url = "2.1.0"
 pkcs8 = { version = "0.9", features = ["std"] }
 sec1 = { version = "0.3", features = ["pem"] }
-futures-util = "0.3.21"
 
 [dependencies.hyper]
 version = "0.14"
@@ -65,5 +66,6 @@ serde_json = "1.0.79"
 tokio = { version = "1.17.0", features = ["full"] }
 
 [features]
-default = ["pem", "reqwest"]
+default = ["pem", "reqwest", "dep:hyper-rustls"]
+hyper = ["dep:hyper", "dep:hyper-rustls"]
 ic_ref_tests = ["default"] # Used to separate integration tests for ic-ref which need a server running.

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -19,10 +19,6 @@ pub enum AgentError {
     #[error("The request timed out.")]
     TimeoutWaitingForResponse(),
 
-    /// The waiter was restarted without being started first.
-    #[error("The waiter was restarted without being started first.")]
-    WaiterRestartError(),
-
     /// An error occurred when signing with the identity.
     #[error("Identity had a signing error: {0}")]
     SigningError(String),

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1124,17 +1124,11 @@ impl Future for UpdateCall<'_> {
     }
 }
 impl<'a> UpdateCall<'a> {
-    fn and_wait(
-        self,
-    ) -> Pin<Box<dyn core::future::Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>> {
-        async fn run(_self: UpdateCall<'_>) -> Result<Vec<u8>, AgentError> {
-            let request_id = _self.request_id.await?;
-            _self
-                .agent
-                .wait(request_id, _self.effective_canister_id)
-                .await
-        }
-        Box::pin(run(self))
+    async fn and_wait(self) -> Result<Vec<u8>, AgentError> {
+        let request_id = self.request_id.await?;
+        self.agent
+            .wait(request_id, self.effective_canister_id)
+            .await
     }
 }
 /// An Update Request Builder.

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -12,6 +12,7 @@ pub mod signed;
 pub mod status;
 pub use agent_config::AgentConfig;
 pub use agent_error::AgentError;
+use backoff::{backoff::Backoff, ExponentialBackoffBuilder};
 pub use builder::AgentBuilder;
 pub use nonce::{NonceFactory, NonceGenerator};
 pub use response::{Replied, RequestStatusResponse};
@@ -29,7 +30,6 @@ use crate::{
     identity::Identity,
     to_request_id, RequestId,
 };
-use garcon::Waiter;
 use serde::Serialize;
 use status::Status;
 
@@ -205,11 +205,6 @@ pub enum PollResult {
 ///   agent.fetch_root_key().await?;
 ///   let management_canister_id = Principal::from_text("aaaaa-aa")?;
 ///
-///   let waiter = garcon::Delay::builder()
-///     .throttle(std::time::Duration::from_millis(500))
-///     .timeout(std::time::Duration::from_secs(60 * 5))
-///     .build();
-///
 ///   // Create a call to the management canister to create a new canister ID,
 ///   // and wait for a result.
 ///   // The effective canister id must belong to the canister ranges of the subnet at which the canister is created.
@@ -217,7 +212,7 @@ pub enum PollResult {
 ///   let response = agent.update(&management_canister_id, "provisional_create_canister_with_cycles")
 ///     .with_effective_canister_id(effective_canister_id)
 ///     .with_arg(&Encode!(&Argument { amount: None })?)
-///     .call_and_wait(waiter)
+///     .call_and_wait()
 ///     .await?;
 ///
 ///   let result = Decode!(response.as_slice(), CreateCanisterResult)?;
@@ -548,13 +543,16 @@ impl Agent {
     }
 
     /// Call request_status on the RequestId in a loop and return the response as a byte vector.
-    pub async fn wait<W: Waiter>(
+    pub async fn wait(
         &self,
         request_id: RequestId,
         effective_canister_id: Principal,
-        mut waiter: W,
     ) -> Result<Vec<u8>, AgentError> {
-        waiter.start();
+        let mut retry_policy = ExponentialBackoffBuilder::new()
+            .with_initial_interval(Duration::from_millis(200))
+            .with_max_interval(Duration::from_secs(1))
+            .with_multiplier(1.4)
+            .build();
         let mut request_accepted = false;
         loop {
             match self.poll(&request_id, effective_canister_id).await? {
@@ -566,21 +564,19 @@ impl Agent {
                         // and we generally cannot know how long that will take.
                         // State transitions between Received and Processing may be
                         // instantaneous. Therefore, once we know the request is accepted,
-                        // we should restart the waiter so the request does not time out.
+                        // we should restart the backoff so the request does not time out.
 
-                        waiter
-                            .restart()
-                            .map_err(|_| AgentError::WaiterRestartError())?;
+                        retry_policy.reset();
                         request_accepted = true;
                     }
                 }
                 PollResult::Completed(result) => return Ok(result),
             };
 
-            waiter
-                .async_wait()
-                .await
-                .map_err(|_| AgentError::TimeoutWaitingForResponse())?;
+            match retry_policy.next_backoff() {
+                Some(duration) => tokio::time::sleep(duration).await,
+                None => return Err(AgentError::TimeoutWaitingForResponse()),
+            }
         }
     }
 
@@ -1127,26 +1123,18 @@ impl Future for UpdateCall<'_> {
         self.request_id.as_mut().poll(cx)
     }
 }
-impl UpdateCall<'_> {
-    fn and_wait<'out, W>(
+impl<'a> UpdateCall<'a> {
+    fn and_wait(
         self,
-        waiter: W,
-    ) -> Pin<Box<dyn core::future::Future<Output = Result<Vec<u8>, AgentError>> + Send + 'out>>
-    where
-        Self: 'out,
-        W: Waiter + 'out,
-    {
-        async fn run<W>(_self: UpdateCall<'_>, waiter: W) -> Result<Vec<u8>, AgentError>
-        where
-            W: Waiter,
-        {
+    ) -> Pin<Box<dyn core::future::Future<Output = Result<Vec<u8>, AgentError>> + Send + 'a>> {
+        async fn run(_self: UpdateCall<'_>) -> Result<Vec<u8>, AgentError> {
             let request_id = _self.request_id.await?;
             _self
                 .agent
-                .wait(request_id, _self.effective_canister_id, waiter)
+                .wait(request_id, _self.effective_canister_id)
                 .await
         }
-        Box::pin(run(self, waiter))
+        Box::pin(run(self))
     }
 }
 /// An Update Request Builder.
@@ -1227,8 +1215,8 @@ impl<'agent> UpdateBuilder<'agent> {
 
     /// Make an update call. This will call request_status on the RequestId in a loop and return
     /// the response as a byte vector.
-    pub async fn call_and_wait<W: Waiter>(&self, waiter: W) -> Result<Vec<u8>, AgentError> {
-        self.call().and_wait(waiter).await
+    pub async fn call_and_wait(&self) -> Result<Vec<u8>, AgentError> {
+        self.call().and_wait().await
     }
 
     /// Make an update call. This will return a RequestId.

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -68,11 +68,6 @@
 //!   agent.fetch_root_key().await?;
 //!   let management_canister_id = Principal::from_text("aaaaa-aa")?;
 //!
-//!   let waiter = garcon::Delay::builder()
-//!     .throttle(std::time::Duration::from_millis(500))
-//!     .timeout(std::time::Duration::from_secs(60 * 5))
-//!     .build();
-//!
 //!   // Create a call to the management canister to create a new canister ID,
 //!   // and wait for a result.
 //!   // The effective canister id must belong to the canister ranges of the subnet at which the canister is created.
@@ -80,7 +75,7 @@
 //!   let response = agent.update(&management_canister_id, "provisional_create_canister_with_cycles")
 //!     .with_effective_canister_id(effective_canister_id)
 //!     .with_arg(&Encode!(&Argument { amount: None})?)
-//!     .call_and_wait(waiter)
+//!     .call_and_wait()
 //!     .await?;
 //!
 //!   let result = Decode!(response.as_slice(), CreateCanisterResult)?;

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -19,7 +19,6 @@ rust-version = "1.60.0"
 [dependencies]
 async-trait = "0.1.40"
 candid = "0.8.0"
-garcon = { version = "0.2", features = ["async"] }
 ic-agent = { path = "../ic-agent", version = "0.22", default-features = false }
 serde = "1.0.115"
 serde_bytes = "0.11"

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use candid::{CandidType, Deserialize, Nat};
-use garcon::Waiter;
 use ic_agent::{export::Principal, AgentError, RequestId};
 use std::str::FromStr;
 
@@ -281,11 +280,8 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     }
 
     /// Make a call. This is equivalent to the [AsyncCall::call_and_wait].
-    pub async fn call_and_wait<W>(self, waiter: W) -> Result<(Principal,), AgentError>
-    where
-        W: Waiter,
-    {
-        self.build()?.call_and_wait(waiter).await
+    pub async fn call_and_wait(self) -> Result<(Principal,), AgentError> {
+        self.build()?.call_and_wait().await
     }
 }
 
@@ -297,11 +293,8 @@ impl<'agent, 'canister: 'agent> AsyncCall<(Principal,)>
         self.build()?.call().await
     }
 
-    async fn call_and_wait<W>(self, waiter: W) -> Result<(Principal,), AgentError>
-    where
-        W: Waiter,
-    {
-        self.build()?.call_and_wait(waiter).await
+    async fn call_and_wait(self) -> Result<(Principal,), AgentError> {
+        self.build()?.call_and_wait().await
     }
 }
 
@@ -421,11 +414,8 @@ impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
     }
 
     /// Make a call. This is equivalent to the [AsyncCall::call_and_wait].
-    pub async fn call_and_wait<W>(self, waiter: W) -> Result<(), AgentError>
-    where
-        W: Waiter,
-    {
-        self.build()?.call_and_wait(waiter).await
+    pub async fn call_and_wait(self) -> Result<(), AgentError> {
+        self.build()?.call_and_wait().await
     }
 }
 
@@ -435,11 +425,8 @@ impl<'agent, 'canister: 'agent> AsyncCall<()> for InstallCodeBuilder<'agent, 'ca
         self.build()?.call().await
     }
 
-    async fn call_and_wait<W>(self, waiter: W) -> Result<(), AgentError>
-    where
-        W: Waiter,
-    {
-        self.build()?.call_and_wait(waiter).await
+    async fn call_and_wait(self) -> Result<(), AgentError> {
+        self.build()?.call_and_wait().await
     }
 }
 
@@ -633,11 +620,8 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     }
 
     /// Make a call. This is equivalent to the [AsyncCall::call_and_wait].
-    pub async fn call_and_wait<W>(self, waiter: W) -> Result<(), AgentError>
-    where
-        W: Waiter,
-    {
-        self.build()?.call_and_wait(waiter).await
+    pub async fn call_and_wait(self) -> Result<(), AgentError> {
+        self.build()?.call_and_wait().await
     }
 }
 
@@ -647,10 +631,7 @@ impl<'agent, 'canister: 'agent> AsyncCall<()> for UpdateCanisterBuilder<'agent, 
         self.build()?.call().await
     }
 
-    async fn call_and_wait<W>(self, waiter: W) -> Result<(), AgentError>
-    where
-        W: Waiter,
-    {
-        self.build()?.call_and_wait(waiter).await
+    async fn call_and_wait(self) -> Result<(), AgentError> {
+        self.build()?.call_and_wait().await
     }
 }

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use candid::{decode_args, utils::ArgumentDecoder, CandidType, Deserialize, Nat};
-use garcon::{Delay, Waiter};
 use ic_agent::{export::Principal, Agent, AgentError, RequestId};
 use once_cell::sync::Lazy;
 use semver::{Version, VersionReq};
@@ -116,12 +115,9 @@ where
         self.build()?.call().await
     }
 
-    /// Calls the forwarded canister call on the wallet canister, and waits for the result. Equivalent to `.build().call_and_wait(waiter)`.
-    pub async fn call_and_wait<W>(self, waiter: W) -> Result<Out, AgentError>
-    where
-        W: Waiter,
-    {
-        self.build()?.call_and_wait(waiter).await
+    /// Calls the forwarded canister call on the wallet canister, and waits for the result. Equivalent to `.build().call_and_wait()`.
+    pub async fn call_and_wait(self) -> Result<Out, AgentError> {
+        self.build()?.call_and_wait().await
     }
 }
 
@@ -134,11 +130,8 @@ where
         self.call().await
     }
 
-    async fn call_and_wait<W>(self, waiter: W) -> Result<Out, AgentError>
-    where
-        W: Waiter,
-    {
-        self.call_and_wait(waiter).await
+    async fn call_and_wait(self) -> Result<Out, AgentError> {
+        self.call_and_wait().await
     }
 }
 
@@ -604,11 +597,10 @@ impl<'agent> WalletCanister<'agent> {
         &'canister self,
         destination: Principal,
         amount: u128,
-        waiter: Delay,
     ) -> Result<(), AgentError> {
         if self.version_supports_u128_cycles() {
             self.wallet_send128(destination, amount)
-                .call_and_wait(waiter)
+                .call_and_wait()
                 .await?
         } else {
             let amount = u64::try_from(amount).map_err(|_| {
@@ -617,7 +609,7 @@ impl<'agent> WalletCanister<'agent> {
                 )
             })?;
             self.wallet_send64(destination, amount)
-                .call_and_wait(waiter)
+                .call_and_wait()
                 .await?
         }
         .0
@@ -730,7 +722,6 @@ impl<'agent> WalletCanister<'agent> {
         compute_allocation: Option<ComputeAllocation>,
         memory_allocation: Option<MemoryAllocation>,
         freezing_threshold: Option<FreezingThreshold>,
-        waiter: Delay,
     ) -> Result<CreateResult, AgentError> {
         if self.version_supports_u128_cycles() {
             self.wallet_create_canister128(
@@ -740,7 +731,7 @@ impl<'agent> WalletCanister<'agent> {
                 memory_allocation,
                 freezing_threshold,
             )
-            .call_and_wait(waiter)
+            .call_and_wait()
             .await?
         } else {
             let cycles = u64::try_from(cycles).map_err(|_| {
@@ -756,7 +747,7 @@ impl<'agent> WalletCanister<'agent> {
                     memory_allocation,
                     freezing_threshold,
                 )
-                .call_and_wait(waiter)
+                .call_and_wait()
                 .await?
             } else {
                 let controller: Option<Principal> = match &controllers {
@@ -777,7 +768,7 @@ impl<'agent> WalletCanister<'agent> {
                     memory_allocation,
                     freezing_threshold,
                 )
-                .call_and_wait(waiter)
+                .call_and_wait()
                 .await?
             }
         }
@@ -877,7 +868,6 @@ impl<'agent> WalletCanister<'agent> {
         compute_allocation: Option<ComputeAllocation>,
         memory_allocation: Option<MemoryAllocation>,
         freezing_threshold: Option<FreezingThreshold>,
-        waiter: Delay,
     ) -> Result<CreateResult, AgentError> {
         if self.version_supports_u128_cycles() {
             self.wallet_create_wallet128(
@@ -887,7 +877,7 @@ impl<'agent> WalletCanister<'agent> {
                 memory_allocation,
                 freezing_threshold,
             )
-            .call_and_wait(waiter)
+            .call_and_wait()
             .await?
         } else {
             let cycles = u64::try_from(cycles).map_err(|_| {
@@ -903,7 +893,7 @@ impl<'agent> WalletCanister<'agent> {
                     memory_allocation,
                     freezing_threshold,
                 )
-                .call_and_wait(waiter)
+                .call_and_wait()
                 .await?
             } else {
                 let controller: Option<Principal> = match &controllers {
@@ -920,7 +910,7 @@ impl<'agent> WalletCanister<'agent> {
                     memory_allocation,
                     freezing_threshold,
                 )
-                .call_and_wait(waiter)
+                .call_and_wait()
                 .await?
             }
         }

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/main.rs"
 anyhow = { version = "1.0", features = ["backtrace"] }
 candid = "0.8.0"
 clap = { version = "3.0.14", features = ["derive", "cargo"] }
-garcon = { version = "0.2.3", features = ["async"] }
 hex = "0.4.2"
 humantime = "2.0.1"
 ic-agent = { path = "../ic-agent", version = "0.22" }

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 candid = "0.8.0"
-garcon = { version = "0.2.3", features = ["async"] }
 ic-agent = { path = "../ic-agent" }
 ic-identity-hsm = { path = "../ic-identity-hsm" }
 ic-utils = { path = "../ic-utils", features = ["raw"] }

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -1,4 +1,3 @@
-use garcon::Delay;
 use ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport;
 use ic_agent::identity::Secp256k1Identity;
 use ic_agent::{export::Principal, identity::BasicIdentity, Agent, Identity};
@@ -14,12 +13,6 @@ const HSM_PIN: &str = "HSM_PIN";
 
 pub fn get_effective_canister_id() -> Principal {
     Principal::from_text("sehci-oaaaa-aaaaa-aaaaa-c").unwrap()
-}
-
-pub fn create_waiter() -> Delay {
-    Delay::builder()
-        .throttle(std::time::Duration::from_secs(5))
-        .build()
 }
 
 pub async fn create_identity() -> Result<Box<dyn Identity>, String> {
@@ -142,12 +135,12 @@ pub async fn create_universal_canister(agent: &Agent) -> Result<Principal, Box<d
         .create_canister()
         .as_provisional_create_with_amount(None)
         .with_effective_canister_id(get_effective_canister_id())
-        .call_and_wait(create_waiter())
+        .call_and_wait()
         .await?;
 
     ic00.install_code(&canister_id, &canister_wasm)
         .with_raw_arg(vec![])
-        .call_and_wait(create_waiter())
+        .call_and_wait()
         .await?;
 
     Ok(canister_id)
@@ -182,12 +175,12 @@ pub async fn create_wallet_canister(
             MemoryAllocation::try_from(8000000000_u64)
                 .expect("Memory allocation must be between 0 and 2^48 (i.e 256TB), inclusively."),
         )
-        .call_and_wait(create_waiter())
+        .call_and_wait()
         .await?;
 
     ic00.install_code(&canister_id, &canister_wasm)
         .with_raw_arg(vec![])
-        .call_and_wait(create_waiter())
+        .call_and_wait()
         .await?;
 
     Ok(canister_id)


### PR DESCRIPTION
Implements SDK-824.

This additionally removes garcon from the public API; the backoff numbers dfx uses are good enough for anyone, and users who want a shorter timeout can use tokio's timeout function.