### PR TITLE
fix: put wasm-bindgen build target behind a feature.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [ '1.65.0' ]
-        os: [ ubuntu-latest ]
+        rust: ["1.65.0"]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
       - name: Run Lint (WASM)
-        run: CARGO_TARGET_DIR=target/wasm cargo clippy --target wasm32-unknown-unknown -p ic-agent -p ic-utils --verbose -- -D clippy::all
+        run: CARGO_TARGET_DIR=target/wasm cargo clippy --target wasm32-unknown-unknown -p ic-agent --features wasm-bindgen -p ic-utils --verbose -- -D clippy::all
   aggregate:
     name: lint:required
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [ '1.65.0' ]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        rust: ["1.65.0"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
           rustup update ${{ matrix.rust }} --no-self-update
           rustup default ${{ matrix.rust }}
           rustup target add wasm32-unknown-unknown
-      
+
       - name: Install wasm-pack
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
@@ -48,11 +48,11 @@ jobs:
           done
         env:
           RUST_BACKTRACE: 1
-      
+
       - name: Run Tests (WASM)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          CARGO_TARGET_DIR=../target/wasm wasm-pack test --chrome --headless ic-agent
+          CARGO_TARGET_DIR=../target/wasm wasm-pack test --chrome --headless ic-agent --features wasm-bindgen
 
       - name: Purge for OSX
         if: matrix.os == 'macos-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Handling rejected update calls where status code is 200. See IC-1462
 * Reject code type is changed from `u64` to enum `RejectCode`.
 
-* Support WASM targets in the browser via `wasm-bindgen`
+* Support WASM targets in the browser via `wasm-bindgen`. Feature `wasm-bindgen` required.
 * Do not send `certificate_version` on HTTP Update requests
 * Update `certificate_version` to `u16` instead of `u128`, fixes an issue where the asset canister always responds with v1 response verification
 

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -66,7 +66,6 @@ tokio = { version = "1.24.2", features = ["time"] }
 rustls = "0.20.4"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-backoff = { version = "0.4", features = ["wasm-bindgen"] }
 getrandom = { version = "0.2", features = ["js"], optional = true }
 js-sys = { version = "0.3", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -67,12 +67,12 @@ rustls = "0.20.4"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 backoff = { version = "0.4", features = ["wasm-bindgen"] }
-getrandom = { version = "0.2", features = ["js"] }
-js-sys = "0.3"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3", features = ["Window"] }
-time = { version = "0.3", features = ["wasm-bindgen"] }
+getrandom = { version = "0.2", features = ["js"], optional = true }
+js-sys = { version = "0.3", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+web-sys = { version = "0.3", features = ["Window"], optional = true }
+time = { version = "0.3", features = ["wasm-bindgen"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.79"
@@ -98,6 +98,15 @@ hyper = ["dep:hyper", "dep:hyper-rustls"]
 ic_ref_tests = [
     "default",
 ] # Used to separate integration tests for ic-ref which need a server running.
+wasm-bindgen = [
+    "dep:js-sys",
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:getrandom",
+    "dep:web-sys",
+    "dep:time",
+    "backoff/wasm-bindgen",
+]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -13,10 +13,10 @@ use crate::{
 };
 use ic_certification::Label;
 use std::collections::BTreeMap;
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
 use wasm_bindgen_test::wasm_bindgen_test;
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[cfg_attr(not(target_family = "wasm"), tokio::test)]
@@ -548,7 +548,7 @@ mod mock {
     }
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
 mod mock {
     use js_sys::*;
     use reqwest::Client;

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -55,7 +55,7 @@ impl ReqwestTransport {
     }
 
     /// Creates a replica transport from a HTTP URL.
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
     pub fn create<U: Into<String>>(url: U) -> Result<Self, AgentError> {
         Self::create_with_client(url, Client::new())
     }
@@ -217,9 +217,9 @@ impl Transport for ReqwestTransport {
 
 #[cfg(test)]
 mod test {
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
     use wasm_bindgen_test::wasm_bindgen_test;
-    #[cfg(target_family = "wasm")]
+    #[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     use super::ReqwestTransport;

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -56,7 +56,7 @@ const IC_ROOT_KEY: &[u8; 133] = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x
 #[cfg(not(target_family = "wasm"))]
 type AgentFuture<'a, V> = Pin<Box<dyn Future<Output = Result<V, AgentError>> + Send + 'a>>;
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
 type AgentFuture<'a, V> = Pin<Box<dyn Future<Output = Result<V, AgentError>> + 'a>>;
 
 /// A facade that connects to a Replica and does requests. These requests can be of any type
@@ -346,7 +346,7 @@ impl Agent {
                         .duration_since(std::time::UNIX_EPOCH)
                         .expect("Time wrapped around.")
                 }
-                #[cfg(target_family = "wasm")]
+                #[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
                 {
                     Duration::from_nanos((js_sys::Date::now() * 1_000_000.) as _)
                 }
@@ -573,7 +573,7 @@ impl Agent {
             match retry_policy.next_backoff() {
                 #[cfg(not(target_family = "wasm"))]
                 Some(duration) => tokio::time::sleep(duration).await,
-                #[cfg(target_family = "wasm")]
+                #[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
                 Some(duration) => {
                     wasm_bindgen_futures::JsFuture::from(js_sys::Promise::new(&mut |rs, rj| {
                         if let Err(e) = web_sys::window()

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -56,7 +56,7 @@ const IC_ROOT_KEY: &[u8; 133] = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x
 #[cfg(not(target_family = "wasm"))]
 type AgentFuture<'a, V> = Pin<Box<dyn Future<Output = Result<V, AgentError>> + Send + 'a>>;
 
-#[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
+#[cfg(target_family = "wasm")]
 type AgentFuture<'a, V> = Pin<Box<dyn Future<Output = Result<V, AgentError>> + 'a>>;
 
 /// A facade that connects to a Replica and does requests. These requests can be of any type


### PR DESCRIPTION
# Description
It is necessary to put the `wasm-bindgen` build target behind a feature in order to use it in the [ic repo](https://github.com/dfinity/ic). Due to bazel and cargo's feature unification, some transitive dependencies such as `getrandom`, `backoff`, and `time` crates were unified which were breaking our builds in the main IC-repo, making it impossible to use the current state of `ic-agent`.

As a consequence, we also have to update the GitHub workflows to include `--features wasm-bindgen`.

Fixes # (issue)

# How Has This Been Tested?
`cargo test`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
