### PR TITLE
chore: Update deprecations

### DIFF
--- a/ic-agent/src/agent/http_transport/mod.rs
+++ b/ic-agent/src/agent/http_transport/mod.rs
@@ -8,7 +8,8 @@ pub mod reqwest_transport;
 pub use reqwest_transport::ReqwestTransport;
 #[cfg(feature = "reqwest")]
 #[doc(hidden)]
-pub use reqwest_transport::*; // deprecate after 0.24
+#[deprecated]
+pub use reqwest_transport::*; // remove after 0.25
 
 #[cfg(feature = "hyper")]
 pub mod hyper_transport;
@@ -18,7 +19,8 @@ pub mod hyper_transport;
 pub use hyper_transport::HyperTransport;
 #[cfg(feature = "hyper")]
 #[doc(hidden)]
-pub use hyper_transport::*; // deprecate after 0.24
+#[deprecated]
+pub use hyper_transport::*; // remove after 0.25
 
 #[allow(dead_code)]
 const IC0_DOMAIN: &str = "ic0.app";


### PR DESCRIPTION
This continues the deprecation path of the transport reexports by marking them deprecated rather than just hidden. To be removed entirely next release.