### PR TITLE
feat: add certificate version to http request canister interface

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           cd cycles-wallet/
           sh ./wallet/build.sh
-          cp wallet/target/wasm32-unknown-unknown/release/wallet-opt.wasm $HOME/wallet.wasm
+          cp target/wasm32-unknown-unknown/release/wallet-opt.wasm $HOME/wallet.wasm
 
       - name: Build ic-hs
         run: |

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -11,15 +11,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [ linux-stable ]
+        build: [linux-stable]
         include:
           - build: linux-stable
-            ghc: '8.10.7'
-            spec: 'f771c6b3e7cdde413d3b960f63165c6ecf3e0b7c'
+            ghc: "8.10.7"
+            spec: "f771c6b3e7cdde413d3b960f63165c6ecf3e0b7c"
             os: ubuntu-latest
-            rust: '1.60.0'
+            rust: "1.60.0"
 
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: haskell/actions/setup@v1
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -28,12 +31,12 @@ jobs:
           path: main
       - uses: actions/checkout@v2
         with:
-          repository: 'dfinity/ic-hs'
+          repository: "dfinity/ic-hs"
           path: ic-hs
           ref: ${{ matrix.spec }}
       - uses: actions/checkout@v2
         with:
-          repository: 'dfinity/cycles-wallet'
+          repository: "dfinity/cycles-wallet"
           path: cycles-wallet
           ref: 89df7966379351d7a82796f64214a744f65960fd
 
@@ -45,11 +48,10 @@ jobs:
           key: cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('ic-hs/cabal.project', 'ic-hs/cabal.project.freeze') }}
           restore-keys: cabal-${{ runner.os }}-${{ matrix.ghc }}-
 
-
       - uses: actions/setup-haskell@v1.1.3
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: '3.2'
+          cabal-version: "3.2"
 
       - name: Cargo cache
         uses: actions/cache@v2
@@ -66,6 +68,12 @@ jobs:
           rustup default ${{ matrix.rust }}
           rustup target add wasm32-unknown-unknown
 
+      - name: Build cycles-wallet canister
+        run: |
+          cd cycles-wallet/
+          sh ./wallet/build.sh
+          cp wallet/target/wasm32-unknown-unknown/release/wallet-opt.wasm $HOME/wallet.wasm
+
       - name: Build ic-hs
         run: |
           ghc --version
@@ -81,12 +89,6 @@ jobs:
           cd ic-hs/universal-canister
           cargo build --target wasm32-unknown-unknown --release
           cp target/wasm32-unknown-unknown/release/universal_canister.wasm $HOME/canister.wasm
-
-      - name: Build cycles-wallet canister
-        run: |
-          cd cycles-wallet/
-          sh ./wallet/build.sh
-          cp wallet/target/wasm32-unknown-unknown/release/wallet-opt.wasm $HOME/wallet.wasm
 
       - name: Run Integration Tests
         run: |

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -33,9 +33,9 @@ jobs:
           ref: ${{ matrix.spec }}
       - uses: actions/checkout@v2
         with:
-          repository: 'dfinity/wallet-rs'
-          path: wallet-rs
-          ref: 9ef38bb7cd0fe17cda749bf8e9bbec5723da0e95
+          repository: 'dfinity/cycles-wallet'
+          path: cycles-wallet
+          ref: 89df7966379351d7a82796f64214a744f65960fd
 
       - name: Cache ~/.cabal/store
         uses: actions/cache@v2
@@ -82,9 +82,9 @@ jobs:
           cargo build --target wasm32-unknown-unknown --release
           cp target/wasm32-unknown-unknown/release/universal_canister.wasm $HOME/canister.wasm
 
-      - name: Build wallet canister
+      - name: Build cycles-wallet canister
         run: |
-          cd wallet-rs/
+          cd cycles-wallet/
           sh ./wallet/build.sh
           cp wallet/target/wasm32-unknown-unknown/release/wallet-opt.wasm $HOME/wallet.wasm
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add `lookup_subtree` method to HashTree & HashTreeNode to allow for subtree lookups
 * Derive `Clone` on `Certificate` and `Delegation` structs
+* Add certificate version to http_request canister interface
 
 ## [0.23.0] - 2022-12-01
 

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -47,9 +47,11 @@ struct HttpRequest<'a, H> {
     pub headers: H,
     /// The request body.
     pub body: &'a [u8],
+    /// The certificate version.
+    pub certificate_version: Option<&'a u128>,
 }
 
-/// A wraper around an iterator of headers
+/// A wrapper around an iterator of headers
 #[derive(Debug, Clone)]
 pub struct Headers<H>(H);
 
@@ -396,12 +398,14 @@ impl<'agent> HttpRequestCanister<'agent> {
             IntoIter = impl 'agent + Send + Sync + Clone + ExactSizeIterator<Item = HeaderField<'agent>>,
         >,
         body: impl AsRef<[u8]>,
+        certificate_version: Option<&u128>,
     ) -> impl 'agent + SyncCall<(HttpResponse,)> {
         self.http_request_custom(
             method.as_ref(),
             url.as_ref(),
             headers.into_iter(),
             body.as_ref(),
+            certificate_version,
         )
     }
 
@@ -413,6 +417,7 @@ impl<'agent> HttpRequestCanister<'agent> {
         url: &str,
         headers: H,
         body: &[u8],
+        certificate_version: Option<&u128>,
     ) -> impl 'agent + SyncCall<(HttpResponse<T, C>,)>
     where
         H: 'agent + Send + Sync + Clone + ExactSizeIterator<Item = HeaderField<'agent>>,
@@ -425,6 +430,7 @@ impl<'agent> HttpRequestCanister<'agent> {
                 url,
                 headers: Headers(headers),
                 body,
+                certificate_version,
             })
             .build()
     }
@@ -437,8 +443,15 @@ impl<'agent> HttpRequestCanister<'agent> {
         url: impl AsRef<str>,
         headers: impl 'agent + Send + Sync + Clone + ExactSizeIterator<Item = HeaderField<'agent>>,
         body: impl AsRef<[u8]>,
+        certificate_version: Option<&u128>,
     ) -> impl 'agent + AsyncCall<(HttpResponse,)> {
-        self.http_request_update_custom(method.as_ref(), url.as_ref(), headers, body.as_ref())
+        self.http_request_update_custom(
+            method.as_ref(),
+            url.as_ref(),
+            headers,
+            body.as_ref(),
+            certificate_version,
+        )
     }
 
     /// Performs a HTTP request over an update call. Unlike query calls, update calls must pass consensus
@@ -450,6 +463,7 @@ impl<'agent> HttpRequestCanister<'agent> {
         url: &str,
         headers: H,
         body: &[u8],
+        certificate_version: Option<&u128>,
     ) -> impl 'agent + AsyncCall<(HttpResponse<T, C>,)>
     where
         H: 'agent + Send + Sync + Clone + ExactSizeIterator<Item = HeaderField<'agent>>,
@@ -462,6 +476,7 @@ impl<'agent> HttpRequestCanister<'agent> {
                 url,
                 headers: Headers(headers),
                 body,
+                certificate_version,
             })
             .build()
     }


### PR DESCRIPTION
# Description

BREAKING CHANGE: Adds an new property to the HttpRequest interface to allow for specifying the desired certificate version for the canister to return.

Relates to [#TT-35](https://dfinity.atlassian.net/browse/TT-35)

# How Has This Been Tested?

I didn't add unit tests because there was no previous unit tests, so I assume it was an active decision to not maintain unit tests for this particular piece, but I'm happy to add some if wanted.

I've already used this in the e2e tests for the response verification repo and it's working well there: https://github.com/dfinity/response-verification/blob/nathan/update-e2e-tests/packages/ic-response-verification-tests/src/main.rs#L95-L98 

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
