### PR TITLE
chore: release v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.23.1] - 2023-03-09
+
 * Add `lookup_subtree` method to HashTree & HashTreeNode to allow for subtree lookups.
 * Derive `Clone` on `Certificate` and `Delegation` structs.
 * Add certificate version to http_request canister interface.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,18 +1958,18 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
@@ -1986,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2172,9 +2172,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2223,18 +2223,18 @@ checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "async-trait",
  "backoff",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "hex",
  "serde",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "hex",
  "ic-agent",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "async-trait",
  "candid",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "candid",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,11 @@ members = [
     "icx",
     "ref-tests"
 ]
+
+[workspace.package]
+version = "0.23.1"
+authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
+edition = "2021"
+repository = "https://github.com/dfinity/agent-rs"
+rust-version = "1.60.0"
+license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.23.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 license = "Apache-2.0"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
     "ic-utils",
     "ic-certification",
     "icx",
-    "ref-tests"
+    "ref-tests",
 ]
 
 [workspace.package]
@@ -16,3 +16,14 @@ edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
 rust-version = "1.60.0"
 license = "Apache-2.0"
+
+[workspace.dependencies]
+candid = "0.8.0"
+hex = "0.4.3"
+ring = "0.16.20"
+serde = "1.0.154"
+serde_bytes = "0.11.9"
+serde_cbor = "0.11.2"
+serde_json = "1.0.94"
+sha2 = "0.10.6"
+thiserror = "1.0.39"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "ic-agent"
-version = "0.23.0"
-authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+rust-version.workspace = true
 description = "Agent library to communicate with the Internet Computer, following the Public Specification."
 homepage = "https://docs.rs/ic-agent"
 documentation = "https://docs.rs/ic-agent"
-repository = "https://github.com/dfinity/agent-rs"
-license = "Apache-2.0"
 readme = "README.md"
 categories = ["api-bindings", "data-structures", "no-std"]
 keywords = ["internet-computer", "agent", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
-rust-version = "1.60.0"
 
 [dependencies]
 async-trait = "0.1.53"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -20,25 +20,28 @@ backoff = "0.4.0"
 base32 = "0.4.0"
 base64 = "0.13.0"
 byteorder = "1.3.2"
-candid = "0.8.0"
+candid = { workspace = true }
 futures-util = "0.3.21"
-hex = "0.4.0"
+hex = { workspace = true }
 http = "0.2.6"
 http-body = "0.4.5"
-hyper-rustls = { version = "0.23.0", features = [ "webpki-roots", "http2" ], optional = true }
+hyper-rustls = { version = "0.23.0", features = [
+    "webpki-roots",
+    "http2",
+], optional = true }
 ic-verify-bls-signature = "0.1"
 k256 = { version = "0.11", features = ["pem"] }
 leb128 = "0.2.5"
 mime = "0.3.16"
 rand = "0.8.5"
 rustls = "0.20.4"
-ring = { version = "0.16.11", features = ["std"] }
-serde = { version = "1.0.136", features = ["derive"] }
-serde_bytes = "0.11.2"
+ring = { workspace = true, features = ["std"] }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
 serde_cbor = "0.11.2"
-sha2 = "0.10"
+sha2 = { workspace = true }
 simple_asn1 = "0.6.1"
-thiserror = "1.0.30"
+thiserror = { workspace = true }
 tokio = { version = "1.21.2", features = ["time"] }
 url = "2.1.0"
 pkcs8 = { version = "0.9", features = ["std"] }
@@ -53,7 +56,7 @@ optional = true
 [dependencies.reqwest]
 version = "0.11.7"
 default-features = false
-features = [ "blocking", "json", "rustls-tls", "stream" ]
+features = ["blocking", "json", "rustls-tls", "stream"]
 optional = true
 
 [dependencies.pem]
@@ -70,4 +73,6 @@ tokio = { version = "1.17.0", features = ["full"] }
 default = ["pem", "reqwest"]
 reqwest = ["dep:reqwest", "dep:hyper-rustls"]
 hyper = ["dep:hyper", "dep:hyper-rustls"]
-ic_ref_tests = ["default"] # Used to separate integration tests for ic-ref which need a server running.
+ic_ref_tests = [
+    "default",
+] # Used to separate integration tests for ic-ref which need a server running.

--- a/ic-certification/Cargo.toml
+++ b/ic-certification/Cargo.toml
@@ -14,20 +14,20 @@ keywords = ["internet-computer", "agent", "utility", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
-hex = "0.4.3"
-sha2 = "0.10.1"
+hex = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
-serde = { version = "1.0.133", features = ["derive"] }
-serde_cbor = "0.11.2"
+serde = { workspace = true, features = ["derive"] }
+serde_cbor = { workspace = true }
 
 [dependencies.serde]
-version = "1.0.115"
+workspace = true
 features = ["derive"]
 optional = true
 
 [dependencies.serde_bytes]
-version = "0.11.5"
+workspace = true
 optional = true
 
 [features]

--- a/ic-certification/Cargo.toml
+++ b/ic-certification/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "ic-certification"
-version = "0.23.0"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+rust-version.workspace = true
 description = "Types related to the Internet Computer Public Specification."
-homepage = "https://docs.rs/ic-certification"
 documentation = "https://docs.rs/ic-certification"
-repository = "https://github.com/dfinity/agent-rs"
-edition = "2021"
-license = "Apache-2.0"
 readme = "README.md"
 categories = ["api-bindings", "data-structures", "no-std"]
 keywords = ["internet-computer", "agent", "utility", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
-rust-version = "1.60.0"
 
 [dependencies]
 hex = "0.4.3"

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -15,13 +15,15 @@ keywords = ["internet-computer", "agent", "utility", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
-hex = "0.4.2"
-ic-agent = { path = "../ic-agent", version = "0.23", features = [ "pem" ], default-features = false}
+hex = { workspace = true }
+ic-agent = { path = "../ic-agent", version = "0.23", features = [
+    "pem",
+], default-features = false }
 num-bigint = "0.4.3"
 pkcs11 = "0.5.0"
-sha2 = "0.10"
+sha2 = { workspace = true }
 simple_asn1 = "0.6.0"
-thiserror = "1.0.20"
+thiserror = { workspace = true }
 
 [dev-dependencies]
 ic-agent = { path = "../ic-agent", version = "0.23", features = ["reqwest"] }

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "ic-identity-hsm"
-version = "0.23.0"
-authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+rust-version.workspace = true
 description = "Identity implementation for HSM for the ic-agent package."
 homepage = "https://docs.rs/ic-identity-hsm"
 documentation = "https://docs.rs/ic-identity-hsm"
-repository = "https://github.com/dfinity/agent-rs"
-edition = "2021"
-license = "Apache-2.0"
 readme = "README.md"
 categories = ["api-bindings", "data-structures", "no-std"]
 keywords = ["internet-computer", "agent", "utility", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
-rust-version = "1.60.0"
 
 [dependencies]
 hex = "0.4.2"

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -18,13 +18,13 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 async-trait = "0.1.40"
-candid = "0.8.0"
+candid = { workspace = true }
 ic-agent = { path = "../ic-agent", version = "0.23", default-features = false }
-serde = "1.0.115"
-serde_bytes = "0.11"
+serde = { workspace = true }
+serde_bytes = { workspace = true }
 strum = "0.24"
 strum_macros = "0.24"
-thiserror = "1.0.29"
+thiserror = { workspace = true }
 paste = "1"
 num-bigint = "0.4"
 leb128 = "0.2"
@@ -33,7 +33,7 @@ once_cell = "1.10.0"
 
 [dev-dependencies]
 ic-agent = { path = "../ic-agent", version = "0.23" }
-ring = "0.16.11"
+ring = { workspace = true }
 tokio = { version = "1.14.0", features = ["full"] }
 
 [features]

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "ic-utils"
-version = "0.23.0"
-authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+rust-version.workspace = true
 description = "Collection of utilities for Rust, on top of ic-agent, to communicate with the Internet Computer, following the Public Specification."
 homepage = "https://docs.rs/ic-utils"
 documentation = "https://docs.rs/ic-utils"
-repository = "https://github.com/dfinity/agent-rs"
-license = "Apache-2.0"
 readme = "README.md"
 categories = ["api-bindings", "data-structures", "no-std"]
 keywords = ["internet-computer", "agent", "utility", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
-rust-version = "1.60.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -21,12 +21,12 @@ anyhow = "1.0"
 base64 = "0.13"
 clap = { version = "3.1.8", features = ["derive", "cargo"] }
 chrono = "0.4.19"
-hex = "0.4.2"
+hex = { workspace = true }
 ic-agent = { path = "../ic-agent", version = "0.23", default-features = false }
 leb128 = "0.2.4"
-reqwest = { version = "0.11", features = [ "blocking", "rustls-tls" ] }
-sha2 = "0.10"
-serde = { version = "1.0.115", features = ["derive"] }
-serde_bytes = "0.11"
-serde_cbor = "0.11"
+reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }
+sha2 = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
+serde_cbor = { workspace = true }
 ic-certification = { path = "../ic-certification", version = "0.23" }

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "icx-cert"
-version = "0.23.0"
-authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+rust-version.workspace = true
 description = "CLI tool to download a document from the Internet Computer and pretty-print the contents of its IC-Certificate header."
 homepage = "https://docs.rs/icx-cert"
 documentation = "https://docs.rs/icx-cert"
-repository = "https://github.com/dfinity/agent-rs"
-license = "Apache-2.0"
 readme = "README.md"
 categories = ["command-line-interface"]
 keywords = ["internet-computer", "agent", "icp", "dfinity", "certificate"]
 include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
-rust-version = "1.60.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "icx"
-version = "0.23.0"
-authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+rust-version.workspace = true
 description = "CLI tool to call canisters on the Internet Computer."
 homepage = "https://docs.rs/icx"
 documentation = "https://docs.rs/icx"
-repository = "https://github.com/dfinity/agent-rs"
-license = "Apache-2.0"
 readme = "README.md"
 categories = ["command-line-interface", "web-programming::http-client"]
 keywords = ["internet-computer", "agent", "icp", "dfinity", "call"]
 include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
-rust-version = "1.60.0"
 
 [[bin]]
 name = "icx"

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -20,15 +20,15 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
-candid = "0.8.0"
+candid = { workspace = true }
 clap = { version = "3.0.14", features = ["derive", "cargo"] }
-hex = "0.4.2"
+hex = { workspace = true }
 humantime = "2.0.1"
 ic-agent = { path = "../ic-agent", version = "0.23" }
 ic-utils = { path = "../ic-utils", version = "0.23" }
 pem = "1.0"
-ring = "0.16.11"
-serde = "1.0.115"
+ring = { workspace = true }
+serde = { workspace = true }
 serde_json = "1.0.57"
 tokio = { version = "1.8.1", features = ["full"] }
-thiserror = "1.0.24"
+thiserror = { workspace = true }

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-candid = "0.8.0"
+candid = { workspace = true }
 ic-agent = { path = "../ic-agent" }
 ic-identity-hsm = { path = "../ic-identity-hsm" }
 ic-utils = { path = "../ic-utils", features = ["raw"] }
-ring = "0.16.11"
-serde = { version = "1.0.101", features = ["derive"] }
-sha2 = "0.10"
+ring = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+sha2 = { workspace = true }
 tokio = { version = "1.8.1", features = ["full"] }
 
 [dev-dependencies]
-serde_cbor = "0.11.1"
+serde_cbor = { workspace = true }


### PR DESCRIPTION
# Description

Utilize the new cargo feature to inherit value from workspace config.
From now on, we will only need modify the version in the root Cargo.toml.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
