### PR TITLE
feat: remove the PasswordManager

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Auto detect text files and perform LF normalization
-* text=auto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Breaking Change: removing the PasswordManager
 * Breaking Change: Enum variant `AgentError::ReplicaError` is now a tuple struct containing `RejectResponse`.
 * Handling rejected update calls where status code is 200. See IC-1462
 * Reject code type is changed from `u64` to enum `RejectCode`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base32"
@@ -228,8 +228,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
 dependencies = [
  "digest 0.9.0",
- "ff",
- "group",
+ "ff 0.12.1",
+ "group 0.12.1",
  "pairing",
  "rand_core",
  "subtle",
@@ -439,9 +439,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -511,9 +511,9 @@ checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "05e58dffcdcc8ee7b22f0c1f71a69243d7c2d9ad87b5a14361f2424a1565c219"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -542,6 +542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -569,11 +570,12 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
 dependencies = [
  "der",
+ "digest 0.10.6",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -587,17 +589,16 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "75c71eaa367f2e5d556414a8eea812bc62985c879748d6403edabd9cb03f16e7"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
  "digest 0.10.6",
- "ff",
+ "ff 0.13.0",
  "generic-array",
- "group",
+ "group 0.13.0",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
@@ -659,6 +660,16 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
@@ -797,6 +808,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -824,7 +836,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core",
  "subtle",
 ]
@@ -1029,7 +1052,6 @@ dependencies = [
  "async-trait",
  "backoff",
  "base32",
- "base64 0.13.1",
  "byteorder",
  "candid",
  "futures-util",
@@ -1046,7 +1068,7 @@ dependencies = [
  "leb128",
  "mime",
  "mockito",
- "pem",
+ "pem 2.0.1",
  "pkcs8",
  "rand",
  "reqwest",
@@ -1138,7 +1160,7 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-utils",
- "pem",
+ "pem 1.1.1",
  "ring",
  "serde",
  "serde_json",
@@ -1240,14 +1262,16 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "once_cell",
  "sha2 0.10.6",
+ "signature",
 ]
 
 [[package]]
@@ -1594,7 +1618,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
 dependencies = [
- "group",
+ "group 0.12.1",
 ]
 
 [[package]]
@@ -1636,10 +1660,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.6.0"
+name = "pem"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+dependencies = [
+ "base64 0.21.0",
+ "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
@@ -1699,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -1915,13 +1949,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint",
  "hmac",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -2043,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
 dependencies = [
  "base16ct",
  "der",
@@ -2192,9 +2225,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest 0.10.6",
  "rand_core",
@@ -2257,9 +2290,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
 dependencies = [
  "base64ct",
  "der",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,7 +1065,6 @@ dependencies = [
  "async-trait",
  "backoff",
  "base32",
- "base64 0.21.0",
  "byteorder",
  "candid",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base32"
@@ -228,8 +228,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
 dependencies = [
  "digest 0.9.0",
- "ff",
- "group",
+ "ff 0.12.1",
+ "group 0.12.1",
  "pairing",
  "rand_core",
  "subtle",
@@ -439,9 +439,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -511,9 +511,9 @@ checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "05e58dffcdcc8ee7b22f0c1f71a69243d7c2d9ad87b5a14361f2424a1565c219"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -542,6 +542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -569,11 +570,12 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
 dependencies = [
  "der",
+ "digest 0.10.6",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -587,17 +589,16 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "75c71eaa367f2e5d556414a8eea812bc62985c879748d6403edabd9cb03f16e7"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
  "digest 0.10.6",
- "ff",
+ "ff 0.13.0",
  "generic-array",
- "group",
+ "group 0.13.0",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
@@ -659,6 +660,16 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
@@ -791,12 +802,13 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -824,7 +836,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff",
+ "ff 0.12.1",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff 0.13.0",
  "rand_core",
  "subtle",
 ]
@@ -977,12 +1000,25 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
+ "rustls 0.20.8",
+ "tokio",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
+dependencies = [
+ "http",
+ "hyper",
  "log",
- "rustls",
+ "rustls 0.21.0",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
- "webpki-roots",
+ "tokio-rustls 0.24.0",
+ "webpki-roots 0.23.0",
 ]
 
 [[package]]
@@ -1029,7 +1065,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "base32",
- "base64 0.13.1",
+ "base64 0.21.0",
  "byteorder",
  "candid",
  "futures-util",
@@ -1038,7 +1074,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.24.0",
  "ic-certification",
  "ic-verify-bls-signature",
  "js-sys",
@@ -1046,12 +1082,12 @@ dependencies = [
  "leb128",
  "mime",
  "mockito",
- "pem",
+ "pem 2.0.1",
  "pkcs8",
  "rand",
  "reqwest",
  "ring",
- "rustls",
+ "rustls 0.21.0",
  "sec1",
  "serde",
  "serde_bytes",
@@ -1138,7 +1174,7 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-utils",
- "pem",
+ "pem 1.1.1",
  "ring",
  "serde",
  "serde_json",
@@ -1240,14 +1276,16 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.11.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "once_cell",
  "sha2 0.10.6",
+ "signature",
 ]
 
 [[package]]
@@ -1594,7 +1632,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
 dependencies = [
- "group",
+ "group 0.12.1",
 ]
 
 [[package]]
@@ -1636,10 +1674,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.6.0"
+name = "pem"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+dependencies = [
+ "base64 0.21.0",
+ "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
@@ -1699,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -1884,7 +1932,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1894,14 +1942,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-util",
  "tower-service",
  "url",
@@ -1909,19 +1957,18 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint",
  "hmac",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -1972,6 +2019,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,6 +2049,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2043,9 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
 dependencies = [
  "base16ct",
  "der",
@@ -2192,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest 0.10.6",
  "rand_core",
@@ -2257,9 +2326,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
 dependencies = [
  "base64ct",
  "der",
@@ -2500,9 +2569,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
+dependencies = [
+ "rustls 0.21.0",
+ "tokio",
 ]
 
 [[package]]
@@ -2794,6 +2873,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base32"
@@ -228,8 +228,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
 dependencies = [
  "digest 0.9.0",
- "ff 0.12.1",
- "group 0.12.1",
+ "ff",
+ "group",
  "pairing",
  "rand_core",
  "subtle",
@@ -439,9 +439,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.2"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -511,9 +511,9 @@ checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "der"
-version = "0.7.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e58dffcdcc8ee7b22f0c1f71a69243d7c2d9ad87b5a14361f2424a1565c219"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -542,7 +542,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -570,12 +569,11 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.6"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der",
- "digest 0.10.6",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -589,16 +587,17 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c71eaa367f2e5d556414a8eea812bc62985c879748d6403edabd9cb03f16e7"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
+ "der",
  "digest 0.10.6",
- "ff 0.13.0",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
@@ -660,16 +659,6 @@ name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "ff"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
@@ -808,7 +797,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -836,18 +824,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff 0.12.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand_core",
  "subtle",
 ]
@@ -1000,25 +977,12 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.8",
- "tokio",
- "tokio-rustls 0.23.4",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
-dependencies = [
- "http",
- "hyper",
  "log",
- "rustls 0.21.0",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.24.0",
- "webpki-roots 0.23.0",
+ "tokio-rustls",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1065,6 +1029,7 @@ dependencies = [
  "async-trait",
  "backoff",
  "base32",
+ "base64 0.13.1",
  "byteorder",
  "candid",
  "futures-util",
@@ -1073,7 +1038,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls 0.24.0",
+ "hyper-rustls",
  "ic-certification",
  "ic-verify-bls-signature",
  "js-sys",
@@ -1081,12 +1046,12 @@ dependencies = [
  "leb128",
  "mime",
  "mockito",
- "pem 2.0.1",
+ "pem",
  "pkcs8",
  "rand",
  "reqwest",
  "ring",
- "rustls 0.21.0",
+ "rustls",
  "sec1",
  "serde",
  "serde_bytes",
@@ -1173,7 +1138,7 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-utils",
- "pem 1.1.1",
+ "pem",
  "ring",
  "serde",
  "serde_json",
@@ -1275,16 +1240,14 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
  "sha2 0.10.6",
- "signature",
 ]
 
 [[package]]
@@ -1631,7 +1594,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
 dependencies = [
- "group 0.12.1",
+ "group",
 ]
 
 [[package]]
@@ -1673,20 +1636,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
-dependencies = [
- "base64 0.21.0",
- "serde",
-]
-
-[[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
 dependencies = [
  "base64ct",
 ]
@@ -1746,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
@@ -1931,7 +1884,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls 0.23.2",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1941,14 +1894,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.8",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.23.4",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -1956,18 +1909,19 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.22.6",
+ "webpki-roots",
  "winreg",
 ]
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
+ "crypto-bigint",
  "hmac",
- "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2018,18 +1972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki",
- "sct",
-]
-
-[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,16 +1990,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -2111,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
  "der",
@@ -2260,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest 0.10.6",
  "rand_core",
@@ -2325,9 +2257,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.7.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",
@@ -2568,19 +2500,9 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls 0.20.8",
+ "rustls",
  "tokio",
  "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
-dependencies = [
- "rustls 0.21.0",
- "tokio",
 ]
 
 [[package]]
@@ -2872,15 +2794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
-dependencies = [
- "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -18,21 +18,19 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 async-trait = "0.1.53"
 backoff = "0.4.0"
 base32 = "0.4.0"
+base64 = "0.13.0"
 byteorder = "1.3.2"
 candid = { workspace = true }
 futures-util = "0.3.21"
 hex = { workspace = true }
 http = "0.2.6"
 http-body = "0.4.5"
-ic-certification = { path = "../ic-certification", version = "0.23" }
 ic-verify-bls-signature = "0.1"
-k256 = { version = "0.13.1", features = ["pem"] }
+k256 = { version = "0.11", features = ["pem"] }
 leb128 = "0.2.5"
 mime = "0.3.16"
-pkcs8 = { version = "0.10.2", features = ["std"] }
 rand = "0.8.5"
 ring = { workspace = true, features = ["std"] }
-sec1 = { version = "0.7.2", features = ["pem"] }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 serde_cbor = "0.11.2"
@@ -41,6 +39,9 @@ sha2 = { workspace = true }
 simple_asn1 = "0.6.1"
 thiserror = { workspace = true }
 url = "2.1.0"
+pkcs8 = { version = "0.9", features = ["std"] }
+sec1 = { version = "0.3", features = ["pem"] }
+ic-certification = { path = "../ic-certification", version = "0.23" }
 
 [dependencies.hyper]
 version = "0.14"
@@ -54,16 +55,16 @@ features = ["blocking", "json", "rustls-tls", "stream"]
 optional = true
 
 [dependencies.pem]
-version = "2.0.1"
+version = "1.0"
 optional = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-hyper-rustls = { version = "0.24.0", features = [
+hyper-rustls = { version = "0.23.0", features = [
     "webpki-roots",
     "http2",
 ], optional = true }
 tokio = { version = "1.24.2", features = ["time"] }
-rustls = "0.21.0"
+rustls = "0.20.4"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 backoff = { version = "0.4", features = ["wasm-bindgen"] }

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -18,19 +18,22 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 async-trait = "0.1.53"
 backoff = "0.4.0"
 base32 = "0.4.0"
-base64 = "0.13.0"
+base64 = "0.21.0"
 byteorder = "1.3.2"
 candid = { workspace = true }
 futures-util = "0.3.21"
 hex = { workspace = true }
 http = "0.2.6"
 http-body = "0.4.5"
+ic-certification = { path = "../ic-certification", version = "0.23" }
 ic-verify-bls-signature = "0.1"
-k256 = { version = "0.11", features = ["pem"] }
+k256 = { version = "0.13.1", features = ["pem"] }
 leb128 = "0.2.5"
 mime = "0.3.16"
+pkcs8 = { version = "0.10.2", features = ["std"] }
 rand = "0.8.5"
 ring = { workspace = true, features = ["std"] }
+sec1 = { version = "0.7.2", features = ["pem"] }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 serde_cbor = "0.11.2"
@@ -39,9 +42,6 @@ sha2 = { workspace = true }
 simple_asn1 = "0.6.1"
 thiserror = { workspace = true }
 url = "2.1.0"
-pkcs8 = { version = "0.9", features = ["std"] }
-sec1 = { version = "0.3", features = ["pem"] }
-ic-certification = { path = "../ic-certification", version = "0.23" }
 
 [dependencies.hyper]
 version = "0.14"
@@ -55,16 +55,16 @@ features = ["blocking", "json", "rustls-tls", "stream"]
 optional = true
 
 [dependencies.pem]
-version = "1.0"
+version = "2.0.1"
 optional = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-hyper-rustls = { version = "0.23.0", features = [
+hyper-rustls = { version = "0.24.0", features = [
     "webpki-roots",
     "http2",
 ], optional = true }
 tokio = { version = "1.24.2", features = ["time"] }
-rustls = "0.20.4"
+rustls = "0.21.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 backoff = { version = "0.4", features = ["wasm-bindgen"] }

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -18,7 +18,6 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 async-trait = "0.1.53"
 backoff = "0.4.0"
 base32 = "0.4.0"
-base64 = "0.21.0"
 byteorder = "1.3.2"
 candid = { workspace = true }
 futures-util = "0.3.21"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -18,17 +18,19 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 async-trait = "0.1.53"
 backoff = "0.4.0"
 base32 = "0.4.0"
-base64 = "0.13.0"
 byteorder = "1.3.2"
 candid = { workspace = true }
 futures-util = "0.3.21"
 hex = { workspace = true }
 http = "0.2.6"
 http-body = "0.4.5"
+ic-certification = { path = "../ic-certification", version = "0.23" }
 ic-verify-bls-signature = "0.1"
-k256 = { version = "0.11", features = ["pem"] }
+k256 = { version = "0.13.1", features = ["pem"] }
 leb128 = "0.2.5"
 mime = "0.3.16"
+pkcs8 = { version = "0.10.2", features = ["std"] }
+sec1 = { version = "0.7.2", features = ["pem"] }
 rand = "0.8.5"
 ring = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive"] }
@@ -39,9 +41,6 @@ sha2 = { workspace = true }
 simple_asn1 = "0.6.1"
 thiserror = { workspace = true }
 url = "2.1.0"
-pkcs8 = { version = "0.9", features = ["std"] }
-sec1 = { version = "0.3", features = ["pem"] }
-ic-certification = { path = "../ic-certification", version = "0.23" }
 
 [dependencies.hyper]
 version = "0.14"
@@ -55,7 +54,7 @@ features = ["blocking", "json", "rustls-tls", "stream"]
 optional = true
 
 [dependencies.pem]
-version = "1.0"
+version = "2.0.1"
 optional = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -127,6 +127,18 @@ pub enum AgentError {
     #[error("Could not read the root key")]
     CouldNotReadRootKey(),
 
+    /// The invocation to the wallet call forward method failed with an error.
+    #[error("The invocation to the wallet call forward method failed with the error: {0}")]
+    WalletCallFailed(String),
+
+    /// The wallet operation failed.
+    #[error("The  wallet operation failed: {0}")]
+    WalletError(String),
+
+    /// The wallet canister must be upgraded. See [`dfx wallet upgrade`](https://smartcontracts.org/docs/developers-guide/cli-reference/dfx-wallet.html)
+    #[error("The wallet canister must be upgraded: {0}")]
+    WalletUpgradeRequired(String),
+
     /// The transport was not specified in the [`AgentBuilder`](super::AgentBuilder).
     #[error("Missing replica transport in the Agent Builder.")]
     MissingReplicaTransport(),

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -59,10 +59,6 @@ pub enum AgentError {
     #[error("The replica returned an HTTP Error: {0}")]
     HttpError(HttpErrorPayload),
 
-    /// Attempted to use HTTP authentication in a non-secure URL (either HTTPS or localhost).
-    #[error("HTTP Authentication cannot be used in a non-secure URL (either HTTPS or localhost)")]
-    CannotUseAuthenticationOnNonSecureUrl(),
-
     /// The password manager returned an error.
     #[error("Password Manager returned an error: {0}")]
     AuthenticationError(String),

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -31,18 +31,6 @@ pub enum AgentError {
     #[error("Invalid CBOR data, could not deserialize: {0}")]
     InvalidCborData(#[from] serde_cbor::Error),
 
-    /// There was an error calculating a request ID.
-    #[error("Cannot calculate a RequestID: {0}")]
-    CannotCalculateRequestId(#[from] RequestIdError),
-
-    /// There was an error when de/serializing with Candid.
-    #[error("Candid returned an error: {0}")]
-    CandidError(Box<dyn Send + Sync + std::error::Error>),
-
-    /// There was an error parsing a URL.
-    #[error(r#"Cannot parse url: "{0}""#)]
-    UrlParseError(#[from] url::ParseError),
-
     /// The HTTP method was invalid.
     #[error(r#"Invalid method: "{0}""#)]
     InvalidMethodError(#[from] http::method::InvalidMethod),
@@ -59,10 +47,6 @@ pub enum AgentError {
     #[error("The replica returned an HTTP Error: {0}")]
     HttpError(HttpErrorPayload),
 
-    /// The password manager returned an error.
-    #[error("Password Manager returned an error: {0}")]
-    AuthenticationError(String),
-
     /// The status endpoint returned an invalid status.
     #[error("Status endpoint returned an invalid status.")]
     InvalidReplicaStatus,
@@ -75,17 +59,9 @@ pub enum AgentError {
     #[error("A tool returned a string message error: {0}")]
     MessageError(String),
 
-    /// An error occurred in an external tool.
-    #[error("A tool returned a custom error: {0}")]
-    CustomError(#[from] Box<dyn Send + Sync + std::error::Error>),
-
     /// There was an error reading a LEB128 value.
     #[error("Error reading LEB128 value: {0}")]
     Leb128ReadError(#[from] read::Error),
-
-    /// A string was invalid UTF-8.
-    #[error("Error in UTF-8 string: {0}")]
-    Utf8ReadError(#[from] Utf8Error),
 
     /// The lookup path was absent in the certificate.
     #[error("The lookup path ({0:?}) is absent in the certificate.")]
@@ -138,22 +114,6 @@ pub enum AgentError {
     /// Could not read the replica root key.
     #[error("Could not read the root key")]
     CouldNotReadRootKey(),
-
-    /// Failed to initialize the BLS library.
-    #[error("Failed to initialize the BLS library")]
-    BlsInitializationFailure(),
-
-    /// The invocation to the wallet call forward method failed with an error.
-    #[error("The invocation to the wallet call forward method failed with the error: {0}")]
-    WalletCallFailed(String),
-
-    /// The wallet operation failed.
-    #[error("The  wallet operation failed: {0}")]
-    WalletError(String),
-
-    /// The wallet canister must be upgraded. See [`dfx wallet upgrade`](https://smartcontracts.org/docs/developers-guide/cli-reference/dfx-wallet.html)
-    #[error("The wallet canister must be upgraded: {0}")]
-    WalletUpgradeRequired(String),
 
     /// The transport was not specified in the [`AgentBuilder`](super::AgentBuilder).
     #[error("Missing replica transport in the Agent Builder.")]

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -31,6 +31,14 @@ pub enum AgentError {
     #[error("Invalid CBOR data, could not deserialize: {0}")]
     InvalidCborData(#[from] serde_cbor::Error),
 
+    /// There was an error calculating a request ID.
+    #[error("Cannot calculate a RequestID: {0}")]
+    CannotCalculateRequestId(#[from] RequestIdError),
+
+    /// There was an error parsing a URL.
+    #[error(r#"Cannot parse url: "{0}""#)]
+    UrlParseError(#[from] url::ParseError),
+
     /// The HTTP method was invalid.
     #[error(r#"Invalid method: "{0}""#)]
     InvalidMethodError(#[from] http::method::InvalidMethod),
@@ -62,6 +70,10 @@ pub enum AgentError {
     /// There was an error reading a LEB128 value.
     #[error("Error reading LEB128 value: {0}")]
     Leb128ReadError(#[from] read::Error),
+
+    /// A string was invalid UTF-8.
+    #[error("Error in UTF-8 string: {0}")]
+    Utf8ReadError(#[from] Utf8Error),
 
     /// The lookup path was absent in the certificate.
     #[error("The lookup path ({0:?}) is absent in the certificate.")]

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -35,6 +35,10 @@ pub enum AgentError {
     #[error("Cannot calculate a RequestID: {0}")]
     CannotCalculateRequestId(#[from] RequestIdError),
 
+    /// There was an error when de/serializing with Candid.
+    #[error("Candid returned an error: {0}")]
+    CandidError(Box<dyn Send + Sync + std::error::Error>),
+
     /// There was an error parsing a URL.
     #[error(r#"Cannot parse url: "{0}""#)]
     UrlParseError(#[from] url::ParseError),

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -150,12 +150,6 @@ impl ReqwestTransport {
         let headers = request_result.1;
         let body = request_result.2;
 
-        // If the server returned UNAUTHORIZED, and it is the first time we replay the call,
-        // check if we can get the username/password for the HTTP Auth.
-        if status == StatusCode::UNAUTHORIZED {
-            return Err(AgentError::CannotUseAuthenticationOnNonSecureUrl());
-        }
-
         // status == OK means we have an error message for call requests
         // see https://internetcomputer.org/docs/current/references/ic-interface-spec#http-call
         if status == StatusCode::OK && endpoint.ends_with("call") {

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -144,22 +144,15 @@ impl ReqwestTransport {
 
         *http_request.body_mut() = body.map(Body::from);
 
-        let status;
-        let headers;
-        let body;
-        loop {
-            let request_result = self.request(http_request.try_clone().unwrap()).await?;
-            status = request_result.0;
-            headers = request_result.1;
-            body = request_result.2;
+        let request_result = self.request(http_request.try_clone().unwrap()).await?;
+        let status = request_result.0;
+        let headers = request_result.1;
+        let body = request_result.2;
 
-            // If the server returned UNAUTHORIZED, and it is the first time we replay the call,
-            // check if we can get the username/password for the HTTP Auth.
-            if status == StatusCode::UNAUTHORIZED {
-                return Err(AgentError::CannotUseAuthenticationOnNonSecureUrl());
-            } else {
-                break;
-            }
+        // If the server returned UNAUTHORIZED, and it is the first time we replay the call,
+        // check if we can get the username/password for the HTTP Auth.
+        if status == StatusCode::UNAUTHORIZED {
+            return Err(AgentError::CannotUseAuthenticationOnNonSecureUrl());
         }
 
         // status == OK means we have an error message for call requests

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -1,5 +1,6 @@
 //! A [`Transport`] that connects using a [`reqwest`] client.
 #![cfg(feature = "reqwest")]
+
 pub use reqwest;
 
 use futures_util::StreamExt;

--- a/ic-agent/src/identity/basic.rs
+++ b/ic-agent/src/identity/basic.rs
@@ -40,7 +40,7 @@ impl BasicIdentity {
             .collect::<Result<Vec<u8>, std::io::Error>>()?;
 
         Ok(BasicIdentity::from_key_pair(Ed25519KeyPair::from_pkcs8(
-            pem::parse(&bytes)?.contents.as_slice(),
+            pem::parse(&bytes)?.contents(),
         )?))
     }
 

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -46,8 +46,8 @@ impl Secp256k1Identity {
             if pem.tag() != EcPrivateKey::PEM_LABEL {
                 continue;
             }
-            let private_key = SecretKey::from_sec1_der(&pem.contents())
-                .map_err(|_| pkcs8::Error::KeyMalformed)?;
+            let private_key =
+                SecretKey::from_sec1_der(pem.contents()).map_err(|_| pkcs8::Error::KeyMalformed)?;
             return Ok(Self::from_private_key(private_key));
         }
         Err(pem::PemError::MissingData.into())

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -39,15 +39,15 @@ impl Secp256k1Identity {
         let contents = pem_reader.bytes().collect::<Result<Vec<u8>, io::Error>>()?;
 
         for pem in pem::parse_many(contents)? {
-            if pem.tag == EC_PARAMETERS && pem.contents != SECP256K1 {
-                return Err(PemError::UnsupportedKeyCurve(pem.contents));
+            if pem.tag() == EC_PARAMETERS && pem.contents() != SECP256K1 {
+                return Err(PemError::UnsupportedKeyCurve(pem.contents().to_vec()));
             }
 
-            if pem.tag != EcPrivateKey::PEM_LABEL {
+            if pem.tag() != EcPrivateKey::PEM_LABEL {
                 continue;
             }
-            let private_key =
-                SecretKey::from_sec1_der(&pem.contents).map_err(|_| pkcs8::Error::KeyMalformed)?;
+            let private_key = SecretKey::from_sec1_der(&pem.contents())
+                .map_err(|_| pkcs8::Error::KeyMalformed)?;
             return Ok(Self::from_private_key(private_key));
         }
         Err(pem::PemError::MissingData.into())

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -133,5 +133,4 @@ pub use identity::{Identity, Signature};
 pub use request_id::{to_request_id, RequestId, RequestIdError};
 
 // Re-export from ic_certification for backward compatibility.
-pub use ic_certification::hash_tree;
-pub use ic_certification::Certificate;
+pub use ic_certification::{hash_tree, Certificate};


### PR DESCRIPTION
# Description

The spec doesn't support any type of HTTP authentication so there is no point in the extra functionality provided the by Password manager.

In addition the MR:

- updates version so of some cargo dependencies.
- removes unused errors (the error space is already too big to be meaningfully handled programatically)

Fixes # (issue)

# How Has This Been Tested?

CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.

BREAKING CHANGE: The MR removes some of the publicly visible methods.
