### PR TITLE
refactor: Remove the lifetimes from `ic-certification`

### DIFF
--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -446,7 +446,7 @@ async fn check_subnet_range_with_valid_range() {
     let _result = agent
         .read_state_raw(
             vec![REQ_WITH_DELEGATED_CERT_PATH
-                .iter()
+                .into_iter()
                 .map(Label::from)
                 .collect()],
             Principal::from_text(REQ_WITH_DELEGATED_CERT_CANISTER).unwrap(),
@@ -478,7 +478,7 @@ async fn check_subnet_range_with_unauthorized_range() {
     let result = agent
         .read_state_raw(
             vec![REQ_WITH_DELEGATED_CERT_PATH
-                .iter()
+                .into_iter()
                 .map(Label::from)
                 .collect()],
             wrong_canister,
@@ -509,7 +509,7 @@ async fn check_subnet_range_with_pruned_range() {
     let result = agent
         .read_state_raw(
             vec![REQ_WITH_DELEGATED_CERT_PATH
-                .iter()
+                .into_iter()
                 .map(Label::from)
                 .collect()],
             canister,

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -600,7 +600,7 @@ impl Agent {
         &self,
         paths: Vec<Vec<Label>>,
         effective_canister_id: Principal,
-    ) -> Result<Certificate<'_>, AgentError> {
+    ) -> Result<Certificate, AgentError> {
         let request = self.read_state_content(paths)?;
         let serialized_bytes = sign_request(&request, self.identity.clone())?;
 
@@ -654,9 +654,9 @@ impl Agent {
                     .map_err(AgentError::InvalidCborData)?;
                 self.verify(&cert, effective_canister_id)?;
                 let canister_range_lookup = [
-                    "subnet".into(),
-                    delegation.subnet_id.clone().into(),
-                    "canister_ranges".into(),
+                    "subnet".as_bytes(),
+                    delegation.subnet_id.as_ref(),
+                    "canister_ranges".as_bytes(),
                 ];
                 let canister_range = lookup_value(&cert, canister_range_lookup)?;
                 let ranges: Vec<(Principal, Principal)> =
@@ -667,9 +667,9 @@ impl Agent {
                 }
 
                 let public_key_path = [
-                    "subnet".into(),
-                    delegation.subnet_id.clone().into(),
-                    "public_key".into(),
+                    "subnet".as_bytes(),
+                    delegation.subnet_id.as_ref(),
+                    "public_key".as_bytes(),
                 ];
                 lookup_value(&cert, public_key_path).map(|pk| pk.to_vec())
             }
@@ -682,7 +682,11 @@ impl Agent {
         canister_id: Principal,
         path: &str,
     ) -> Result<Vec<u8>, AgentError> {
-        let paths: Vec<Vec<Label>> = vec![vec!["canister".into(), canister_id.into(), path.into()]];
+        let paths: Vec<Vec<Label>> = vec![vec![
+            "canister".into(),
+            Label::from_bytes(canister_id.as_slice()),
+            path.into(),
+        ]];
 
         let cert = self.read_state_raw(paths, canister_id).await?;
 
@@ -697,7 +701,7 @@ impl Agent {
     ) -> Result<Vec<u8>, AgentError> {
         let paths: Vec<Vec<Label>> = vec![vec![
             "canister".into(),
-            canister_id.into(),
+            Label::from_bytes(canister_id.as_slice()),
             "metadata".into(),
             path.into(),
         ]];

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -1,6 +1,6 @@
 use crate::agent::{RejectCode, RejectResponse, Replied, RequestStatusResponse};
 use crate::{export::Principal, AgentError, RequestId};
-use ic_certification::{Certificate, Label, LookupResult};
+use ic_certification::{certificate::Certificate, hash_tree::Label, LookupResult};
 use std::str::from_utf8;
 
 const DER_PREFIX: &[u8; 37] = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x01\x02\x01\x06\x0c\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x02\x01\x03\x61\x00";
@@ -27,31 +27,36 @@ pub fn extract_der(buf: Vec<u8>) -> Result<Vec<u8>, AgentError> {
     Ok(key.to_vec())
 }
 
-pub(crate) fn lookup_canister_info(
-    certificate: Certificate,
-    canister_id: Principal,
-    path: &str,
-) -> Result<Vec<u8>, AgentError> {
-    let path_canister = ["canister".into(), canister_id.into(), path.into()];
-    lookup_value(&certificate, path_canister).map(<[u8]>::to_vec)
-}
-
-pub(crate) fn lookup_canister_metadata(
-    certificate: Certificate,
+pub(crate) fn lookup_canister_info<Storage: AsRef<[u8]>>(
+    certificate: Certificate<Storage>,
     canister_id: Principal,
     path: &str,
 ) -> Result<Vec<u8>, AgentError> {
     let path_canister = [
-        "canister".into(),
-        canister_id.into(),
-        "metadata".into(),
-        path.into(),
+        "canister".as_bytes(),
+        canister_id.as_slice(),
+        path.as_bytes(),
     ];
     lookup_value(&certificate, path_canister).map(<[u8]>::to_vec)
 }
 
-pub(crate) fn lookup_request_status(
-    certificate: Certificate,
+pub(crate) fn lookup_canister_metadata<Storage: AsRef<[u8]>>(
+    certificate: Certificate<Storage>,
+    canister_id: Principal,
+    path: &str,
+) -> Result<Vec<u8>, AgentError> {
+    let path_canister = [
+        "canister".as_bytes(),
+        canister_id.as_slice(),
+        "metadata".as_bytes(),
+        path.as_bytes(),
+    ];
+
+    lookup_value(&certificate, path_canister).map(<[u8]>::to_vec)
+}
+
+pub(crate) fn lookup_request_status<Storage: AsRef<[u8]>>(
+    certificate: Certificate<Storage>,
     request_id: &RequestId,
 ) -> Result<RequestStatusResponse, AgentError> {
     use AgentError::*;
@@ -75,8 +80,8 @@ pub(crate) fn lookup_request_status(
     }
 }
 
-pub(crate) fn lookup_rejection(
-    certificate: &Certificate,
+pub(crate) fn lookup_rejection<Storage: AsRef<[u8]>>(
+    certificate: &Certificate<Storage>,
     request_id: &RequestId,
 ) -> Result<RequestStatusResponse, AgentError> {
     let reject_code = lookup_reject_code(certificate, request_id)?;
@@ -89,14 +94,14 @@ pub(crate) fn lookup_rejection(
     }))
 }
 
-pub(crate) fn lookup_reject_code(
-    certificate: &Certificate,
+pub(crate) fn lookup_reject_code<Storage: AsRef<[u8]>>(
+    certificate: &Certificate<Storage>,
     request_id: &RequestId,
 ) -> Result<RejectCode, AgentError> {
     let path = [
-        "request_status".into(),
-        request_id.to_vec().into(),
-        "reject_code".into(),
+        "request_status".as_bytes(),
+        request_id.as_slice(),
+        "reject_code".as_bytes(),
     ];
     let code = lookup_value(certificate, path)?;
     let mut readable = code;
@@ -104,49 +109,152 @@ pub(crate) fn lookup_reject_code(
     RejectCode::try_from(code_digit)
 }
 
-pub(crate) fn lookup_reject_message(
-    certificate: &Certificate,
+pub(crate) fn lookup_reject_message<Storage: AsRef<[u8]>>(
+    certificate: &Certificate<Storage>,
     request_id: &RequestId,
 ) -> Result<String, AgentError> {
     let path = [
-        "request_status".into(),
-        request_id.to_vec().into(),
-        "reject_message".into(),
+        "request_status".as_bytes(),
+        request_id.as_slice(),
+        "reject_message".as_bytes(),
     ];
     let msg = lookup_value(certificate, path)?;
     Ok(from_utf8(msg)?.to_string())
 }
 
-pub(crate) fn lookup_reply(
-    certificate: &Certificate,
+pub(crate) fn lookup_reply<Storage: AsRef<[u8]>>(
+    certificate: &Certificate<Storage>,
     request_id: &RequestId,
 ) -> Result<RequestStatusResponse, AgentError> {
     let path = [
-        "request_status".into(),
-        request_id.to_vec().into(),
-        "reply".into(),
+        "request_status".as_bytes(),
+        request_id.as_slice(),
+        "reply".as_bytes(),
     ];
     let reply_data = lookup_value(certificate, path)?;
     let reply = Replied::CallReplied(Vec::from(reply_data));
     Ok(RequestStatusResponse::Replied { reply })
 }
 
+/// The path to [`lookup_value`]
+pub trait LookupPath {
+    type Item<'a>: AsRef<[u8]>
+    where
+        Self: 'a;
+    type Iter<'a>: Iterator<Item = Self::Item<'a>>
+    where
+        Self: 'a;
+    fn iter(&self) -> Self::Iter<'_>;
+    fn into_vec(self) -> Vec<Label<Vec<u8>>>;
+}
+
+impl<'b, const N: usize> LookupPath for [&'b [u8]; N] {
+    type Item<'a> = &'a &'b [u8] where Self: 'a;
+    type Iter<'a> = std::slice::Iter<'a, &'b [u8]> where Self: 'a;
+    fn iter(&self) -> Self::Iter<'_> {
+        self.as_slice().iter()
+    }
+    fn into_vec(self) -> Vec<Label<Vec<u8>>> {
+        self.map(Label::from_bytes).into()
+    }
+}
+impl<'b, 'c> LookupPath for &'c [&'b [u8]] {
+    type Item<'a> = &'a &'b [u8] where Self: 'a;
+    type Iter<'a> = std::slice::Iter<'a, &'b [u8]> where Self: 'a;
+    fn iter(&self) -> Self::Iter<'_> {
+        <[_]>::iter(self)
+    }
+    fn into_vec(self) -> Vec<Label<Vec<u8>>> {
+        self.iter().map(|v| Label::from_bytes(v)).collect()
+    }
+}
+impl<'b> LookupPath for Vec<&'b [u8]> {
+    type Item<'a> = &'a &'b [u8] where Self: 'a;
+    type Iter<'a> = std::slice::Iter<'a, &'b [u8]> where Self: 'a;
+    fn iter(&self) -> Self::Iter<'_> {
+        <[_]>::iter(self.as_slice())
+    }
+    fn into_vec(self) -> Vec<Label<Vec<u8>>> {
+        self.into_iter().map(Label::from_bytes).collect()
+    }
+}
+
+impl<const N: usize> LookupPath for [Vec<u8>; N] {
+    type Item<'a> = &'a Vec<u8> where Self: 'a;
+    type Iter<'a> = std::slice::Iter<'a, Vec<u8>> where Self: 'a;
+    fn iter(&self) -> Self::Iter<'_> {
+        self.as_slice().iter()
+    }
+    fn into_vec(self) -> Vec<Label<Vec<u8>>> {
+        self.map(Label::from).into()
+    }
+}
+impl<'c> LookupPath for &'c [Vec<u8>] {
+    type Item<'a> = &'a Vec<u8> where Self: 'a;
+    type Iter<'a> = std::slice::Iter<'a, Vec<u8>> where Self: 'a;
+    fn iter(&self) -> Self::Iter<'_> {
+        <[_]>::iter(self)
+    }
+    fn into_vec(self) -> Vec<Label<Vec<u8>>> {
+        self.iter().map(|v| Label::from(v.clone())).collect()
+    }
+}
+impl LookupPath for Vec<Vec<u8>> {
+    type Item<'a> = &'a Vec<u8> where Self: 'a;
+    type Iter<'a> = std::slice::Iter<'a, Vec<u8>> where Self: 'a;
+    fn iter(&self) -> Self::Iter<'_> {
+        <[_]>::iter(self.as_slice())
+    }
+    fn into_vec(self) -> Vec<Label<Vec<u8>>> {
+        self.into_iter().map(Label::from).collect()
+    }
+}
+
+impl<Storage: AsRef<[u8]> + Into<Vec<u8>>, const N: usize> LookupPath for [Label<Storage>; N] {
+    type Item<'a> = &'a Label<Storage> where Self: 'a;
+    type Iter<'a> = std::slice::Iter<'a, Label<Storage>> where Self: 'a;
+    fn iter(&self) -> Self::Iter<'_> {
+        self.as_slice().iter()
+    }
+    fn into_vec(self) -> Vec<Label<Vec<u8>>> {
+        self.map(Label::from_label).into()
+    }
+}
+impl<'c, Storage: AsRef<[u8]> + Into<Vec<u8>>> LookupPath for &'c [Label<Storage>] {
+    type Item<'a> = &'a Label<Storage> where Self: 'a;
+    type Iter<'a> = std::slice::Iter<'a, Label<Storage>> where Self: 'a;
+    fn iter(&self) -> Self::Iter<'_> {
+        <[_]>::iter(self)
+    }
+    fn into_vec(self) -> Vec<Label<Vec<u8>>> {
+        self.iter()
+            .map(|v| Label::from_bytes(v.as_bytes()))
+            .collect()
+    }
+}
+impl LookupPath for Vec<Label<Vec<u8>>> {
+    type Item<'a> = &'a Label<Vec<u8>> where Self: 'a;
+    type Iter<'a> = std::slice::Iter<'a, Label<Vec<u8>>> where Self: 'a;
+    fn iter(&self) -> Self::Iter<'_> {
+        <[_]>::iter(self.as_slice())
+    }
+    fn into_vec(self) -> Vec<Label<Vec<u8>>> {
+        self
+    }
+}
+
 /// Looks up a value in the certificate's tree at the specified hash.
 ///
 /// Returns the value if it was found; otherwise, errors with `LookupPathAbsent`, `LookupPathUnknown`, or `LookupPathError`.
-pub fn lookup_value<'a, P>(
-    certificate: &'a Certificate<'a>,
+pub fn lookup_value<P: LookupPath, Storage: AsRef<[u8]>>(
+    certificate: &Certificate<Storage>,
     path: P,
-) -> Result<&'a [u8], AgentError>
-where
-    for<'p> &'p P: IntoIterator<Item = &'p Label>,
-    P: Into<Vec<Label>>,
-{
+) -> Result<&[u8], AgentError> {
     use AgentError::*;
-    match certificate.tree.lookup_path(&path) {
-        LookupResult::Absent => Err(LookupPathAbsent(path.into())),
-        LookupResult::Unknown => Err(LookupPathUnknown(path.into())),
+    match certificate.tree.lookup_path(path.iter()) {
+        LookupResult::Absent => Err(LookupPathAbsent(path.into_vec())),
+        LookupResult::Unknown => Err(LookupPathUnknown(path.into_vec())),
         LookupResult::Found(value) => Ok(value),
-        LookupResult::Error => Err(LookupPathError(path.into())),
+        LookupResult::Error => Err(LookupPathError(path.into_vec())),
     }
 }

--- a/ic-certification/src/certificate.rs
+++ b/ic-certification/src/certificate.rs
@@ -1,30 +1,273 @@
-use crate::HashTree;
+use crate::hash_tree::HashTree;
 
 /// A `Certificate` as defined in <https://internetcomputer.org/docs/current/references/ic-interface-spec/#certificate>
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Certificate<'a> {
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(serialize = "Storage: serde_bytes::Serialize"))
+)]
+pub struct Certificate<Storage: AsRef<[u8]>> {
     /// The hash tree.
-    pub tree: HashTree<'a>,
+    pub tree: HashTree<Storage>,
 
     /// The signature of the root hash in `tree`.
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    pub signature: Vec<u8>,
+    pub signature: Storage,
 
     /// A delegation from the root key to the key used to sign `signature`, if one exists.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub delegation: Option<Delegation>,
+    pub delegation: Option<Delegation<Storage>>,
 }
 
 /// A `Delegation` as defined in <https://internetcomputer.org/docs/current/references/ic-interface-spec/#certification-delegation>
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Delegation {
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(serialize = "Storage: serde_bytes::Serialize"))
+)]
+pub struct Delegation<Storage: AsRef<[u8]>> {
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    pub subnet_id: Vec<u8>,
+    pub subnet_id: Storage,
 
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
-    pub certificate: Vec<u8>,
+    pub certificate: Storage,
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::{Certificate, Delegation};
+    use crate::{hash_tree::HashTreeNode, serde_impl::*};
+
+    use std::{borrow::Cow, fmt, marker::PhantomData};
+
+    use serde::{
+        de::{self, MapAccess, SeqAccess, Visitor},
+        Deserialize, Deserializer,
+    };
+
+    #[derive(Deserialize)]
+    #[serde(field_identifier, rename_all = "snake_case")]
+    enum CertificateField {
+        Tree,
+        Signature,
+        Delegation,
+    }
+    struct CertificateVisitor<S>(PhantomData<S>);
+
+    impl<'de, S: Storage> Visitor<'de> for CertificateVisitor<S>
+    where
+        Delegation<S::Value<'de>>: Deserialize<'de>,
+        HashTreeNode<S::Value<'de>>: Deserialize<'de>,
+    {
+        type Value = Certificate<S::Value<'de>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("struct Delegation")
+        }
+
+        fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+        where
+            V: SeqAccess<'de>,
+        {
+            let tree = seq
+                .next_element()?
+                .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+            let signature = S::convert(
+                seq.next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?,
+            );
+            let delegation = seq.next_element()?;
+
+            Ok(Certificate {
+                tree,
+                signature,
+                delegation,
+            })
+        }
+
+        fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+        where
+            V: MapAccess<'de>,
+        {
+            let mut tree = None;
+            let mut signature = None;
+            let mut delegation = None;
+            while let Some(key) = map.next_key()? {
+                match key {
+                    CertificateField::Tree => {
+                        if tree.is_some() {
+                            return Err(de::Error::duplicate_field("tree"));
+                        }
+                        tree = Some(map.next_value()?);
+                    }
+                    CertificateField::Signature => {
+                        if signature.is_some() {
+                            return Err(de::Error::duplicate_field("signature"));
+                        }
+                        signature = Some(map.next_value()?);
+                    }
+                    CertificateField::Delegation => {
+                        if delegation.is_some() {
+                            return Err(de::Error::duplicate_field("signature"));
+                        }
+                        delegation = Some(map.next_value()?);
+                    }
+                }
+            }
+            let tree = tree.ok_or_else(|| de::Error::missing_field("tree"))?;
+            let signature =
+                S::convert(signature.ok_or_else(|| de::Error::missing_field("signature"))?);
+            Ok(Certificate {
+                tree,
+                signature,
+                delegation,
+            })
+        }
+    }
+
+    fn deserialize_certificate<'de, S: Storage, D>(
+        deserializer: D,
+    ) -> Result<Certificate<S::Value<'de>>, D::Error>
+    where
+        Delegation<S::Value<'de>>: Deserialize<'de>,
+        HashTreeNode<S::Value<'de>>: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["tree", "signature", "delegation"];
+        deserializer.deserialize_struct("Certificate", FIELDS, CertificateVisitor::<S>(PhantomData))
+    }
+
+    impl<'de> Deserialize<'de> for Certificate<Vec<u8>> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_certificate::<VecStorage, _>(deserializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Certificate<&'de [u8]> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_certificate::<SliceStorage, _>(deserializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Certificate<Cow<'de, [u8]>> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_certificate::<CowStorage, _>(deserializer)
+        }
+    }
+
+    #[derive(Deserialize)]
+    #[serde(field_identifier, rename_all = "snake_case")]
+    enum DelegationField {
+        SubnetId,
+        Certificate,
+    }
+    struct DelegationVisitor<S>(PhantomData<S>);
+
+    impl<'de, S: Storage> Visitor<'de> for DelegationVisitor<S> {
+        type Value = Delegation<S::Value<'de>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("struct Delegation")
+        }
+
+        fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+        where
+            V: SeqAccess<'de>,
+        {
+            let subnet_id = S::convert(
+                seq.next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?,
+            );
+            let certificate = S::convert(
+                seq.next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?,
+            );
+            Ok(Delegation {
+                subnet_id,
+                certificate,
+            })
+        }
+
+        fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+        where
+            V: MapAccess<'de>,
+        {
+            let mut subnet_id = None;
+            let mut certificate = None;
+            while let Some(key) = map.next_key()? {
+                match key {
+                    DelegationField::SubnetId => {
+                        if subnet_id.is_some() {
+                            return Err(de::Error::duplicate_field("subnet_id"));
+                        }
+                        subnet_id = Some(map.next_value()?);
+                    }
+                    DelegationField::Certificate => {
+                        if certificate.is_some() {
+                            return Err(de::Error::duplicate_field("certificate"));
+                        }
+                        certificate = Some(map.next_value()?);
+                    }
+                }
+            }
+            let subnet_id =
+                S::convert(subnet_id.ok_or_else(|| de::Error::missing_field("subnet_id"))?);
+            let certificate =
+                S::convert(certificate.ok_or_else(|| de::Error::missing_field("certificate"))?);
+            Ok(Delegation {
+                subnet_id,
+                certificate,
+            })
+        }
+    }
+
+    fn deserialize_delegation<'de, S: Storage, D>(
+        deserializer: D,
+    ) -> Result<Delegation<S::Value<'de>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &["subnet_id", "certificate"];
+        deserializer.deserialize_struct("Delegation", FIELDS, DelegationVisitor::<S>(PhantomData))
+    }
+
+    impl<'de> Deserialize<'de> for Delegation<Vec<u8>> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_delegation::<VecStorage, _>(deserializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Delegation<&'de [u8]> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_delegation::<SliceStorage, _>(deserializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Delegation<Cow<'de, [u8]>> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_delegation::<CowStorage, _>(deserializer)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -33,19 +276,19 @@ mod tests {
     use super::*;
     use crate::hash_tree::{empty, fork, label, leaf};
 
-    fn create_tree<'a>() -> HashTree<'a> {
+    fn create_tree<'a>() -> HashTree<Vec<u8>> {
         fork(
             fork(
                 label(
                     "a",
                     fork(
-                        fork(label("x", leaf(b"hello")), empty()),
-                        label("y", leaf(b"world")),
+                        fork(label("x", leaf(*b"hello")), empty()),
+                        label("y", leaf(*b"world")),
                     ),
                 ),
-                label("b", leaf(b"good")),
+                label("b", leaf(*b"good")),
             ),
-            fork(label("c", empty()), label("d", leaf(b"morning"))),
+            fork(label("c", empty()), label("d", leaf(*b"morning"))),
         )
     }
 

--- a/ic-certification/src/hash_tree/tests.rs
+++ b/ic-certification/src/hash_tree/tests.rs
@@ -1,28 +1,26 @@
 #![cfg(test)]
 
 use crate::hash_tree::{
-    empty, fork, label, leaf, pruned, pruned_from_hex, HashTree, Label, LookupResult,
-    SubtreeLookupResult,
+    empty, fork, label, leaf, pruned, pruned_from_hex, HashTree, LookupResult, SubtreeLookupResult,
 };
 
-fn lookup_path<'a, P: AsRef<[&'static str]>>(tree: &'a HashTree<'a>, path: P) -> LookupResult<'a> {
-    let path: Vec<Label> = path.as_ref().iter().map(|l| l.into()).collect();
-
-    tree.lookup_path(&path)
+fn lookup_path<'a, P: AsRef<[&'static str]>>(
+    tree: &'a HashTree<Vec<u8>>,
+    path: P,
+) -> LookupResult<'a> {
+    tree.lookup_path(path.as_ref().iter().map(|s| s.as_bytes()))
 }
 
 fn lookup_subtree<'a, P: AsRef<[&'static str]>>(
-    tree: &'a HashTree<'a>,
+    tree: &'a HashTree<Vec<u8>>,
     path: P,
-) -> SubtreeLookupResult<'a> {
-    let path: Vec<Label> = path.as_ref().iter().map(|l| l.into()).collect();
-
-    tree.lookup_subtree(&path)
+) -> SubtreeLookupResult<Vec<u8>> {
+    tree.lookup_subtree(path.as_ref().iter().map(|s| s.as_bytes()))
 }
 
 #[test]
 fn works_with_simple_tree() {
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         label("label 1", empty()),
         fork(
             pruned(*b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"),
@@ -39,18 +37,18 @@ fn works_with_simple_tree() {
 #[test]
 fn spec_example() {
     // This is the example straight from the spec.
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         fork(
             label(
                 "a",
                 fork(
-                    fork(label("x", leaf(b"hello")), empty()),
-                    label("y", leaf(b"world")),
+                    fork(label("x", leaf(*b"hello")), empty()),
+                    label("y", leaf(*b"world")),
                 ),
             ),
-            label("b", leaf(b"good")),
+            label("b", leaf(*b"good")),
         ),
-        fork(label("c", empty()), label("d", leaf(b"morning"))),
+        fork(label("c", empty()), label("d", leaf(*b"morning"))),
     );
 
     // Check CBOR serialization.
@@ -69,7 +67,7 @@ fn spec_example() {
 #[test]
 fn spec_example_pruned() {
     // This is the example straight from the spec.
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         fork(
             label(
                 "a",
@@ -78,7 +76,7 @@ fn spec_example_pruned() {
                         "1b4feff9bef8131788b0c9dc6dbad6e81e524249c879e9f10f71ce3749f5a638",
                     )
                     .unwrap(),
-                    label("y", leaf(b"world")),
+                    label("y", leaf(*b"world")),
                 ),
             ),
             label(
@@ -90,7 +88,7 @@ fn spec_example_pruned() {
         fork(
             pruned_from_hex("ec8324b8a1f1ac16bd2e806edba78006479c9877fed4eb464a25485465af601d")
                 .unwrap(),
-            label("d", leaf(b"morning")),
+            label("d", leaf(*b"morning")),
         ),
     );
 
@@ -114,7 +112,7 @@ fn spec_example_pruned() {
 
 #[test]
 fn can_lookup_paths_1() {
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         label("label 1", empty()),
         fork(
             pruned([1; 32]),
@@ -125,21 +123,21 @@ fn can_lookup_paths_1() {
         ),
     );
 
-    assert_eq!(tree.lookup_path(&["label 0".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 1".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path([b"label 0"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 1"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Unknown);
     assert_eq!(
-        tree.lookup_path(&["label 3".into()]),
+        tree.lookup_path([b"label 3"]),
         LookupResult::Found(&[1, 2, 3, 4, 5, 6])
     );
-    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Absent);
 }
 
 #[test]
 fn can_lookup_paths_2() {
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         label("label 1", empty()),
         fork(
             fork(
@@ -150,21 +148,21 @@ fn can_lookup_paths_2() {
         ),
     );
 
-    assert_eq!(tree.lookup_path(&["label 0".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 1".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 0"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 1"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Absent);
     assert_eq!(
-        tree.lookup_path(&["label 3".into()]),
+        tree.lookup_path([b"label 3"]),
         LookupResult::Found(&[1, 2, 3, 4, 5, 6])
     );
-    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Unknown);
 }
 
 #[test]
 fn can_lookup_paths_3() {
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         pruned([0; 32]),
         fork(
             pruned([1; 32]),
@@ -175,19 +173,19 @@ fn can_lookup_paths_3() {
         ),
     );
 
-    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Unknown);
     assert_eq!(
-        tree.lookup_path(&["label 3".into()]),
+        tree.lookup_path([b"label 3"]),
         LookupResult::Found(&[1, 2, 3, 4, 5, 6])
     );
-    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Absent);
 }
 
 #[test]
 fn can_lookup_paths_4() {
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         pruned([0; 32]),
         fork(
             fork(
@@ -198,19 +196,19 @@ fn can_lookup_paths_4() {
         ),
     );
 
-    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Unknown);
     assert_eq!(
-        tree.lookup_path(&["label 3".into()]),
+        tree.lookup_path([b"label 3"]),
         LookupResult::Found(&[1, 2, 3, 4, 5, 6])
     );
-    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Unknown);
 }
 
 #[test]
 fn can_lookup_paths_5() {
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         fork(
             pruned([1; 32]),
             fork(
@@ -221,21 +219,21 @@ fn can_lookup_paths_5() {
         label("label 7", empty()),
     );
 
-    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Unknown);
     assert_eq!(
-        tree.lookup_path(&["label 3".into()]),
+        tree.lookup_path([b"label 3"]),
         LookupResult::Found(&[1, 2, 3, 4, 5, 6])
     );
-    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 7".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 8".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 7"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 8"]), LookupResult::Absent);
 }
 
 #[test]
 fn can_lookup_paths_6() {
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         fork(
             fork(
                 label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
@@ -246,21 +244,21 @@ fn can_lookup_paths_6() {
         label("label 7", empty()),
     );
 
-    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Absent);
     assert_eq!(
-        tree.lookup_path(&["label 3".into()]),
+        tree.lookup_path([b"label 3"]),
         LookupResult::Found(&[1, 2, 3, 4, 5, 6])
     );
-    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Unknown);
-    assert_eq!(tree.lookup_path(&["label 7".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 8".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path([b"label 7"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 8"]), LookupResult::Absent);
 }
 
 #[test]
 fn can_lookup_paths_7() {
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         fork(
             pruned([1; 32]),
             fork(
@@ -271,19 +269,19 @@ fn can_lookup_paths_7() {
         pruned([0; 32]),
     );
 
-    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Unknown);
     assert_eq!(
-        tree.lookup_path(&["label 3".into()]),
+        tree.lookup_path([b"label 3"]),
         LookupResult::Found(&[1, 2, 3, 4, 5, 6])
     );
-    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Unknown);
 }
 
 #[test]
 fn can_lookup_paths_8() {
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         fork(
             fork(
                 label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
@@ -294,21 +292,21 @@ fn can_lookup_paths_8() {
         pruned([0; 32]),
     );
 
-    assert_eq!(tree.lookup_path(&["label 2".into()]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 2"]), LookupResult::Absent);
     assert_eq!(
-        tree.lookup_path(&["label 3".into()]),
+        tree.lookup_path([b"label 3"]),
         LookupResult::Found(&[1, 2, 3, 4, 5, 6])
     );
-    assert_eq!(tree.lookup_path(&["label 4".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 5".into()]), LookupResult::Absent);
-    assert_eq!(tree.lookup_path(&["label 6".into()]), LookupResult::Unknown);
+    assert_eq!(tree.lookup_path([b"label 4"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 5"]), LookupResult::Absent);
+    assert_eq!(tree.lookup_path([b"label 6"]), LookupResult::Unknown);
 }
 
 #[test]
 fn can_lookup_subtrees_1() {
     use SubtreeLookupResult::*;
 
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         label("label 1", empty()),
         fork(
             pruned([1; 32]),
@@ -335,7 +333,7 @@ fn can_lookup_subtrees_1() {
 fn can_lookup_subtrees_2() {
     use SubtreeLookupResult::*;
 
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         label("label 1", empty()),
         fork(
             fork(
@@ -362,7 +360,7 @@ fn can_lookup_subtrees_2() {
 fn can_lookup_subtrees_3() {
     use SubtreeLookupResult::*;
 
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         pruned([0; 32]),
         fork(
             pruned([1; 32]),
@@ -387,7 +385,7 @@ fn can_lookup_subtrees_3() {
 fn can_lookup_subtrees_4() {
     use SubtreeLookupResult::*;
 
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         pruned([0; 32]),
         fork(
             fork(
@@ -412,7 +410,7 @@ fn can_lookup_subtrees_4() {
 fn can_lookup_subtrees_5() {
     use SubtreeLookupResult::*;
 
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         fork(
             pruned([1; 32]),
             fork(
@@ -439,7 +437,7 @@ fn can_lookup_subtrees_5() {
 fn can_lookup_subtrees_6() {
     use SubtreeLookupResult::*;
 
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         fork(
             fork(
                 label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),
@@ -466,7 +464,7 @@ fn can_lookup_subtrees_6() {
 fn can_lookup_subtrees_7() {
     use SubtreeLookupResult::*;
 
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         fork(
             pruned([1; 32]),
             fork(
@@ -491,7 +489,7 @@ fn can_lookup_subtrees_7() {
 fn can_lookup_subtrees_8() {
     use SubtreeLookupResult::*;
 
-    let tree = fork(
+    let tree: HashTree<Vec<u8>> = fork(
         fork(
             fork(
                 label("label 3", leaf(vec![1, 2, 3, 4, 5, 6])),

--- a/ic-certification/src/lib.rs
+++ b/ic-certification/src/lib.rs
@@ -2,11 +2,106 @@
 //!
 //! If you need support for the serde library, you will need to use the `serde` feature
 //! (available by default).
-
-pub mod hash_tree;
-#[doc(inline)]
-pub use hash_tree::{HashTree, Label, LookupResult, SubtreeLookupResult};
+use hash_tree::Sha256Digest;
+use hex::FromHexError;
 
 pub mod certificate;
+pub mod hash_tree;
+
 #[doc(inline)]
-pub use certificate::{Certificate, Delegation};
+pub use hash_tree::LookupResult;
+
+/// A HashTree representing a full tree.
+pub type HashTree = hash_tree::HashTree<Vec<u8>>;
+/// For labeled [HashTreeNode]
+pub type Label = hash_tree::Label<Vec<u8>>;
+/// A result of looking up for a subtree.
+pub type SubtreeLookupResult = hash_tree::SubtreeLookupResult<Vec<u8>>;
+
+/// A `Delegation` as defined in <https://internetcomputer.org/docs/current/references/ic-interface-spec/#certification-delegation>
+pub type Delegation = certificate::Delegation<Vec<u8>>;
+/// A `Certificate` as defined in <https://internetcomputer.org/docs/current/references/ic-interface-spec/#certificate>
+pub type Certificate = certificate::Certificate<Vec<u8>>;
+
+/// Create an empty hash tree.
+#[inline]
+pub fn empty() -> HashTree {
+    hash_tree::empty()
+}
+
+/// Create a forked tree from two trees or node.
+#[inline]
+pub fn fork(left: HashTree, right: HashTree) -> HashTree {
+    hash_tree::fork(left, right)
+}
+
+/// Create a labeled hash tree.
+#[inline]
+pub fn label<L: Into<Label>, N: Into<HashTree>>(label: L, node: N) -> HashTree {
+    hash_tree::label(label, node)
+}
+
+/// Create a leaf in the tree.
+#[inline]
+pub fn leaf<L: Into<Vec<u8>>>(leaf: L) -> HashTree {
+    hash_tree::leaf(leaf)
+}
+
+/// Create a pruned tree node.
+#[inline]
+pub fn pruned<C: Into<Sha256Digest>>(content: C) -> HashTree {
+    hash_tree::pruned(content)
+}
+
+/// Create a pruned tree node, from a hex representation of the data. Useful for
+/// testing or hard coded values.
+#[inline]
+pub fn pruned_from_hex<C: AsRef<str>>(content: C) -> Result<HashTree, FromHexError> {
+    hash_tree::pruned_from_hex(content)
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use std::borrow::Cow;
+
+    use serde::Deserialize;
+    use serde_bytes::{ByteBuf, Bytes};
+
+    /// A trait to genericize deserializing owned or borrowed bytes
+    pub trait Storage {
+        type Temp<'a>: Deserialize<'a>;
+        type Value<'a>: AsRef<[u8]>;
+        fn convert(t: Self::Temp<'_>) -> Self::Value<'_>;
+    }
+
+    /// `Vec<u8>`
+    pub struct VecStorage;
+    /// `&[u8]`
+    pub struct SliceStorage;
+    /// `Cow<[u8]>`
+    pub struct CowStorage;
+
+    impl Storage for VecStorage {
+        type Temp<'a> = ByteBuf;
+        type Value<'a> = Vec<u8>;
+        fn convert(t: Self::Temp<'_>) -> Self::Value<'_> {
+            t.into_vec()
+        }
+    }
+
+    impl Storage for SliceStorage {
+        type Temp<'a> = &'a Bytes;
+        type Value<'a> = &'a [u8];
+        fn convert(t: Self::Temp<'_>) -> Self::Value<'_> {
+            t.as_ref()
+        }
+    }
+
+    impl Storage for CowStorage {
+        type Temp<'a> = &'a Bytes;
+        type Value<'a> = Cow<'a, [u8]>;
+        fn convert(t: Self::Temp<'_>) -> Self::Value<'_> {
+            Cow::Borrowed(t.as_ref())
+        }
+    }
+}

--- a/icx-cert/src/pprint.rs
+++ b/icx-cert/src/pprint.rs
@@ -14,7 +14,7 @@ struct StructuredCertHeader<'a> {
 /// A fully parsed replica certificate.
 #[derive(Deserialize)]
 struct ReplicaCertificate {
-    tree: HashTree<'static>,
+    tree: HashTree,
     signature: serde_bytes::ByteBuf,
 }
 
@@ -118,7 +118,7 @@ pub fn pprint(url: String, accept_encodings: Option<Vec<String>>) -> Result<()> 
     );
     println!("TREE HASH: {}", hex::encode(tree.digest()));
     println!("SIGNATURE: {}", hex::encode(cert.signature.as_ref()));
-    if let LookupResult::Found(mut date_bytes) = cert.tree.lookup_path(&["time".into()]) {
+    if let LookupResult::Found(mut date_bytes) = cert.tree.lookup_path(&["time"]) {
         let timestamp_nanos = leb128::read::unsigned(&mut date_bytes)
             .with_context(|| "failed to decode certificate time as LEB128")?;
         const NANOS_PER_SEC: u64 = 1_000_000_000;


### PR DESCRIPTION
# Description

So it turns out the current `ic-certification`, kind of making the lifetimes pointlessly complex (what's the point in borrowing some of the data?).

This change removes the lifetime generics from the types in `ic-certification`, while also strengthening the zero-alloc modes for any power uses.

# How Has This Been Tested?

Pass all unit tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
