### PR TITLE
chore: Fix clippy in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
           rustup default ${{ matrix.rust }}
           rustup target add wasm32-unknown-unknown
       - name: Run Lint
-        run: cargo clippy --verbose --tests --benches -- -D clippy::all
+        run: cargo clippy --verbose --tests --benches -- -D warnings
         env:
           RUST_BACKTRACE: 1
       - name: Run Lint (WASM)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.65.0"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-ic-agent = { path = "ic-agent", version = "0.26.1" }
+ic-agent = { path = "ic-agent", version = "0.26.1", default-features = false }
 ic-utils = { path = "ic-utils", version = "0.26.1" }
 ic-certification = { path = "ic-certification", version = "0.26.1" }
 

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -30,7 +30,7 @@ semver = "1.0.7"
 once_cell = "1.10.0"
 
 [dev-dependencies]
-ic-agent = { workspace = true }
+ic-agent = { workspace = true, default-features = true }
 ring = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -24,7 +24,7 @@ candid = { workspace = true, features = ["parser"] }
 clap = { version = "3.0.14", features = ["derive", "cargo"] }
 hex = { workspace = true }
 humantime = "2.0.1"
-ic-agent = { workspace = true }
+ic-agent = { workspace = true, default-features = true }
 ic-utils = { workspace = true }
 ring = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
The lint action is set as `-Dclippy::all`. This errors on any Clippy lint, but not on rustc lints. The correct flag to forbid all warning lints is `-Dwarnings`.