### PR TITLE
chore: rename Transport and implementors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/ic-agent/src/agent/agent_config.rs
+++ b/ic-agent/src/agent/agent_config.rs
@@ -1,5 +1,5 @@
 use crate::{
-    agent::{NonceFactory, NonceGenerator, ReplicaV2Transport},
+    agent::{NonceFactory, NonceGenerator, Transport},
     identity::{anonymous::AnonymousIdentity, Identity},
 };
 use std::{sync::Arc, time::Duration};
@@ -14,7 +14,7 @@ pub struct AgentConfig {
     /// See [`with_ingress_expiry`](super::AgentBuilder::with_ingress_expiry).
     pub ingress_expiry_duration: Option<Duration>,
     /// The [`with_transport`](super::AgentBuilder::with_transport).
-    pub transport: Option<Arc<dyn ReplicaV2Transport>>,
+    pub transport: Option<Arc<dyn Transport>>,
 }
 
 impl Default for AgentConfig {

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     agent::{
-        http_transport::ReqwestHttpReplicaV2Transport,
+        http_transport::ReqwestTransport,
         replica_api::{CallReply, QueryResponse},
         Status,
     },
@@ -28,9 +28,7 @@ fn query() -> Result<(), AgentError> {
         .create();
 
     let agent = Agent::builder()
-        .with_transport(ReqwestHttpReplicaV2Transport::create(
-            &mockito::server_url(),
-        )?)
+        .with_transport(ReqwestTransport::create(&mockito::server_url())?)
         .build()?;
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(async {
@@ -58,9 +56,7 @@ fn query_error() -> Result<(), AgentError> {
         .with_status(500)
         .create();
     let agent = Agent::builder()
-        .with_transport(ReqwestHttpReplicaV2Transport::create(
-            &mockito::server_url(),
-        )?)
+        .with_transport(ReqwestTransport::create(&mockito::server_url())?)
         .build()?;
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
 
@@ -97,9 +93,7 @@ fn query_rejected() -> Result<(), AgentError> {
         .create();
 
     let agent = Agent::builder()
-        .with_transport(ReqwestHttpReplicaV2Transport::create(
-            &mockito::server_url(),
-        )?)
+        .with_transport(ReqwestTransport::create(&mockito::server_url())?)
         .build()?;
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
 
@@ -138,9 +132,7 @@ fn call_error() -> Result<(), AgentError> {
         .create();
 
     let agent = Agent::builder()
-        .with_transport(ReqwestHttpReplicaV2Transport::create(
-            &mockito::server_url(),
-        )?)
+        .with_transport(ReqwestTransport::create(&mockito::server_url())?)
         .build()?;
 
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
@@ -174,9 +166,7 @@ fn status() -> Result<(), AgentError> {
         .create();
 
     let agent = Agent::builder()
-        .with_transport(ReqwestHttpReplicaV2Transport::create(
-            &mockito::server_url(),
-        )?)
+        .with_transport(ReqwestTransport::create(&mockito::server_url())?)
         .build()?;
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(async { agent.status().await });
@@ -201,9 +191,7 @@ fn status_okay() -> Result<(), AgentError> {
         .create();
 
     let agent = Agent::builder()
-        .with_transport(ReqwestHttpReplicaV2Transport::create(
-            &mockito::server_url(),
-        )?)
+        .with_transport(ReqwestTransport::create(&mockito::server_url())?)
         .build()?;
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(agent.status());
@@ -226,9 +214,7 @@ fn status_error() -> Result<(), AgentError> {
     let _read_mock = mock("GET", "/api/v2/status").with_status(500).create();
 
     let agent = Agent::builder()
-        .with_transport(ReqwestHttpReplicaV2Transport::create(
-            &mockito::server_url(),
-        )?)
+        .with_transport(ReqwestTransport::create(&mockito::server_url())?)
         .build()?;
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
     let result = runtime.block_on(async { agent.status().await });
@@ -369,7 +355,7 @@ fn check_subnet_range_with_valid_range() {
     .with_body(REQ_WITH_DELEGATED_CERT_RESPONSE)
     .create();
     let agent = Agent::builder()
-        .with_transport(ReqwestHttpReplicaV2Transport::create(&mockito::server_url()).unwrap())
+        .with_transport(ReqwestTransport::create(&mockito::server_url()).unwrap())
         .build()
         .unwrap();
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
@@ -403,7 +389,7 @@ fn check_subnet_range_with_unauthorized_range() {
     .with_body(REQ_WITH_DELEGATED_CERT_RESPONSE)
     .create();
     let agent = Agent::builder()
-        .with_transport(ReqwestHttpReplicaV2Transport::create(&mockito::server_url()).unwrap())
+        .with_transport(ReqwestTransport::create(&mockito::server_url()).unwrap())
         .build()
         .unwrap();
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");
@@ -435,7 +421,7 @@ fn check_subnet_range_with_pruned_range() {
     .with_body(PRUNED_SUBNET)
     .create();
     let agent = Agent::builder()
-        .with_transport(ReqwestHttpReplicaV2Transport::create(&mockito::server_url()).unwrap())
+        .with_transport(ReqwestTransport::create(&mockito::server_url()).unwrap())
         .build()
         .unwrap();
     let runtime = tokio::runtime::Runtime::new().expect("Unable to create a runtime");

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    agent::{agent_config::AgentConfig, Agent, ReplicaV2Transport},
+    agent::{agent_config::AgentConfig, Agent, Transport},
     AgentError, Identity, NonceFactory, NonceGenerator,
 };
 use std::sync::Arc;
@@ -18,21 +18,20 @@ impl AgentBuilder {
 
     /// Set the URL of the [Agent].
     #[cfg(feature = "reqwest")]
-    #[deprecated(since = "0.3.0", note = "Prefer using with_transport().")]
     pub fn with_url<S: Into<String>>(self, url: S) -> Self {
-        use crate::agent::http_transport::ReqwestHttpReplicaV2Transport;
+        use crate::agent::http_transport::ReqwestTransport;
 
-        self.with_transport(ReqwestHttpReplicaV2Transport::create(url).unwrap())
+        self.with_transport(ReqwestTransport::create(url).unwrap())
     }
 
     /// Set a Replica transport to talk to serve as the replica interface.
-    pub fn with_transport<T: 'static + ReplicaV2Transport>(self, transport: T) -> Self {
+    pub fn with_transport<T: 'static + Transport>(self, transport: T) -> Self {
         self.with_arc_transport(Arc::new(transport))
     }
 
     /// Same as [Self::with_transport], but provides a `Arc` boxed implementation instead
     /// of a direct type.
-    pub fn with_arc_transport(mut self, transport: Arc<dyn ReplicaV2Transport>) -> Self {
+    pub fn with_arc_transport(mut self, transport: Arc<dyn Transport>) -> Self {
         self.config.transport = Some(transport);
         self
     }

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -1,4 +1,4 @@
-//! A [ReplicaV2Transport] that connects using a hyper client.
+//! A [`Transport`] that connects using a [`hyper`] client.
 #![cfg(any(feature = "hyper"))]
 
 pub use hyper;
@@ -20,22 +20,25 @@ use crate::{
     agent::{
         agent_error::HttpErrorPayload,
         http_transport::{IC0_DOMAIN, IC0_SUB_DOMAIN},
-        AgentFuture, ReplicaV2Transport,
+        AgentFuture, Transport,
     },
     export::Principal,
     AgentError, RequestId,
 };
 
-/// A [ReplicaV2Transport] using [hyper] to make HTTP calls to the internet computer.
+/// A [`Transport`] using [`hyper`] to make HTTP calls to the Internet Computer.
 #[derive(Debug)]
-pub struct HyperReplicaV2Transport<B1, S = Client<HttpsConnector<HttpConnector>, B1>> {
+pub struct HyperTransport<B1, S = Client<HttpsConnector<HttpConnector>, B1>> {
     _marker: PhantomData<AtomicPtr<B1>>,
     url: Uri,
     max_response_body_size: Option<usize>,
     service: S,
 }
 
-/// Trait representing the contraints on [`HttpBody`] that [`HyperReplicaV2Transport`] requires
+#[doc(hidden)]
+pub use HyperTransport as HyperReplicaV2Transport; // remove after 0.24
+
+/// Trait representing the contraints on [`HttpBody`] that [`HyperTransport`] requires
 pub trait HyperBody:
     HttpBody<Data = Self::BodyData, Error = Self::BodyError> + Send + From<Vec<u8>> + 'static
 {
@@ -55,7 +58,7 @@ where
     type BodyError = B::Error;
 }
 
-/// Trait representing the contraints on [`Service`] that [`HyperReplicaV2Transport`] requires.
+/// Trait representing the contraints on [`Service`] that [`HyperTransport`] requires.
 pub trait HyperService<B1: HyperBody>:
     Send
     + Sync
@@ -84,7 +87,7 @@ where
     type ServiceFuture = S::Future;
 }
 
-impl<B1: HyperBody> HyperReplicaV2Transport<B1> {
+impl<B1: HyperBody> HyperTransport<B1> {
     /// Creates a replica transport from a HTTP URL.
     pub fn create<U: Into<Uri>>(url: U) -> Result<Self, AgentError> {
         let connector = HttpsConnectorBuilder::new()
@@ -97,7 +100,7 @@ impl<B1: HyperBody> HyperReplicaV2Transport<B1> {
     }
 }
 
-impl<B1, S> HyperReplicaV2Transport<B1, S>
+impl<B1, S> HyperTransport<B1, S>
 where
     B1: HyperBody,
     S: HyperService<B1>,
@@ -230,7 +233,7 @@ where
     }
 }
 
-impl<B1, S> ReplicaV2Transport for HyperReplicaV2Transport<B1, S>
+impl<B1, S> Transport for HyperTransport<B1, S>
 where
     B1: HyperBody,
     S: HyperService<B1>,
@@ -276,7 +279,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::HyperReplicaV2Transport;
+    use super::HyperTransport;
     use hyper::{Client, Uri};
 
     #[test]
@@ -284,7 +287,7 @@ mod test {
         fn test(base: &str, result: &str) {
             let client: Client<_> = Client::builder().build_http();
             let uri: Uri = base.parse().unwrap();
-            let t = HyperReplicaV2Transport::create_with_service(uri, client).unwrap();
+            let t = HyperTransport::create_with_service(uri, client).unwrap();
             assert_eq!(t.url, result, "{}", base);
         }
 

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -36,7 +36,7 @@ pub struct HyperTransport<B1, S = Client<HttpsConnector<HttpConnector>, B1>> {
 }
 
 #[doc(hidden)]
-pub use HyperTransport as HyperReplicaV2Transport; // remove after 0.24
+pub use HyperTransport as HyperReplicaV2Transport; // deprecate after 0.24
 
 /// Trait representing the contraints on [`HttpBody`] that [`HyperTransport`] requires
 pub trait HyperBody:

--- a/ic-agent/src/agent/http_transport/mod.rs
+++ b/ic-agent/src/agent/http_transport/mod.rs
@@ -1,16 +1,24 @@
-//! [super::ReplicaV2Transport] implementations.
+//! [`Transport`](super::Transport) implementations.
 
 #[cfg(feature = "reqwest")]
 pub mod reqwest_transport;
 
 #[cfg(feature = "reqwest")]
-pub use reqwest_transport::*;
+#[doc(inline)]
+pub use reqwest_transport::ReqwestTransport;
+#[cfg(feature = "reqwest")]
+#[doc(hidden)]
+pub use reqwest_transport::*; // remove after 0.24
 
 #[cfg(feature = "hyper")]
 pub mod hyper_transport;
 
 #[cfg(feature = "hyper")]
-pub use hyper_transport::*;
+#[doc(inline)]
+pub use hyper_transport::HyperTransport;
+#[cfg(feature = "hyper")]
+#[doc(hidden)]
+pub use hyper_transport::*; // remove after 0.24
 
 #[allow(dead_code)]
 const IC0_DOMAIN: &str = "ic0.app";

--- a/ic-agent/src/agent/http_transport/mod.rs
+++ b/ic-agent/src/agent/http_transport/mod.rs
@@ -8,7 +8,7 @@ pub mod reqwest_transport;
 pub use reqwest_transport::ReqwestTransport;
 #[cfg(feature = "reqwest")]
 #[doc(hidden)]
-pub use reqwest_transport::*; // remove after 0.24
+pub use reqwest_transport::*; // deprecate after 0.24
 
 #[cfg(feature = "hyper")]
 pub mod hyper_transport;
@@ -18,7 +18,7 @@ pub mod hyper_transport;
 pub use hyper_transport::HyperTransport;
 #[cfg(feature = "hyper")]
 #[doc(hidden)]
-pub use hyper_transport::*; // remove after 0.24
+pub use hyper_transport::*; // deprecate after 0.24
 
 #[allow(dead_code)]
 const IC0_DOMAIN: &str = "ic0.app";

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -1,4 +1,4 @@
-//! A [ReplicaV2Transport] that connects using a reqwest client.
+//! A [`Transport`] that connects using a [`reqwest`] client.
 #![cfg(feature = "reqwest")]
 
 pub use reqwest;
@@ -16,7 +16,7 @@ use crate::{
     agent::{
         agent_error::HttpErrorPayload,
         http_transport::{IC0_DOMAIN, IC0_SUB_DOMAIN},
-        AgentFuture, ReplicaV2Transport,
+        AgentFuture, Transport,
     },
     export::Principal,
     AgentError, RequestId,
@@ -51,16 +51,19 @@ impl dyn PasswordManager {
 
 impl_debug_empty!(dyn PasswordManager);
 
-/// A [ReplicaV2Transport] using [reqwest] to make HTTP calls to the internet computer.
+/// A [`Transport`] using [`reqwest`] to make HTTP calls to the Internet Computer.
 #[derive(Debug)]
-pub struct ReqwestHttpReplicaV2Transport {
+pub struct ReqwestTransport {
     url: Url,
     client: Client,
     password_manager: Option<Arc<dyn PasswordManager>>,
     max_response_body_size: Option<usize>,
 }
 
-impl ReqwestHttpReplicaV2Transport {
+#[doc(hidden)]
+pub use ReqwestTransport as ReqwestHttpReplicaV2Transport; // remove after 0.24
+
+impl ReqwestTransport {
     /// Creates a replica transport from a HTTP URL.
     pub fn create<U: Into<String>>(url: U) -> Result<Self, AgentError> {
         let mut tls_config = rustls::ClientConfig::builder()
@@ -108,7 +111,7 @@ impl ReqwestHttpReplicaV2Transport {
 
     /// Same as [`Self::with_password_manager`], but providing the Arc so one does not have to be created.
     pub fn with_arc_password_manager(self, password_manager: Arc<dyn PasswordManager>) -> Self {
-        ReqwestHttpReplicaV2Transport {
+        ReqwestTransport {
             password_manager: Some(password_manager),
             ..self
         }
@@ -116,7 +119,7 @@ impl ReqwestHttpReplicaV2Transport {
 
     /// Sets a max response body size limit
     pub fn with_max_response_body_size(self, max_response_body_size: usize) -> Self {
-        ReqwestHttpReplicaV2Transport {
+        ReqwestTransport {
             max_response_body_size: Some(max_response_body_size),
             ..self
         }
@@ -240,7 +243,7 @@ impl ReqwestHttpReplicaV2Transport {
     }
 }
 
-impl ReplicaV2Transport for ReqwestHttpReplicaV2Transport {
+impl Transport for ReqwestTransport {
     fn call(
         &self,
         effective_canister_id: Principal,
@@ -280,12 +283,12 @@ impl ReplicaV2Transport for ReqwestHttpReplicaV2Transport {
 
 #[cfg(test)]
 mod test {
-    use super::ReqwestHttpReplicaV2Transport;
+    use super::ReqwestTransport;
 
     #[test]
     fn redirect() {
         fn test(base: &str, result: &str) {
-            let t = ReqwestHttpReplicaV2Transport::create(base).unwrap();
+            let t = ReqwestTransport::create(base).unwrap();
             assert_eq!(t.url.as_str(), result, "{}", base);
         }
 

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -61,7 +61,7 @@ pub struct ReqwestTransport {
 }
 
 #[doc(hidden)]
-pub use ReqwestTransport as ReqwestHttpReplicaV2Transport; // remove after 0.24
+pub use ReqwestTransport as ReqwestHttpReplicaV2Transport; // deprecate after 0.24
 
 impl ReqwestTransport {
     /// Creates a replica transport from a HTTP URL.

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -97,7 +97,7 @@ pub trait Transport: Send + Sync {
 }
 
 #[doc(hidden)]
-pub use Transport as ReplicaV2Transport; // remove after 0.24
+pub use Transport as ReplicaV2Transport; // deprecate after 0.24
 
 impl_debug_empty!(dyn Transport);
 

--- a/ic-agent/src/export.rs
+++ b/ic-agent/src/export.rs
@@ -1,2 +1,3 @@
 //! A module to re-export types that are visible through the ic-agent API.
+#[doc(inline)]
 pub use candid::types::principal::{Principal, PrincipalError};

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -24,11 +24,11 @@ pub struct Signature {
     pub signature: Option<Vec<u8>>,
 }
 
-/// An Identity takes a request id and returns the [Signature]. Since it
-/// also knows about the Principal of the sender.
+/// An Identity takes a request id and returns the [Signature]. It knows or
+/// represents the Principal of the sender.
 ///
 /// Agents are assigned a single Identity object, but there can be multiple
-/// identities used
+/// identities used.
 pub trait Identity: Send + Sync {
     /// Returns a sender, ie. the Principal ID that is used to sign a request.
     /// Only one sender can be used per request.

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -119,11 +119,14 @@ pub mod export;
 pub mod identity;
 pub mod request_id;
 
+#[doc(inline)]
 pub use agent::{
     agent_error, agent_error::AgentError, response_authentication::lookup_value, Agent,
     NonceFactory, NonceGenerator,
 };
+#[doc(inline)]
 pub use identity::{Identity, Signature};
+#[doc(inline)]
 pub use request_id::{to_request_id, RequestId, RequestIdError};
 
 // Re-export from ic_certification for backward compatibility.

--- a/ic-agent/src/request_id/error.rs
+++ b/ic-agent/src/request_id/error.rs
@@ -15,6 +15,7 @@ pub enum RequestIdFromStringError {
 }
 
 /// An error during the calculation of the RequestId.
+///
 /// Since we use serde for serializing a data type into a hash, this has to support traits that
 /// serde expects, such as Display
 #[derive(Error, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]

--- a/ic-agent/src/request_id/mod.rs
+++ b/ic-agent/src/request_id/mod.rs
@@ -12,6 +12,7 @@ use sha2::{Digest, Sha256};
 use std::{collections::BTreeMap, iter::Extend, str::FromStr};
 
 pub mod error;
+#[doc(inline)]
 pub use error::RequestIdError;
 
 /// Type alias for a sha256 result (ie. a u256).

--- a/ic-identity-hsm/src/lib.rs
+++ b/ic-identity-hsm/src/lib.rs
@@ -5,7 +5,7 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use ic_agent::agent::{Agent, http_transport::ReqwestHttpReplicaV2Transport};
+//! use ic_agent::agent::{Agent, http_transport::ReqwestTransport};
 //! use ic_identity_hsm::HardwareIdentity;
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # let replica_url = "";
@@ -13,7 +13,7 @@
 //! # let slot_index = 0;
 //! # let key_id = "";
 //! let agent = Agent::builder()
-//!     .with_transport(ReqwestHttpReplicaV2Transport::create(replica_url)?)
+//!     .with_transport(ReqwestTransport::create(replica_url)?)
 //!     .with_identity(HardwareIdentity::new(lib_path, slot_index, key_id, || Ok("hunter2".to_string()))?)
 //!     .build();
 //! # Ok(())

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -399,7 +399,7 @@ impl<'agent, 'canister: 'agent> AsyncCallBuilder<'agent, 'canister> {
 mod tests {
     use super::super::interfaces::ManagementCanister;
     use crate::call::AsyncCall;
-    use ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport;
+    use ic_agent::agent::http_transport::ReqwestTransport;
     use ic_agent::identity::BasicIdentity;
 
     #[ignore]
@@ -417,7 +417,7 @@ mod tests {
         );
 
         let agent = ic_agent::Agent::builder()
-            .with_transport(ReqwestHttpReplicaV2Transport::create("http://localhost:8001").unwrap())
+            .with_transport(ReqwestTransport::create("http://localhost:8001").unwrap())
             .with_identity(identity)
             .build()
             .unwrap();

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -341,7 +341,7 @@ async fn main() -> Result<()> {
 
     let agent = Agent::builder()
         .with_transport(
-            agent::http_transport::ReqwestHttpReplicaV2Transport::create(opts.replica.clone())
+            agent::http_transport::ReqwestTransport::create(opts.replica.clone())
                 .context("Failed to create Transport for Agent")?,
         )
         .with_boxed_identity(Box::new(create_identity(opts.pem)))

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -1,4 +1,4 @@
-use ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport;
+use ic_agent::agent::http_transport::ReqwestTransport;
 use ic_agent::identity::Secp256k1Identity;
 use ic_agent::{export::Principal, identity::BasicIdentity, Agent, Identity};
 use ic_identity_hsm::HardwareIdentity;
@@ -85,9 +85,7 @@ pub async fn create_agent(identity: Box<dyn Identity>) -> Result<Agent, String> 
         .expect("Could not parse the IC_REF_PORT environment variable as an integer.");
 
     Agent::builder()
-        .with_transport(
-            ReqwestHttpReplicaV2Transport::create(format!("http://127.0.0.1:{}", port)).unwrap(),
-        )
+        .with_transport(ReqwestTransport::create(format!("http://127.0.0.1:{}", port)).unwrap())
         .with_boxed_identity(identity)
         .build()
         .map_err(|e| format!("{:?}", e))


### PR DESCRIPTION
There are a few unnecessarily large names which make the documentation feel slightly daunting while referencing an undocumented and inaccessible V1, namely `ReplicaV2Transport`, `ReqwestHttpReplicaV2Transport`, and `HyperReplicaV2Transport`. This renames these to `Transport`, `ReqwestTransport`, and `HyperTransport`, as well as un-deprecating `AgentBuilder::with_url`. However, the old names are left up as `pub use`s under `#[doc(hidden)]` to avoid making this a breaking change; they can be `#[deprecate]`d in the next release and removed in the one after that. Additionally, in the interest of friendlier documentation, many `pub use`s have been marked `#[doc(inline)]`.