### PR TITLE
chore: Release 0.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "hex",
  "serde",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "async-trait",
  "candid",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "candid",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.24.0"
+version = "0.24.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
@@ -18,9 +18,9 @@ rust-version = "1.65.0"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-ic-agent = { path = "ic-agent", version = "0.24" }
-ic-utils = { path = "ic-utils", version = "0.24" }
-ic-certification = { path = "ic-certification", version = "0.24" }
+ic-agent = { path = "ic-agent", version = "0.24.1" }
+ic-utils = { path = "ic-utils", version = "0.24.1" }
+ic-certification = { path = "ic-certification", version = "0.24.1" }
 
 candid = "0.8.4"
 hex = "0.4.3"

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -22,6 +22,7 @@ base64 = "0.13"
 clap = { version = "3.1.8", features = ["derive", "cargo"] }
 hex = { workspace = true }
 ic-agent = { workspace = true, default-features = false }
+ic-certification = { workspace = true }
 leb128 = "0.2.4"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }
 sha2 = { workspace = true }
@@ -29,4 +30,3 @@ serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 serde_cbor = { workspace = true }
 time = { workspace = true }
-ic-certification = { path = "../ic-certification", version = "0.24" }


### PR DESCRIPTION
Includes #441, which fixes an issue in 0.24.0 that caused guaranteed runtime errors when using the agent in a way invisible to our CI.