### PR TITLE
feat: Disable arc_type requirement in candid for ic-utils

### DIFF
--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -18,7 +18,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 async-trait = "0.1.68"
-candid = { workspace = true, features = ["arc_type"] }
+candid = { workspace = true }
 ic-agent = { workspace = true, default-features = false }
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -4,9 +4,15 @@ use ic_agent::{agent::UpdateBuilder, export::Principal, Agent, AgentError, Reque
 use serde::de::DeserializeOwned;
 use std::fmt;
 use std::future::Future;
+use std::pin::Pin;
 
 mod expiry;
 pub use expiry::Expiry;
+
+#[cfg(target_family = "wasm")]
+pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+#[cfg(not(target_family = "wasm"))]
+pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a + Send>>;
 
 /// A type that implements synchronous calls (ie. 'query' calls).
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -102,14 +102,15 @@ where
     ///     .create_canister()
     ///     .as_provisional_create_with_amount(None)
     ///     .with_effective_canister_id(effective_id)
-    ///     .and_then(|(canister_id,)| async move {
-    ///       management_canister
-    ///         .install_code(&canister_id, canister_wasm)
-    ///         .build()
-    ///         .unwrap()
-    ///         .call_and_wait()
-    ///         .await?;
-    ///       Ok((canister_id,))
+    ///     .and_then(|(canister_id,)| {
+    ///         let call = management_canister
+    ///             .install_code(&canister_id, canister_wasm)
+    ///             .build()
+    ///             .unwrap();
+    ///         async move {
+    ///             call.call_and_wait().await?;
+    ///             Ok((canister_id,))
+    ///         }
     ///     })
     ///     .call_and_wait()
     ///     .await?;

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -1,7 +1,10 @@
 //! Builder interfaces for some method calls of the management canister.
 
 use crate::{
-    call::AsyncCall, canister::Argument, interfaces::management_canister::MgmtMethod, Canister,
+    call::{AsyncCall, BoxFuture},
+    canister::Argument,
+    interfaces::management_canister::MgmtMethod,
+    Canister,
 };
 use async_trait::async_trait;
 use candid::{CandidType, Deserialize, Nat};
@@ -437,15 +440,20 @@ impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
     }
 }
 
-#[cfg_attr(target_family = "wasm", async_trait(?Send))]
-#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<'agent, 'canister: 'agent> AsyncCall<()> for InstallCodeBuilder<'agent, 'canister> {
-    async fn call(self) -> Result<RequestId, AgentError> {
-        self.build()?.call().await
+    fn call<'async_trait>(self) -> BoxFuture<'async_trait, Result<RequestId, AgentError>>
+    where
+        Self: 'async_trait,
+    {
+        let call_res = self.build();
+        Box::pin(async move { call_res?.call().await })
     }
-
-    async fn call_and_wait(self) -> Result<(), AgentError> {
-        self.build()?.call_and_wait().await
+    fn call_and_wait<'async_trait>(self) -> BoxFuture<'async_trait, Result<(), AgentError>>
+    where
+        Self: 'async_trait,
+    {
+        let call_res = self.build();
+        Box::pin(async move { call_res?.call_and_wait().await })
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.65.0"
 components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This allows avoiding the 0.9.x deprecation warnings from candid, at the expense of the cleanliness of `async fn`. 