### PR TITLE
fix: update `icx-cert` reqwest call to include a user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Support WASM targets in the browser via `wasm-bindgen`
 
+### icx-cert
+* Fixed issue where a missing request header caused the canister to not respond with an `ic-certificate` header.
+
 ## [0.23.2] - 2023-04-21
 
 * Expose the root key to clients through `read_root_key`

--- a/icx-cert/src/pprint.rs
+++ b/icx-cert/src/pprint.rs
@@ -77,6 +77,7 @@ pub fn pprint(url: String, accept_encodings: Option<Vec<String>>) -> Result<()> 
             client
         };
         client
+            .user_agent("icx-cert")
             .build()?
             .get(url)
             .send()


### PR DESCRIPTION
# Description

This fixes an error where the canister would not respond with an `ic-certificate` header if the `User-Agent` header was not included in the request, thus breaking the application

Fixes #418 

# How Has This Been Tested?

```bash
$ cd icx-cert
$ cargo run print "https://mzgdj-vqaaa-aaaag-qanaa-cai.ic0.app"
```
Now responds with the pretty printed tree instead of:
`Error: IC-Certificate header not found:`

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
