### PR TITLE
ci: run conventional commits workflow from pull request

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,6 +1,6 @@
 name: Check PR title
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* Fix the conventional-commits job to allow `!` suffix for PRs introducing breaking changes.
 * Support WASM targets in the browser via `wasm-bindgen`
 
 ## [0.23.2] - 2023-04-21


### PR DESCRIPTION
# Description

The conventional commits workflow no longer needs to run on `pull_request_target`, since the repo now holds all of the code.

Also note: Github workflows that run against `pull_request_target` won't be tested in a PR that changes that workflow. 

# How Has This Been Tested?

This is the same workflow as https://github.com/dfinity/sdk/blob/master/.github/workflows/conventional-commits.yml

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

