### PR TITLE
feat!: Update Identity API to receive the full content map

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -67,7 +67,6 @@ jobs:
           export IC_REF_PORT=$(cat $HOME/ic_ref_port)
           export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
           export IC_WALLET_CANISTER_PATH=$HOME/wallet.wasm
-          cd main/ref-tests
           cargo test --all-features -- --ignored
           killall ic-ref
         env:

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -67,6 +67,7 @@ jobs:
           export IC_REF_PORT=$(cat $HOME/ic_ref_port)
           export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
           export IC_WALLET_CANISTER_PATH=$HOME/wallet.wasm
+          cd main
           cargo test --all-features -- --ignored
           killall ic-ref
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+##  Unreleased
+
+* Breaking Change: builders are now owning-style rather than borrowing-style; with_arg takes an owned Vec rather than a borrowed Vec
+* Breaking Change: Identity::sign takes &EnvelopeContent rather than the request ID.
+
 ## [0.24.0] - 2023-05-19
 
 * fix: Adjust the default polling parameters to provide better UX. Remove the `CouldNotReadRootKey` error and panic on poisoned mutex.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,9 +2032,9 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -2060,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.162"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,12 +121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base32"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,10 +951,7 @@ dependencies = [
 name = "ic-agent"
 version = "0.24.1"
 dependencies = [
- "async-trait",
  "backoff",
- "base32",
- "byteorder",
  "candid",
  "futures-util",
  "getrandom",
@@ -974,9 +965,8 @@ dependencies = [
  "js-sys",
  "k256",
  "leb128",
- "mime",
  "mockito",
- "pem 2.0.1",
+ "pem",
  "pkcs8",
  "rand",
  "reqwest",
@@ -1017,7 +1007,6 @@ version = "0.24.1"
 dependencies = [
  "hex",
  "ic-agent",
- "num-bigint 0.4.3",
  "pkcs11",
  "sha2 0.10.6",
  "simple_asn1",
@@ -1031,10 +1020,7 @@ dependencies = [
  "async-trait",
  "candid",
  "ic-agent",
- "leb128",
- "num-bigint 0.4.3",
  "once_cell",
- "paste",
  "ring",
  "semver",
  "serde",
@@ -1068,11 +1054,9 @@ dependencies = [
  "humantime",
  "ic-agent",
  "ic-utils",
- "pem 1.1.1",
  "ring",
  "serde",
  "serde_json",
- "thiserror",
  "tokio",
 ]
 
@@ -1084,7 +1068,6 @@ dependencies = [
  "base64 0.13.1",
  "clap",
  "hex",
- "ic-agent",
  "ic-certification",
  "leb128",
  "reqwest",
@@ -1559,15 +1542,6 @@ name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
-
-[[package]]
-name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
 
 [[package]]
 name = "pem"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -15,10 +15,7 @@ keywords = ["internet-computer", "agent", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
-async-trait = "0.1.68"
 backoff = "0.4.0"
-base32 = "0.4.0"
-byteorder = "1.3.2"
 candid = { workspace = true }
 futures-util = "0.3.21"
 hex = { workspace = true }
@@ -28,7 +25,6 @@ ic-certification = { workspace = true }
 ic-verify-bls-signature = "0.1"
 k256 = { version = "0.13.1", features = ["pem"] }
 leb128 = "0.2.5"
-mime = "0.3.16"
 pkcs8 = { version = "0.10.2", features = ["std"] }
 sec1 = { version = "0.7.2", features = ["pem"] }
 rand = "0.8.5"

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -41,10 +41,10 @@ async fn query() -> Result<(), AgentError> {
         .build()?;
     let result = agent
         .query_raw(
-            &Principal::management_canister(),
             Principal::management_canister(),
-            "main",
-            &[],
+            Principal::management_canister(),
+            "main".to_string(),
+            vec![],
             None,
         )
         .await;
@@ -67,10 +67,10 @@ async fn query_error() -> Result<(), AgentError> {
 
     let result = agent
         .query_raw(
-            &Principal::management_canister(),
             Principal::management_canister(),
-            "greet",
-            &[],
+            Principal::management_canister(),
+            "greet".to_string(),
+            vec![],
             None,
         )
         .await;
@@ -106,10 +106,10 @@ async fn query_rejected() -> Result<(), AgentError> {
 
     let result = agent
         .query_raw(
-            &Principal::management_canister(),
             Principal::management_canister(),
-            "greet",
-            &[],
+            Principal::management_canister(),
+            "greet".to_string(),
+            vec![],
             None,
         )
         .await;

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -301,7 +301,7 @@ impl Agent {
         let status = self.status().await?;
         let root_key = match status.root_key {
             Some(key) => key,
-            None => return Err(AgentError::NoRootKeyInStatus(status))
+            None => return Err(AgentError::NoRootKeyInStatus(status)),
         };
         self.set_root_key(root_key);
         Ok(())
@@ -1287,7 +1287,7 @@ impl<'agent> UpdateBuilder<'agent> {
         )?;
         let signed_update = sign_envelope(&content, self.agent.identity.clone())?;
         let request_id = to_request_id(&content)?;
-        let EnvelopeContent::Call { 
+        let EnvelopeContent::Call {
             nonce,
             ingress_expiry,
             sender,

--- a/ic-agent/src/agent/replica_api.rs
+++ b/ic-agent/src/agent/replica_api.rs
@@ -1,12 +1,14 @@
-use crate::{export::Principal, AgentError};
+use std::borrow::Cow;
+
+use crate::{export::Principal, to_request_id, AgentError, RequestId};
 use ic_certification::Label;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub struct Envelope<T: Serialize> {
-    pub content: T,
+pub struct Envelope<'a> {
+    pub content: Cow<'a, EnvelopeContent>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "serde_bytes")]
@@ -17,68 +19,74 @@ pub struct Envelope<T: Serialize> {
     pub sender_sig: Option<Vec<u8>>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(tag = "request_type")]
-pub enum AsyncContent {
-    #[serde(rename = "call")]
-    CallRequest {
-        #[serde(default)]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[serde(with = "serde_bytes")]
+/// The content of an IC ingress message, not including any signature information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "request_type", rename_all = "snake_case")]
+pub enum EnvelopeContent {
+    /// A replicated call to a canister method, whether update or query.
+    Call {
+        /// A random series of bytes to uniquely identify this message.
+        #[serde(default, skip_serializing_if = "Option::is_none", with = "serde_bytes")]
         nonce: Option<Vec<u8>>,
+        /// A nanosecond timestamp after which this request is no longer valid.
         ingress_expiry: u64,
+        /// The principal that is sending this request.
         sender: Principal,
+        /// The ID of the canister to be called.
         canister_id: Principal,
+        /// The name of the canister method to be called.
         method_name: String,
+        /// The argument to pass to the canister method.
         #[serde(with = "serde_bytes")]
         arg: Vec<u8>,
     },
-}
-
-// A request as submitted to /api/v2/.../call
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(tag = "request_type")]
-pub enum CallRequestContent {
-    #[serde(rename = "call")]
-    CallRequest {
-        #[serde(default)]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[serde(with = "serde_bytes")]
-        nonce: Option<Vec<u8>>,
+    /// A request for information from the [IC state tree](https://internetcomputer.org/docs/current/references/ic-interface-spec#state-tree).
+    ReadState {
+        /// A nanosecond timestamp after which this request is no longer valid.
         ingress_expiry: u64,
+        /// The principal that is sending this request.
         sender: Principal,
-        canister_id: Principal,
-        method_name: String,
-        #[serde(with = "serde_bytes")]
-        arg: Vec<u8>,
-    },
-}
-
-// A request as submitted to /api/v2/.../read_state
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(tag = "request_type")]
-pub enum ReadStateContent {
-    #[serde(rename = "read_state")]
-    ReadStateRequest {
-        ingress_expiry: u64,
-        sender: Principal,
+        /// A list of paths within the state tree to fetch.
         paths: Vec<Vec<Label>>,
     },
-}
-
-// A request as submitted to /api/v2/.../query
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(tag = "request_type")]
-pub enum QueryContent {
-    #[serde(rename = "query")]
-    QueryRequest {
+    /// An unreplicated call to a canister query method.
+    Query {
+        /// A nanosecond timestamp after which this request is no longer valid.
         ingress_expiry: u64,
+        /// The principal that is sending this request.
         sender: Principal,
+        /// The ID of the canister to be called.
         canister_id: Principal,
+        /// The name of the canister method to be called.
         method_name: String,
+        /// The argument to pass to the canister method.
         #[serde(with = "serde_bytes")]
         arg: Vec<u8>,
     },
+}
+
+impl EnvelopeContent {
+    /// Returns the `ingress_expiry` field common to all variants.
+    pub fn ingress_expiry(&self) -> u64 {
+        let (Self::Call { ingress_expiry, .. }
+        | Self::Query { ingress_expiry, .. }
+        | Self::ReadState { ingress_expiry, .. }) = self;
+        *ingress_expiry
+    }
+    /// Returns the `sender` field common to all variants.
+    pub fn sender(&self) -> &Principal {
+        let (Self::Call { sender, .. }
+        | Self::Query { sender, .. }
+        | Self::ReadState { sender, .. }) = self;
+        sender
+    }
+    /// Converts the envelope content to a request ID.
+    ///
+    /// Equivalent to calling [`to_request_id`], but infallible.
+    pub fn to_request_id(&self) -> RequestId {
+        to_request_id(self)
+            .expect("to_request_id::<EnvelopeContent> should always succeed but did not")
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/ic-agent/src/identity/anonymous.rs
+++ b/ic-agent/src/identity/anonymous.rs
@@ -1,4 +1,4 @@
-use crate::{export::Principal, identity::Identity, Signature};
+use crate::{agent::EnvelopeContent, export::Principal, identity::Identity, Signature};
 
 /// The anonymous identity.
 ///
@@ -11,7 +11,7 @@ impl Identity for AnonymousIdentity {
         Ok(Principal::anonymous())
     }
 
-    fn sign(&self, _blob: &[u8]) -> Result<Signature, String> {
+    fn sign(&self, _: &EnvelopeContent) -> Result<Signature, String> {
         Ok(Signature {
             signature: None,
             public_key: None,

--- a/ic-agent/src/identity/basic.rs
+++ b/ic-agent/src/identity/basic.rs
@@ -1,4 +1,4 @@
-use crate::{export::Principal, Identity, Signature};
+use crate::{agent::EnvelopeContent, export::Principal, Identity, Signature};
 
 #[cfg(feature = "pem")]
 use crate::identity::error::PemError;
@@ -59,11 +59,9 @@ impl Identity for BasicIdentity {
     fn sender(&self) -> Result<Principal, String> {
         Ok(Principal::self_authenticating(&self.der_encoded_public_key))
     }
-    fn sign(&self, msg: &[u8]) -> Result<Signature, String> {
-        let signature = self.key_pair.sign(msg.as_ref());
-        // At this point we shall validate the signature in this first
-        // skeleton version.
 
+    fn sign(&self, content: &EnvelopeContent) -> Result<Signature, String> {
+        let signature = self.key_pair.sign(&content.to_request_id().signable());
         Ok(Signature {
             signature: Some(signature.as_ref().to_vec()),
             public_key: Some(self.der_encoded_public_key.clone()),

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -1,5 +1,5 @@
 //! Types and traits dealing with identity across the Internet Computer.
-use crate::export::Principal;
+use crate::{agent::EnvelopeContent, export::Principal};
 
 pub(crate) mod anonymous;
 pub(crate) mod basic;
@@ -31,10 +31,12 @@ pub struct Signature {
 /// identities used.
 pub trait Identity: Send + Sync {
     /// Returns a sender, ie. the Principal ID that is used to sign a request.
+    ///
     /// Only one sender can be used per request.
     fn sender(&self) -> Result<Principal, String>;
 
-    /// Sign a blob, the concatenation of the domain separator & request ID,
-    /// creating the sender signature.
-    fn sign(&self, blob: &[u8]) -> Result<Signature, String>;
+    /// Sign a request ID derived from a content map.
+    ///
+    /// Implementors should call `content.to_request_id().signable()` for the actual bytes that need to be signed.
+    fn sign(&self, content: &EnvelopeContent) -> Result<Signature, String>;
 }

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -1,4 +1,4 @@
-use crate::{export::Principal, Identity, Signature};
+use crate::{agent::EnvelopeContent, export::Principal, Identity, Signature};
 
 #[cfg(feature = "pem")]
 use crate::identity::error::PemError;
@@ -74,10 +74,10 @@ impl Identity for Secp256k1Identity {
         ))
     }
 
-    fn sign(&self, msg: &[u8]) -> Result<Signature, String> {
+    fn sign(&self, content: &EnvelopeContent) -> Result<Signature, String> {
         let ecdsa_sig: ecdsa::Signature = self
             .private_key
-            .try_sign(msg)
+            .try_sign(&content.to_request_id().signable())
             .map_err(|err| format!("Cannot create secp256k1 signature: {}", err))?;
         let r = ecdsa_sig.r().as_ref().to_bytes();
         let s = ecdsa_sig.s().as_ref().to_bytes();
@@ -100,6 +100,7 @@ impl Identity for Secp256k1Identity {
 #[cfg(test)]
 mod test {
     use super::*;
+    use candid::Encode;
     use k256::{
         ecdsa::{signature::Verifier, Signature},
         elliptic_curve::PrimeField,
@@ -175,10 +176,17 @@ N3d26cRxD99TPtm8uo2OuzKhSiq6EQ==
         let identity = Secp256k1Identity::from_pem(IDENTITY_FILE.as_bytes())
             .expect("Cannot create secp256k1 identity from PEM file.");
 
-        // Create a secp256k1 signature on the message "Hello World".
-        let message = b"Hello World";
+        // Create a secp256k1 signature for a hello-world canister.
+        let message = EnvelopeContent::Call {
+            nonce: None,
+            ingress_expiry: 0,
+            sender: identity.sender().unwrap(),
+            canister_id: "bkyz2-fmaaa-aaaaa-qaaaq-cai".parse().unwrap(),
+            method_name: "greet".to_string(),
+            arg: Encode!(&"world").unwrap(),
+        };
         let signature = identity
-            .sign(message)
+            .sign(&message)
             .expect("Cannot create secp256k1 signature.")
             .signature
             .expect("Cannot find secp256k1 signature bytes.");
@@ -196,7 +204,7 @@ N3d26cRxD99TPtm8uo2OuzKhSiq6EQ==
         // Assert the secp256k1 signature is valid.
         identity
             ._public_key
-            .verify(message, &ecdsa_sig)
+            .verify(&message.to_request_id().signable(), &ecdsa_sig)
             .expect("Cannot verify secp256k1 signature.");
     }
 }

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -74,7 +74,7 @@
 //!   let effective_canister_id = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
 //!   let response = agent.update(&management_canister_id, "provisional_create_canister_with_cycles")
 //!     .with_effective_canister_id(effective_canister_id)
-//!     .with_arg(&Encode!(&Argument { amount: None})?)
+//!     .with_arg(Encode!(&Argument { amount: None})?)
 //!     .call_and_wait()
 //!     .await?;
 //!

--- a/ic-agent/src/request_id/mod.rs
+++ b/ic-agent/src/request_id/mod.rs
@@ -15,6 +15,8 @@ pub mod error;
 #[doc(inline)]
 pub use error::RequestIdError;
 
+const IC_REQUEST_DOMAIN_SEPARATOR: &[u8; 11] = b"\x0Aic-request";
+
 /// Type alias for a sha256 result (ie. a u256).
 type Sha256Hash = [u8; 32];
 
@@ -35,6 +37,15 @@ impl RequestId {
 
     pub(crate) fn to_vec(self) -> Vec<u8> {
         self.0.to_vec()
+    }
+
+    /// Returns the signable form of the request ID, by prepending `"\x0Aic-request"` to it,
+    /// for use in [`Identity::sign`](crate::identity::Identity::sign).
+    pub fn signable(&self) -> Vec<u8> {
+        let mut signable = Vec::with_capacity(43);
+        signable.extend_from_slice(IC_REQUEST_DOMAIN_SEPARATOR);
+        signable.extend_from_slice(&self.0);
+        signable
     }
 }
 
@@ -660,7 +671,8 @@ impl<'a> ser::SerializeStructVariant for &'a mut RequestIdSerializer {
 
 /// Derive the request ID from a serializable data structure.
 ///
-/// See <https://hydra.dfinity.systems//build/268411/download/1/dfinity/spec/public/index.html#api-request-id>
+/// See [Representation-independent Hashing of Structured Data](https://internetcomputer.org/docs/current/references/ic-interface-spec#hash-of-map)
+/// from the IC spec for the method of calculation.
 ///
 /// # Warnings
 ///

--- a/ic-identity-hsm/Cargo.toml
+++ b/ic-identity-hsm/Cargo.toml
@@ -17,7 +17,6 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 [dependencies]
 hex = { workspace = true }
 ic-agent = { workspace = true, default-features = false }
-num-bigint = "0.4.3"
 pkcs11 = "0.5.0"
 sha2 = { workspace = true }
 simple_asn1 = "0.6.0"

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -1,4 +1,4 @@
-use ic_agent::{export::Principal, Identity, Signature};
+use ic_agent::{agent::EnvelopeContent, export::Principal, Identity, Signature};
 
 use pkcs11::{
     types::{
@@ -136,8 +136,8 @@ impl Identity for HardwareIdentity {
     fn sender(&self) -> Result<Principal, String> {
         Ok(Principal::self_authenticating(&self.public_key))
     }
-    fn sign(&self, msg: &[u8]) -> Result<Signature, String> {
-        let hash = Sha256::digest(msg);
+    fn sign(&self, content: &EnvelopeContent) -> Result<Signature, String> {
+        let hash = Sha256::digest(content.to_request_id().signable());
         let signature = self.sign_hash(&hash)?;
 
         Ok(Signature {

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -25,9 +25,6 @@ serde_bytes = { workspace = true }
 strum = "0.24"
 strum_macros = "0.24"
 thiserror = { workspace = true }
-paste = "1"
-num-bigint = "0.4"
-leb128 = "0.2"
 semver = "1.0.7"
 once_cell = "1.10.0"
 

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -165,7 +165,7 @@ where
         let mut builder = self.agent.query(&self.canister_id, &self.method_name);
         builder = self.expiry.apply_to_query(builder);
         builder
-            .with_arg(&self.arg?)
+            .with_arg(self.arg?)
             .with_effective_canister_id(self.effective_canister_id)
             .call()
             .await

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -163,10 +163,12 @@ where
     /// Perform the call, consuming the the abstraction. This is a private method.
     async fn call_raw(self) -> Result<Vec<u8>, AgentError> {
         let mut builder = self.agent.query(&self.canister_id, &self.method_name);
-        self.expiry.apply_to_query(&mut builder);
-        builder.with_arg(&self.arg?);
-        builder.with_effective_canister_id(self.effective_canister_id);
-        builder.call().await
+        builder = self.expiry.apply_to_query(builder);
+        builder
+            .with_arg(&self.arg?)
+            .with_effective_canister_id(self.effective_canister_id)
+            .call()
+            .await
     }
 }
 
@@ -212,9 +214,10 @@ where
     /// essentially downleveling this type into the lower level [ic-agent] abstraction.
     pub fn build_call(self) -> Result<UpdateBuilder<'agent>, AgentError> {
         let mut builder = self.agent.update(&self.canister_id, &self.method_name);
-        self.expiry.apply_to_update(&mut builder);
-        builder.with_arg(&self.arg?);
-        builder.with_effective_canister_id(self.effective_canister_id);
+        builder = self.expiry.apply_to_update(builder);
+        builder = builder
+            .with_arg(self.arg?)
+            .with_effective_canister_id(self.effective_canister_id);
         Ok(builder)
     }
 

--- a/ic-utils/src/call/expiry.rs
+++ b/ic-utils/src/call/expiry.rs
@@ -28,27 +28,19 @@ impl Expiry {
         Self::DateTime(dt)
     }
 
-    pub(crate) fn apply_to_update(self, u: &mut UpdateBuilder<'_>) {
+    pub(crate) fn apply_to_update(self, u: UpdateBuilder<'_>) -> UpdateBuilder<'_> {
         match self {
-            Expiry::Unspecified => {}
-            Expiry::Delay(d) => {
-                u.expire_after(d);
-            }
-            Expiry::DateTime(dt) => {
-                u.expire_at(dt);
-            }
+            Expiry::Unspecified => u,
+            Expiry::Delay(d) => u.expire_after(d),
+            Expiry::DateTime(dt) => u.expire_at(dt),
         }
     }
 
-    pub(crate) fn apply_to_query(self, u: &mut QueryBuilder<'_>) {
+    pub(crate) fn apply_to_query(self, u: QueryBuilder<'_>) -> QueryBuilder<'_> {
         match self {
-            Expiry::Unspecified => {}
-            Expiry::Delay(d) => {
-                u.expire_after(d);
-            }
-            Expiry::DateTime(dt) => {
-                u.expire_at(dt);
-            }
+            Expiry::Unspecified => u,
+            Expiry::Delay(d) => u.expire_after(d),
+            Expiry::DateTime(dt) => u.expire_at(dt),
         }
     }
 }

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -21,7 +21,6 @@ anyhow = "1.0"
 base64 = "0.13"
 clap = { version = "3.1.8", features = ["derive", "cargo"] }
 hex = { workspace = true }
-ic-agent = { workspace = true, default-features = false }
 ic-certification = { workspace = true }
 leb128 = "0.2.4"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -28,4 +28,4 @@ sha2 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }
 serde_cbor = { workspace = true }
-time = { workspace = true }
+time = { workspace = true, features = ["formatting"] }

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -26,9 +26,7 @@ hex = { workspace = true }
 humantime = "2.0.1"
 ic-agent = { workspace = true }
 ic-utils = { workspace = true }
-pem = "1.0"
 ring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-thiserror = { workspace = true }

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -381,7 +381,7 @@ async fn main() -> Result<()> {
                         let mut builder = agent.update(&t.canister_id, &t.method_name);
 
                         if let Some(d) = expire_after {
-                            builder.expire_after(d);
+                            builder = builder.expire_after(d);
                         }
 
                         let printer = async {
@@ -404,7 +404,7 @@ async fn main() -> Result<()> {
                     SubCommand::Query(_) => {
                         let mut builder = agent.query(&t.canister_id, &t.method_name);
                         if let Some(d) = expire_after {
-                            builder.expire_after(d);
+                            builder = builder.expire_after(d);
                         }
 
                         builder
@@ -461,7 +461,7 @@ async fn main() -> Result<()> {
 
                         let mut builder = agent.update(&t.canister_id, &t.method_name);
                         if let Some(d) = expire_after {
-                            builder.expire_after(d);
+                            builder = builder.expire_after(d);
                         }
                         let signed_update = builder
                             .with_arg(arg)
@@ -482,7 +482,7 @@ async fn main() -> Result<()> {
                     &SubCommand::Query(_) => {
                         let mut builder = agent.query(&t.canister_id, &t.method_name);
                         if let Some(d) = expire_after {
-                            builder.expire_after(d);
+                            builder = builder.expire_after(d);
                         }
                         let signed_query = builder
                             .with_arg(arg)

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -408,7 +408,7 @@ async fn main() -> Result<()> {
                         }
 
                         builder
-                            .with_arg(&arg)
+                            .with_arg(arg)
                             .with_effective_canister_id(effective_canister_id)
                             .call()
                             .await

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -78,8 +78,7 @@ yeMC60IsMNxDjLqElV7+T7dkb5Ki7Q==
 }
 
 pub async fn create_agent(identity: Box<dyn Identity>) -> Result<Agent, String> {
-    let port_env = std::env::var("IC_REF_PORT")
-        .expect("Need to specify the IC_REF_PORT environment variable.");
+    let port_env = std::env::var("IC_REF_PORT").unwrap_or_else(|_| "8001".into());
     let port = port_env
         .parse::<u32>()
         .expect("Could not parse the IC_REF_PORT environment variable as an integer.");

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -771,7 +771,7 @@ mod simple_calls {
             let arg = payload().reply_data(b"hello").build();
             let result = agent
                 .query(&canister_id, "non_existent_method")
-                .with_arg(&arg)
+                .with_arg(arg)
                 .call()
                 .await;
 

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -717,7 +717,7 @@ mod simple_calls {
             let arg = payload().reply_data(b"hello").build();
             let result = agent
                 .update(&canister_id, "update")
-                .with_arg(&arg)
+                .with_arg(arg)
                 .call_and_wait()
                 .await?;
 
@@ -749,7 +749,7 @@ mod simple_calls {
             let arg = payload().reply_data(b"hello").build();
             let result = agent
                 .update(&canister_id, "non_existent_method")
-                .with_arg(&arg)
+                .with_arg(arg)
                 .call_and_wait()
                 .await;
 

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -31,7 +31,7 @@ fn basic_expiry() {
         // Verify this works first.
         let result = agent
             .update(&canister_id, "update")
-            .with_arg(&arg)
+            .with_arg(arg.clone())
             .expire_after(std::time::Duration::from_secs(120))
             .call_and_wait()
             .await?;
@@ -41,7 +41,7 @@ fn basic_expiry() {
         // Verify a zero expiry will fail with the proper code.
         let result = agent
             .update(&canister_id, "update")
-            .with_arg(&arg)
+            .with_arg(arg.clone())
             .expire_after(std::time::Duration::from_secs(0))
             .call_and_wait()
             .await;
@@ -53,7 +53,7 @@ fn basic_expiry() {
 
         let result = agent
             .update(&canister_id, "update")
-            .with_arg(&arg)
+            .with_arg(arg.clone())
             .expire_after(std::time::Duration::from_secs(120))
             .call_and_wait()
             .await?;


### PR DESCRIPTION
To support `Identity` implementations such as the Ledger Nano, the `Identity::sign` function must be able to receive the full message being signed, not just the calculated request ID. This PR exposes the envelope content map in the API and makes it the new parameter for `Identity::sign`, while refactoring several places that the content map ends up in the implementation to accommodate. 

This is a breaking change in a couple high profile places, so I took the opportunity to make a couple more related ones around unnecessarily cloning data that we've held off on making for user convenience.