### PR TITLE
feat: Use `OffsetDateTime` instead of `SystemTime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "time",
  "tokio",
 ]
 

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -36,6 +36,7 @@ serde_repr = "0.1.12"
 sha2 = { workspace = true }
 simple_asn1 = "0.6.1"
 thiserror = { workspace = true }
+time = { workspace = true }
 url = "2.1.0"
 
 [dependencies.hyper]
@@ -67,7 +68,6 @@ js-sys = { version = "0.3", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 web-sys = { version = "0.3", features = ["Window"], optional = true }
-time = { workspace = true, features = ["wasm-bindgen"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.79"
@@ -99,7 +99,7 @@ wasm-bindgen = [
     "dep:wasm-bindgen-futures",
     "dep:getrandom",
     "dep:web-sys",
-    "dep:time",
+    "time/wasm-bindgen",
     "backoff/wasm-bindgen",
 ]
 

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -25,6 +25,7 @@ serde_bytes = { workspace = true }
 strum = "0.24"
 strum_macros = "0.24"
 thiserror = { workspace = true }
+time = { workspace = true }
 semver = "1.0.7"
 once_cell = "1.10.0"
 

--- a/ic-utils/src/call/expiry.rs
+++ b/ic-utils/src/call/expiry.rs
@@ -1,4 +1,7 @@
+use std::time::{Duration, SystemTime};
+
 use ic_agent::agent::{QueryBuilder, UpdateBuilder};
+use time::OffsetDateTime;
 
 /// An expiry value. Either not specified (the default), a delay relative to the time the
 /// call is made, or a specific date time.
@@ -9,23 +12,23 @@ pub enum Expiry {
     Unspecified,
 
     /// A duration that will be added to the system time when the call is made.
-    Delay(std::time::Duration),
+    Delay(Duration),
 
     /// A specific date and time to use for the expiry of the request.
-    DateTime(std::time::SystemTime),
+    DateTime(OffsetDateTime),
 }
 
 impl Expiry {
     /// Create an expiry that happens after a duration.
     #[inline]
-    pub fn after(d: std::time::Duration) -> Self {
+    pub fn after(d: Duration) -> Self {
         Self::Delay(d)
     }
 
     /// Set the expiry field to a specific date and time.
     #[inline]
-    pub fn at(dt: std::time::SystemTime) -> Self {
-        Self::DateTime(dt)
+    pub fn at(dt: impl Into<OffsetDateTime>) -> Self {
+        Self::DateTime(dt.into())
     }
 
     pub(crate) fn apply_to_update(self, u: UpdateBuilder<'_>) -> UpdateBuilder<'_> {
@@ -45,14 +48,20 @@ impl Expiry {
     }
 }
 
-impl From<std::time::Duration> for Expiry {
-    fn from(d: std::time::Duration) -> Self {
+impl From<Duration> for Expiry {
+    fn from(d: Duration) -> Self {
         Self::Delay(d)
     }
 }
 
-impl From<std::time::SystemTime> for Expiry {
-    fn from(dt: std::time::SystemTime) -> Self {
+impl From<SystemTime> for Expiry {
+    fn from(dt: SystemTime) -> Self {
+        Self::DateTime(dt.into())
+    }
+}
+
+impl From<OffsetDateTime> for Expiry {
+    fn from(dt: OffsetDateTime) -> Self {
         Self::DateTime(dt)
     }
 }


### PR DESCRIPTION
`std::time::SystemTime` is incompatible with wasm-bindgen, while `time::OffsetDateTime` is not. This changes the expiry timestamp to be based on `OffsetDateTime` instead of `SystemTime`, leaving source compatibility via the From impl. 