### PR TITLE
chore: update Rust version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-latest, ubuntu-latest ]
-        rust: [ '1.65.0' ]
+        rust: [ '1.71.1' ]
         dfx: [ '0.8.4', '0.9.2', '0.10.1', '0.11.1' ]
 
     steps:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [ '1.65.0' ]
+        rust: [ 1.71.1' ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: [ 1.71.1' ]
+        rust: [ '1.71.1' ]
         os: [ ubuntu-latest ]
 
     steps:

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -17,7 +17,7 @@ jobs:
             ic-hs-ref: "3d71032e"
             wallet-tag: "20230308"
             os: ubuntu-latest
-            rust: "1.65.0"
+            rust: "1.71.1"
 
     steps:
       - uses: actions/setup-node@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.65.0"]
+        rust: ["1.71.1"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
             name: linux
             binary_path: target/x86_64-unknown-linux-musl/release
             binary_files: icx
-            rust: '1.65.0'
+            rust: '1.71.1'
           - os: macos-latest
             name: macos
             binary_path: target/release
             binary_files: icx
-            rust: '1.65.0'
+            rust: '1.71.1'
     steps:
     - uses: actions/checkout@master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.65.0"]
+        rust: ["1.71.1"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.25.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
-rust-version = "1.65.0"
+rust-version = "1.71.1"
 license = "Apache-2.0"
 
 [workspace.dependencies]

--- a/ic-agent/src/identity/basic.rs
+++ b/ic-agent/src/identity/basic.rs
@@ -40,7 +40,7 @@ impl BasicIdentity {
             .collect::<Result<Vec<u8>, std::io::Error>>()?;
 
         Ok(BasicIdentity::from_key_pair(Ed25519KeyPair::from_pkcs8(
-            pem::parse(&bytes)?.contents(),
+            pem::parse(bytes)?.contents(),
         )?))
     }
 

--- a/ic-utils/src/call/expiry.rs
+++ b/ic-utils/src/call/expiry.rs
@@ -5,10 +5,11 @@ use time::OffsetDateTime;
 
 /// An expiry value. Either not specified (the default), a delay relative to the time the
 /// call is made, or a specific date time.
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Default)]
 pub enum Expiry {
     /// Unspecified. Will not try to override the Agent's value, which might itself have
     /// its own default value.
+    #[default]
     Unspecified,
 
     /// A duration that will be added to the system time when the call is made.
@@ -63,11 +64,5 @@ impl From<SystemTime> for Expiry {
 impl From<OffsetDateTime> for Expiry {
     fn from(dt: OffsetDateTime) -> Self {
         Self::DateTime(dt)
-    }
-}
-
-impl Default for Expiry {
-    fn default() -> Self {
-        Expiry::Unspecified
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.71.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
# Description

ProdSec recommends bumping the Rust version to 1.71.1

# How Has This Been Tested?

CI

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
