### PR TITLE
feat(ic-certification): add subtree_lookup method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Add `lookup_subtree` method to HashTree & HashTreeNode to allow for subtree lookups
+
 ## [0.23.0] - 2022-12-01
 
 * Remove `garcon` from API. Callers can remove the dependency and any usages of it; all waiting functions no longer take a waiter parameter.


### PR DESCRIPTION
# Description

Adds a `subtree_lookup` method to `HashTree` and `HashTreeNode`. This method will return a subtree if it can be found at the provided path.

Relates to [#TT-42](https://dfinity.atlassian.net/browse/TT-42)

# How Has This Been Tested?

Unit tests have been provided.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
