### PR TITLE
fix: broken link to Agent

### DIFF
--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -90,7 +90,7 @@
 //! # });
 //! ```
 //! For more information about the Agent interface used in this example, see the
-//! [Agent](https://agent-rust.netlify.app/ic_agent/struct.agent) documentation.
+//! [Agent] documentation.
 //!
 //! ## References
 //! For an introduction to the Internet Computer and the DFINITY Canister SDK,


### PR DESCRIPTION
# Description

Reported by @mariodfinity

# How Has This Been Tested?

Manually checked that `cargo doc -p ic-agent` produces the right link.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
