### PR TITLE
feat: derive Clone on `Certificate` and `Delegation` structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * Add `lookup_subtree` method to HashTree & HashTreeNode to allow for subtree lookups
+* Derive `Clone` on `Certificate` and `Delegation` structs
 
 ## [0.23.0] - 2022-12-01
 

--- a/ic-certification/src/certificate.rs
+++ b/ic-certification/src/certificate.rs
@@ -1,7 +1,7 @@
 use crate::HashTree;
 
 /// A `Certificate` as defined in <https://internetcomputer.org/docs/current/references/ic-interface-spec/#certificate>
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Certificate<'a> {
     /// The hash tree.
@@ -17,7 +17,7 @@ pub struct Certificate<'a> {
 }
 
 /// A `Delegation` as defined in <https://internetcomputer.org/docs/current/references/ic-interface-spec/#certification-delegation>
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Delegation {
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]


### PR DESCRIPTION
# Description

This makes working with the `Certificate` and `Delegation` structs much easier 

# How Has This Been Tested?

N/A

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
