### PR TITLE
fix(ic-certification): update subtree_lookup method to return hash tree instead of a hash tree node

### DIFF
--- a/ic-certification/src/hash_tree/mod.rs
+++ b/ic-certification/src/hash_tree/mod.rs
@@ -104,7 +104,7 @@ pub enum SubtreeLookupResult<'tree> {
     Unknown,
 
     /// The subtree was found at the provided path.
-    Found(&'tree HashTreeNode<'tree>),
+    Found(HashTree<'tree>),
 }
 
 /// A HashTree representing a full tree.
@@ -455,7 +455,9 @@ impl<'a> HashTreeNode<'a> {
             Some(LLR::Found(node)) => node.lookup_subtree(path),
             Some(LLR::Unknown) => Unknown,
             Some(LLR::Absent | LLR::Greater | LLR::Less) => Absent,
-            None => Found(self),
+            None => Found(HashTree {
+                root: self.to_owned(),
+            }),
         }
     }
 

--- a/ic-certification/src/hash_tree/tests.rs
+++ b/ic-certification/src/hash_tree/tests.rs
@@ -1,10 +1,9 @@
 #![cfg(test)]
 
 use crate::hash_tree::{
-    empty, fork, label, leaf, pruned, pruned_from_hex, HashTree, HashTreeNode, Label, LookupResult,
+    empty, fork, label, leaf, pruned, pruned_from_hex, HashTree, Label, LookupResult,
     SubtreeLookupResult,
 };
-use std::borrow::Cow;
 
 fn lookup_path<'a, P: AsRef<[&'static str]>>(tree: &'a HashTree<'a>, path: P) -> LookupResult<'a> {
     let path: Vec<Label> = path.as_ref().iter().map(|l| l.into()).collect();
@@ -307,7 +306,6 @@ fn can_lookup_paths_8() {
 
 #[test]
 fn can_lookup_subtrees_1() {
-    use HashTreeNode::*;
     use SubtreeLookupResult::*;
 
     let tree = fork(
@@ -322,20 +320,19 @@ fn can_lookup_subtrees_1() {
     );
 
     assert_eq!(lookup_subtree(&tree, &["label 0"]), Absent);
-    assert_eq!(lookup_subtree(&tree, &["label 1"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 1"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 2"]), Unknown);
     assert_eq!(
         lookup_subtree(&tree, &["label 3"]),
-        Found(&Leaf(Cow::Owned(vec![1, 2, 3, 4, 5, 6])))
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
     );
     assert_eq!(lookup_subtree(&tree, &["label 4"]), Absent);
-    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 6"]), Absent);
 }
 
 #[test]
 fn can_lookup_subtrees_2() {
-    use HashTreeNode::*;
     use SubtreeLookupResult::*;
 
     let tree = fork(
@@ -350,20 +347,19 @@ fn can_lookup_subtrees_2() {
     );
 
     assert_eq!(lookup_subtree(&tree, &["label 0"]), Absent);
-    assert_eq!(lookup_subtree(&tree, &["label 1"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 1"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 2"]), Absent);
     assert_eq!(
         lookup_subtree(&tree, &["label 3"]),
-        Found(&Leaf(Cow::Owned(vec![1, 2, 3, 4, 5, 6])))
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
     );
     assert_eq!(lookup_subtree(&tree, &["label 4"]), Absent);
-    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 6"]), Unknown);
 }
 
 #[test]
 fn can_lookup_subtrees_3() {
-    use HashTreeNode::*;
     use SubtreeLookupResult::*;
 
     let tree = fork(
@@ -380,16 +376,15 @@ fn can_lookup_subtrees_3() {
     assert_eq!(lookup_subtree(&tree, &["label 2"]), Unknown);
     assert_eq!(
         lookup_subtree(&tree, &["label 3"]),
-        Found(&Leaf(Cow::Owned(vec![1, 2, 3, 4, 5, 6])))
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
     );
     assert_eq!(lookup_subtree(&tree, &["label 4"]), Absent);
-    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 6"]), Absent);
 }
 
 #[test]
 fn can_lookup_subtrees_4() {
-    use HashTreeNode::*;
     use SubtreeLookupResult::*;
 
     let tree = fork(
@@ -406,16 +401,15 @@ fn can_lookup_subtrees_4() {
     assert_eq!(lookup_subtree(&tree, &["label 2"]), Unknown);
     assert_eq!(
         lookup_subtree(&tree, &["label 3"]),
-        Found(&Leaf(Cow::Owned(vec![1, 2, 3, 4, 5, 6])))
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
     );
     assert_eq!(lookup_subtree(&tree, &["label 4"]), Absent);
-    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 6"]), Unknown);
 }
 
 #[test]
 fn can_lookup_subtrees_5() {
-    use HashTreeNode::*;
     use SubtreeLookupResult::*;
 
     let tree = fork(
@@ -432,18 +426,17 @@ fn can_lookup_subtrees_5() {
     assert_eq!(lookup_subtree(&tree, &["label 2"]), Unknown);
     assert_eq!(
         lookup_subtree(&tree, &["label 3"]),
-        Found(&Leaf(Cow::Owned(vec![1, 2, 3, 4, 5, 6])))
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
     );
     assert_eq!(lookup_subtree(&tree, &["label 4"]), Absent);
-    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 6"]), Absent);
-    assert_eq!(lookup_subtree(&tree, &["label 7"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 7"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 8"]), Absent);
 }
 
 #[test]
 fn can_lookup_subtrees_6() {
-    use HashTreeNode::*;
     use SubtreeLookupResult::*;
 
     let tree = fork(
@@ -460,18 +453,17 @@ fn can_lookup_subtrees_6() {
     assert_eq!(lookup_subtree(&tree, &["label 2"]), Absent);
     assert_eq!(
         lookup_subtree(&tree, &["label 3"]),
-        Found(&Leaf(Cow::Owned(vec![1, 2, 3, 4, 5, 6])))
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
     );
     assert_eq!(lookup_subtree(&tree, &["label 4"]), Absent);
-    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 6"]), Unknown);
-    assert_eq!(lookup_subtree(&tree, &["label 7"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 7"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 8"]), Absent);
 }
 
 #[test]
 fn can_lookup_subtrees_7() {
-    use HashTreeNode::*;
     use SubtreeLookupResult::*;
 
     let tree = fork(
@@ -488,16 +480,15 @@ fn can_lookup_subtrees_7() {
     assert_eq!(lookup_subtree(&tree, &["label 2"]), Unknown);
     assert_eq!(
         lookup_subtree(&tree, &["label 3"]),
-        Found(&Leaf(Cow::Owned(vec![1, 2, 3, 4, 5, 6])))
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
     );
     assert_eq!(lookup_subtree(&tree, &["label 4"]), Absent);
-    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 6"]), Unknown);
 }
 
 #[test]
 fn can_lookup_subtrees_8() {
-    use HashTreeNode::*;
     use SubtreeLookupResult::*;
 
     let tree = fork(
@@ -514,9 +505,9 @@ fn can_lookup_subtrees_8() {
     assert_eq!(lookup_subtree(&tree, &["label 2"]), Absent);
     assert_eq!(
         lookup_subtree(&tree, &["label 3"]),
-        Found(&Leaf(Cow::Owned(vec![1, 2, 3, 4, 5, 6])))
+        Found(leaf(vec![1, 2, 3, 4, 5, 6]))
     );
     assert_eq!(lookup_subtree(&tree, &["label 4"]), Absent);
-    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(&Empty()));
+    assert_eq!(lookup_subtree(&tree, &["label 5"]), Found(empty()));
     assert_eq!(lookup_subtree(&tree, &["label 6"]), Unknown);
 }

--- a/ic-certification/src/lib.rs
+++ b/ic-certification/src/lib.rs
@@ -5,7 +5,7 @@
 
 pub mod hash_tree;
 #[doc(inline)]
-pub use hash_tree::{HashTree, Label, LookupResult};
+pub use hash_tree::{HashTree, Label, LookupResult, SubtreeLookupResult};
 
 pub mod certificate;
 #[doc(inline)]


### PR DESCRIPTION
# Description

Returning a hash tree allows for easier lookups on the returned hash tree. If a hash tree node is returned then this is more difficult as the methods are all private. 

Relates to [#TT-42](https://dfinity.atlassian.net/browse/TT-42)

Note, I didn't update the changelog since this feature is still unreleased and I don't think this commit affects the changelog message, I'm happy to update it though if you disagree.

# How Has This Been Tested?

Unit tests have been updated.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
