### PR TITLE
feat: sign delegations and arbitrary data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##  Unreleased
 
+* feat: Added `public_key`, `sign_arbitrary`, `sign_delegation` functions to `Identity`.
+
 ## [0.26.1] - 2023-08-22
 
 Switched from rustls crate to rustls-webpki fork to address https://rustsec.org/advisories/RUSTSEC-2023-0052

--- a/ic-agent/src/identity/anonymous.rs
+++ b/ic-agent/src/identity/anonymous.rs
@@ -11,10 +11,21 @@ impl Identity for AnonymousIdentity {
         Ok(Principal::anonymous())
     }
 
+    fn public_key(&self) -> Option<Vec<u8>> {
+        None
+    }
+
     fn sign(&self, _: &EnvelopeContent) -> Result<Signature, String> {
         Ok(Signature {
             signature: None,
             public_key: None,
+        })
+    }
+
+    fn sign_arbitrary(&self, _: &[u8]) -> Result<Signature, String> {
+        Ok(Signature {
+            public_key: None,
+            signature: None,
         })
     }
 }

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -49,6 +49,8 @@ pub trait Identity: Send + Sync {
 
     /// Sign a delegation to let another key be used to authenticate [`sender`](Identity::sender).
     ///
+    /// Not all `Identity` implementations support this operation.
+    ///
     /// Implementors should call `content.signable()` for the actual bytes that need to be signed.
     fn sign_delegation(&self, content: &Delegation) -> Result<Signature, String> {
         let _ = content; // silence unused warning
@@ -83,13 +85,15 @@ pub struct Delegation {
     pub senders: Option<Vec<Principal>>,
 }
 
+const IC_REQUEST_DELEGATION_DOMAIN_SEPARATOR: &[u8] = b"\x1Aic-request-auth-delegation";
+
 impl Delegation {
     /// Returns the signable form of the delegation, by running it through [`to_request_id`]
     /// and prepending `\x1Aic-request-auth-delegation` to the result.
     pub fn signable(&self) -> Vec<u8> {
         let hash = to_request_id(self).unwrap();
         let mut bytes = Vec::with_capacity(59);
-        bytes.extend_from_slice(b"\x1Aic-request-auth-delegation");
+        bytes.extend_from_slice(IC_REQUEST_DELEGATION_DOMAIN_SEPARATOR);
         bytes.extend_from_slice(hash.as_slice());
         bytes
     }

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -1,5 +1,7 @@
 //! Types and traits dealing with identity across the Internet Computer.
-use crate::{agent::EnvelopeContent, export::Principal};
+use crate::{agent::EnvelopeContent, export::Principal, to_request_id};
+
+use serde::{Deserialize, Serialize};
 
 pub(crate) mod anonymous;
 pub(crate) mod basic;
@@ -24,10 +26,10 @@ pub struct Signature {
     pub signature: Option<Vec<u8>>,
 }
 
-/// An Identity takes a request id and returns the [Signature]. It knows or
-/// represents the Principal of the sender.
+/// An `Identity` produces [`Signatures`](Signature) for requests or delegations. It knows or
+/// represents the [`Principal`] of the sender.
 ///
-/// Agents are assigned a single Identity object, but there can be multiple
+/// [`Agents`](crate::Agent) are assigned a single `Identity` object, but there can be multiple
 /// identities used.
 pub trait Identity: Send + Sync {
     /// Returns a sender, ie. the Principal ID that is used to sign a request.
@@ -35,8 +37,60 @@ pub trait Identity: Send + Sync {
     /// Only one sender can be used per request.
     fn sender(&self) -> Result<Principal, String>;
 
+    /// Produce the public key commonly returned in [`Signature`].
+    ///
+    /// May return `None` when [`sign`](Identity::sign) would return `Some`.
+    fn public_key(&self) -> Option<Vec<u8>>;
+
     /// Sign a request ID derived from a content map.
     ///
     /// Implementors should call `content.to_request_id().signable()` for the actual bytes that need to be signed.
     fn sign(&self, content: &EnvelopeContent) -> Result<Signature, String>;
+
+    /// Sign a delegation to let another key be used to authenticate [`sender`](Identity::sender).
+    ///
+    /// Implementors should call `content.signable()` for the actual bytes that need to be signed.
+    fn sign_delegation(&self, content: &Delegation) -> Result<Signature, String> {
+        let _ = content; // silence unused warning
+        Err(String::from("unsupported"))
+    }
+
+    /// Sign arbitrary bytes.
+    ///
+    /// Not all `Identity` implementations support this operation.
+    fn sign_arbitrary(&self, content: &[u8]) -> Result<Signature, String> {
+        let _ = content; // silence unused warning
+        Err(String::from("unsupported"))
+    }
+}
+
+/// A delegation from one key to another.
+///
+/// If key A signs a delegation containing key B, then key B may be used to
+/// authenticate as key A's corresponding principal(s).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Delegation {
+    /// The delegated-to key.
+    #[serde(with = "serde_bytes")]
+    pub pubkey: Vec<u8>,
+    /// A nanosecond timestamp after which this delegation is no longer valid.
+    pub expiration: u64,
+    /// If present, this delegation only applies to requests sent to one of these canisters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub targets: Option<Vec<Principal>>,
+    /// If present, this delegation only applies to requests originating from one of these principals.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub senders: Option<Vec<Principal>>,
+}
+
+impl Delegation {
+    /// Returns the signable form of the delegation, by running it through [`to_request_id`]
+    /// and prepending `\x1Aic-request-auth-delegation` to the result.
+    pub fn signable(&self) -> Vec<u8> {
+        let hash = to_request_id(self).unwrap();
+        let mut bytes = Vec::with_capacity(59);
+        bytes.extend_from_slice(b"\x1Aic-request-auth-delegation");
+        bytes.extend_from_slice(hash.as_slice());
+        bytes
+    }
 }

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -39,7 +39,7 @@ pub trait Identity: Send + Sync {
 
     /// Produce the public key commonly returned in [`Signature`].
     ///
-    /// May return `None` when [`sign`](Identity::sign) would return `Some`.
+    /// May return `None` when [`sign`](Identity::sign) would return `Some`, in non-`ic-agent` identities.
     fn public_key(&self) -> Option<Vec<u8>>;
 
     /// Sign a request ID derived from a content map.
@@ -49,7 +49,7 @@ pub trait Identity: Send + Sync {
 
     /// Sign a delegation to let another key be used to authenticate [`sender`](Identity::sender).
     ///
-    /// Not all `Identity` implementations support this operation.
+    /// Not all `Identity` implementations support this operation, though all `ic-agent` implementations other than `AnonymousIdentity` do.
     ///
     /// Implementors should call `content.signable()` for the actual bytes that need to be signed.
     fn sign_delegation(&self, content: &Delegation) -> Result<Signature, String> {
@@ -59,7 +59,7 @@ pub trait Identity: Send + Sync {
 
     /// Sign arbitrary bytes.
     ///
-    /// Not all `Identity` implementations support this operation.
+    /// Not all `Identity` implementations support this operation, though all `ic-agent` implementations do.
     fn sign_arbitrary(&self, content: &[u8]) -> Result<Signature, String> {
         let _ = content; // silence unused warning
         Err(String::from("unsupported"))

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -39,7 +39,7 @@ pub trait Identity: Send + Sync {
 
     /// Produce the public key commonly returned in [`Signature`].
     ///
-    /// May return `None` when [`sign`](Identity::sign) would return `Some`, in non-`ic-agent` identities.
+    /// Should only return `None` if `sign` would do the same.
     fn public_key(&self) -> Option<Vec<u8>>;
 
     /// Sign a request ID derived from a content map.

--- a/ic-identity-hsm/src/hsm.rs
+++ b/ic-identity-hsm/src/hsm.rs
@@ -1,4 +1,6 @@
-use ic_agent::{agent::EnvelopeContent, export::Principal, Identity, Signature};
+use ic_agent::{
+    agent::EnvelopeContent, export::Principal, identity::Delegation, Identity, Signature,
+};
 
 use pkcs11::{
     types::{
@@ -136,12 +138,25 @@ impl Identity for HardwareIdentity {
     fn sender(&self) -> Result<Principal, String> {
         Ok(Principal::self_authenticating(&self.public_key))
     }
+
+    fn public_key(&self) -> Option<Vec<u8>> {
+        Some(self.public_key.clone())
+    }
+
     fn sign(&self, content: &EnvelopeContent) -> Result<Signature, String> {
-        let hash = Sha256::digest(content.to_request_id().signable());
+        self.sign_arbitrary(&content.to_request_id().signable())
+    }
+
+    fn sign_delegation(&self, content: &Delegation) -> Result<Signature, String> {
+        self.sign_arbitrary(&content.signable())
+    }
+
+    fn sign_arbitrary(&self, content: &[u8]) -> Result<Signature, String> {
+        let hash = Sha256::digest(content);
         let signature = self.sign_hash(&hash)?;
 
         Ok(Signature {
-            public_key: Some(self.public_key.clone()),
+            public_key: self.public_key(),
             signature: Some(signature),
         })
     }


### PR DESCRIPTION
The two things an identity is expected to sign in the IC spec are content maps and delegations; this PR adds delegations where ic-agent currently only supports the content map.

This PR also partially reverts the constriction imposed in #443 to re-allow arbitrary garbage to be signed without being a valid content map; it, like delegations, is an explicitly *optional* feature of the Identity trait which not all implementations support.

Finally a `public_key` function is added so `sign_arbitrary(&[])` is not required in order to get the unhashed public key for the identity.