### PR TITLE
feat: enable clients to get the currently used root key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Expose the root key to clients through `read_root_key`
+
 ## [0.23.1] - 2023-03-09
 
 * Add `lookup_subtree` method to HashTree & HashTreeNode to allow for subtree lookups.

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -317,7 +317,8 @@ impl Agent {
         Ok(())
     }
 
-    fn read_root_key(&self) -> Result<Vec<u8>, AgentError> {
+    /// Return the root key currently in use.
+    pub fn read_root_key(&self) -> Result<Vec<u8>, AgentError> {
         if let Ok(read_lock) = self.root_key.read() {
             if let Some(root_key) = read_lock.clone() {
                 Ok(root_key)


### PR DESCRIPTION
# Description

Enable clients to get the currently used root key through the `read_root_key` method.

Fixes # (issue)

# How Has This Been Tested?

N/A

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
