### PR TITLE
fix: stop using preconfigured tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,7 +937,7 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -998,6 +998,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+ "webpki-roots 0.23.0",
 ]
 
 [[package]]
@@ -1862,7 +1863,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "winreg",
 ]
 
@@ -1942,6 +1943,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2722,6 +2733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,7 +937,7 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "webpki-roots 0.22.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -998,7 +998,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
- "webpki-roots 0.23.0",
 ]
 
 [[package]]
@@ -1863,7 +1862,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.22.6",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -1943,16 +1942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -2733,15 +2722,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
-dependencies = [
- "rustls-webpki",
 ]
 
 [[package]]

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -41,7 +41,6 @@ sha2 = { workspace = true }
 simple_asn1 = "0.6.1"
 thiserror = { workspace = true }
 url = "2.1.0"
-webpki-roots = "0.23"
 
 [dependencies.hyper]
 version = "0.14"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -41,6 +41,7 @@ sha2 = { workspace = true }
 simple_asn1 = "0.6.1"
 thiserror = { workspace = true }
 url = "2.1.0"
+webpki-roots = "0.23"
 
 [dependencies.hyper]
 version = "0.14"
@@ -50,7 +51,7 @@ optional = true
 [dependencies.reqwest]
 version = "0.11.7"
 default-features = false
-features = ["blocking", "json", "rustls-tls", "stream"]
+features = ["blocking", "json", "rustls-tls-webpki-roots", "stream"]
 optional = true
 
 [dependencies.pem]
@@ -92,7 +93,7 @@ web-sys = { version = "0.3", features = [
 
 [features]
 default = ["pem", "reqwest"]
-reqwest = ["dep:reqwest", "dep:hyper-rustls"]
+reqwest = ["dep:reqwest"]
 hyper = ["dep:hyper", "dep:hyper-rustls"]
 ic_ref_tests = [
     "default",

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -5,7 +5,6 @@ pub use reqwest;
 
 use futures_util::StreamExt;
 #[cfg(not(target_family = "wasm"))]
-use hyper_rustls::ConfigBuilderExt;
 use reqwest::{
     header::{HeaderMap, CONTENT_TYPE},
     Body, Client, Method, Request, StatusCode, Url,
@@ -38,18 +37,10 @@ impl ReqwestTransport {
     pub fn create<U: Into<String>>(url: U) -> Result<Self, AgentError> {
         #[cfg(not(target_family = "wasm"))]
         {
-            let mut tls_config = rustls::ClientConfig::builder()
-                .with_safe_defaults()
-                .with_webpki_roots()
-                .with_no_client_auth();
-
-            // Advertise support for HTTP/2
-            tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-
             Self::create_with_client(
                 url,
                 Client::builder()
-                    .use_preconfigured_tls(tls_config)
+                    .use_rustls_tls()
                     .build()
                     .expect("Could not create HTTP client."),
             )

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -4,7 +4,6 @@
 pub use reqwest;
 
 use futures_util::StreamExt;
-#[cfg(not(target_family = "wasm"))]
 use reqwest::{
     header::{HeaderMap, CONTENT_TYPE},
     Body, Client, Method, Request, StatusCode, Url,


### PR DESCRIPTION
We use a function `use_preconfigured_tls`, which requires ic-agent to be using the same version of rustls that reqwest is. However reqwest has a habit of bumping it in minor releases, making this impossible to track in reality. This PR removes the TLS configuration code, which was only ever reproducing the defaults anyway. Fixes #284.