### PR TITLE
fix: Fixed bug in conventional commits file

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -9,13 +9,22 @@ on:
 
 jobs:
   check:
+    name: conventional-pr-title:required
     runs-on: ubuntu-latest
     steps:
-      - uses: dfinity/conventional-pr-title-action@v2.2.3
-        with:
-          success-state: Title follows the specification.
-          failure-state: Title does not follow the specification.
-          context-name: conventional-pr-title
-          preset: conventional-changelog-angular@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Conventional commit patterns:
+        #   verb: description
+        #   verb!: description of breaking change
+        #   verb(scope): Description of change to $scope
+        #   verb(scope)!: Description of breaking change to $scope
+        # verb: feat, fix, ...
+        # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
+        # !: Indicates that the PR contains a breaking change.
+      - run: |
+          if [[ "${{ github.event.pull_request.title }}" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
+              echo pass
+          else
+              echo "PR title does not match conventions"
+              echo "PR title: ${{ github.event.pull_request.title }}"
+              exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Fix the conventional-commits job to allow `!` suffix for PRs introducing breaking changes.
 * Support WASM targets in the browser via `wasm-bindgen`
 
 ## [0.23.2] - 2023-04-21


### PR DESCRIPTION
# Description

I copied the jobs from the [conventional commits configuration file from the SDK Repo.](https://sourcegraph.com/github.com/dfinity/sdk/-/blob/.github/workflows/conventional-commits.yml?L20-41)

This allows us to have PRs with a suffix of `!`, and should fix the job failing for the title of #422.
Fixes #423

# How Has This Been Tested?

N\A. The job is the same as used in https://sourcegraph.com/github.com/dfinity/sdk/-/blob/.github/workflows/conventional-commits.yml

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
