### PR TITLE
fix: do not send certificate_version on http update requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * Support WASM targets in the browser via `wasm-bindgen`
+* Do not send `certificate_version` on HTTP Update requests
 
 ## [0.23.2] - 2023-04-21
 

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -51,6 +51,20 @@ struct HttpRequest<'a, H> {
     pub certificate_version: Option<&'a u128>,
 }
 
+/// The important components of an HTTP update request.
+/// This is the same as `HttpRequest`, excluding the `certificate_version` property.
+#[derive(Debug, Clone, CandidType)]
+struct HttpUpdateRequest<'a, H> {
+    /// The HTTP method string.
+    pub method: &'a str,
+    /// The URL that was visited.
+    pub url: &'a str,
+    /// The request headers.
+    pub headers: H,
+    /// The request body.
+    pub body: &'a [u8],
+}
+
 /// A wrapper around an iterator of headers
 #[derive(Debug, Clone)]
 pub struct Headers<H>(H);
@@ -443,15 +457,8 @@ impl<'agent> HttpRequestCanister<'agent> {
         url: impl AsRef<str>,
         headers: impl 'agent + Send + Sync + Clone + ExactSizeIterator<Item = HeaderField<'agent>>,
         body: impl AsRef<[u8]>,
-        certificate_version: Option<&u128>,
     ) -> impl 'agent + AsyncCall<(HttpResponse,)> {
-        self.http_request_update_custom(
-            method.as_ref(),
-            url.as_ref(),
-            headers,
-            body.as_ref(),
-            certificate_version,
-        )
+        self.http_request_update_custom(method.as_ref(), url.as_ref(), headers, body.as_ref())
     }
 
     /// Performs a HTTP request over an update call. Unlike query calls, update calls must pass consensus
@@ -463,7 +470,6 @@ impl<'agent> HttpRequestCanister<'agent> {
         url: &str,
         headers: H,
         body: &[u8],
-        certificate_version: Option<&u128>,
     ) -> impl 'agent + AsyncCall<(HttpResponse<T, C>,)>
     where
         H: 'agent + Send + Sync + Clone + ExactSizeIterator<Item = HeaderField<'agent>>,
@@ -471,12 +477,11 @@ impl<'agent> HttpRequestCanister<'agent> {
         C: 'agent + Send + Sync + CandidType + for<'de> Deserialize<'de>,
     {
         self.update_("http_request_update")
-            .with_arg(HttpRequest {
+            .with_arg(HttpUpdateRequest {
                 method,
                 url,
                 headers: Headers(headers),
                 body,
-                certificate_version,
             })
             .build()
     }


### PR DESCRIPTION
# Description

This puts the HTTP request interface in line with recent changes to the spec: https://github.com/dfinity/interface-spec/pull/147
The `certificate_version` should always be ignored on Update calls since its not relevant. Requiring it to be provided confuses this.

# How Has This Been Tested?

I have not added any new tests for this.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
