### PR TITLE
chore: QoL improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##  Unreleased
 
+* Add `From` trait to coerce `candid::Error` into `ic_agent::AgentError`.
+* Add `Agent::set_arc_identity` method to switch identity.
+
 ## [0.26.1] - 2023-08-22
 
 Switched from rustls crate to rustls-webpki fork to address https://rustsec.org/advisories/RUSTSEC-2023-0052

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -180,6 +180,12 @@ impl Display for RejectResponse {
     }
 }
 
+impl From<candid::Error> for AgentError {
+    fn from(e: candid::Error) -> AgentError {
+        AgentError::CandidError(e.into())
+    }
+}
+
 /// A HTTP error from the replica.
 pub struct HttpErrorPayload {
     /// The HTTP status code.

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -285,6 +285,14 @@ impl Agent {
     {
         self.identity = Arc::new(identity);
     }
+    /// Set the arc identity provider for signing messages.
+    ///
+    /// NOTE: if you change the identity while having update calls in
+    /// flight, you will not be able to [Agent::poll] the status of these
+    /// messages.
+    pub fn set_arc_identity(&mut self, identity: Arc<dyn Identity>) {
+        self.identity = identity;
+    }
 
     /// By default, the agent is configured to talk to the main Internet Computer, and verifies
     /// responses using a hard-coded public key.


### PR DESCRIPTION
# Description

* Add `From` trait to coerce `candid::Error` into `ic_agent::AgentError`.
* Add `Agent::set_arc_identity` method to switch identity.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
