### PR TITLE
fix: http_request not matching expected candid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Support WASM targets in the browser via `wasm-bindgen`
 * Do not send `certificate_version` on HTTP Update requests
+* Update `certificate_version` to `u16` instead of `u128`, fixes an issue where the asset canister always responds with v1 response verification
 
 ### icx-cert
 * Fixed issue where a missing request header caused the canister to not respond with an `ic-certificate` header.

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -48,7 +48,7 @@ struct HttpRequest<'a, H> {
     /// The request body.
     pub body: &'a [u8],
     /// The certificate version.
-    pub certificate_version: Option<&'a u128>,
+    pub certificate_version: Option<&'a u16>,
 }
 
 /// The important components of an HTTP update request.
@@ -412,7 +412,7 @@ impl<'agent> HttpRequestCanister<'agent> {
             IntoIter = impl 'agent + Send + Sync + Clone + ExactSizeIterator<Item = HeaderField<'agent>>,
         >,
         body: impl AsRef<[u8]>,
-        certificate_version: Option<&u128>,
+        certificate_version: Option<&u16>,
     ) -> impl 'agent + SyncCall<(HttpResponse,)> {
         self.http_request_custom(
             method.as_ref(),
@@ -431,7 +431,7 @@ impl<'agent> HttpRequestCanister<'agent> {
         url: &str,
         headers: H,
         body: &[u8],
-        certificate_version: Option<&u128>,
+        certificate_version: Option<&u16>,
     ) -> impl 'agent + SyncCall<(HttpResponse<T, C>,)>
     where
         H: 'agent + Send + Sync + Clone + ExactSizeIterator<Item = HeaderField<'agent>>,


### PR DESCRIPTION
# Description

Using `u128` instead of `u16` broke the request sent to the asset canister, so even if `certificate_version` was set to `2` the asset canister was always responding with version 1.

# How Has This Been Tested?

This was found by updating the e2e tests on the response verification side to assert that the correct version of response verification is used. The assertion failed for v2 tests because the version was always 1. With this change all tests are passing.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
