### PR TITLE
fix: remove argument builder from ic-utils

### DIFF
--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -16,10 +16,10 @@ sudo apt-get install --yes bats
 
 # Install Bats support.
 version=0.3.0
-wget https://github.com/ztombol/bats-support/archive/v$version.tar.gz
+curl --location --output bats-support.tar.gz https://github.com/ztombol/bats-support/archive/v$version.tar.gz
 sudo mkdir /usr/local/lib/bats-support
-sudo tar --directory /usr/local/lib/bats-support --extract --file v$version.tar.gz --strip-components 1
-rm v$version.tar.gz
+sudo tar --directory /usr/local/lib/bats-support --extract --file bats-support.tar.gz --strip-components 1
+rm bats-support.tar.gz
 
 # Install DFINITY SDK.
 wget --output-document install-dfx.sh "https://sdk.dfinity.org/install.sh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##  Unreleased
 
-* Breaking change: Remove argument builder form `ic-utils`. `CallBuilder::with_arg` replaces the argument, instead of pushing a new argument to the list. If you have multiple arguments, use `CallBuilder::set_raw_arg(candid::Encode!(arg1, arg2)?)` instead.
+* Breaking change: Remove argument builder form `ic-utils`. `CallBuilder::with_arg` sets a single argument, instead of pushing a new argument to the list. This function can be called at most once. If it's called multiple times, it panics. If you have multiple arguments, use `CallBuilder::with_args((arg1, arg2))` or `CallBuilder::set_raw_arg(candid::Encode!(arg1, arg2)?)`.
 * feat: Added `public_key`, `sign_arbitrary`, `sign_delegation` functions to `Identity`.
 * Add `From` trait to coerce `candid::Error` into `ic_agent::AgentError`.
 * Add `Agent::set_arc_identity` method to switch identity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##  Unreleased
 
+* Breaking change: Remove argument builder form `ic-utils`. `CallBuilder::with_arg` replaces the argument, instead of pushing a new argument to the list. If you have multiple arguments, use `CallBuilder::set_raw_arg(candid::Encode!(arg1, arg2)?)` instead.
 * feat: Added `public_key`, `sign_arbitrary`, `sign_delegation` functions to `Identity`.
 * Add `From` trait to coerce `candid::Error` into `ic_agent::AgentError`.
 * Add `Agent::set_arc_identity` method to switch identity.

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -4,15 +4,9 @@ use ic_agent::{agent::UpdateBuilder, export::Principal, Agent, AgentError, Reque
 use serde::de::DeserializeOwned;
 use std::fmt;
 use std::future::Future;
-use std::pin::Pin;
 
 mod expiry;
 pub use expiry::Expiry;
-
-#[cfg(target_family = "wasm")]
-pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
-#[cfg(not(target_family = "wasm"))]
-pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a + Send>>;
 
 /// A type that implements synchronous calls (ie. 'query' calls).
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
@@ -102,15 +96,14 @@ where
     ///     .create_canister()
     ///     .as_provisional_create_with_amount(None)
     ///     .with_effective_canister_id(effective_id)
-    ///     .and_then(|(canister_id,)| {
-    ///         let call = management_canister
-    ///             .install_code(&canister_id, canister_wasm)
-    ///             .build()
-    ///             .unwrap();
-    ///         async move {
-    ///             call.call_and_wait().await?;
-    ///             Ok((canister_id,))
-    ///         }
+    ///     .and_then(|(canister_id,)| async move {
+    ///       management_canister
+    ///         .install_code(&canister_id, canister_wasm)
+    ///         .build()
+    ///         .unwrap()
+    ///         .call_and_wait()
+    ///         .await?;
+    ///       Ok((canister_id,))
     ///     })
     ///     .call_and_wait()
     ///     .await?;

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -181,10 +181,13 @@ impl Argument {
     }
 
     /// Creates an argument from an existing Candid ArgumentEncoder.
-    pub fn from_candid(tuple: impl ArgumentEncoder) -> Result<Self, AgentError> {
+    pub fn from_candid(tuple: impl ArgumentEncoder) -> Self {
         let mut builder = IDLBuilder::new();
-        tuple.encode(&mut builder)?;
-        Ok(Self(Ok(builder.serialize_to_vec()?)))
+        let result = tuple
+            .encode(&mut builder)
+            .and_then(|_| builder.serialize_to_vec())
+            .map_err(|e| e.into());
+        Self(result)
     }
 }
 

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -138,7 +138,7 @@ impl Argument {
     pub fn set_idl_arg<A: CandidType>(&mut self, arg: A) {
         match self.0 {
             None => self.0 = Some(Encode!(&arg).map_err(|e| e.into())),
-            Some(_) => panic!("argument is being set for more than once"),
+            Some(_) => panic!("argument is being set more than once"),
         }
     }
 
@@ -153,7 +153,7 @@ impl Argument {
                     .map_err(|e| e.into());
                 self.0 = Some(result);
             }
-            Some(_) => panic!("argument is being set for more than once"),
+            Some(_) => panic!("argument is being set more than once"),
         }
     }
 
@@ -161,7 +161,7 @@ impl Argument {
     pub fn set_raw_arg(&mut self, arg: Vec<u8>) {
         match self.0 {
             None => self.0 = Some(Ok(arg)),
-            Some(_) => panic!("argument is being set for more than once"),
+            Some(_) => panic!("argument is being set more than once"),
         }
     }
 
@@ -234,7 +234,7 @@ impl<'agent, 'canister: 'agent> SyncCallBuilder<'agent, 'canister> {
     /// Set the argument with multiple arguments as tuple. Can be called at most once.
     pub fn with_args(mut self, tuple: impl ArgumentEncoder) -> SyncCallBuilder<'agent, 'canister> {
         if self.arg.0.is_some() {
-            panic!("argument is being set for more than once");
+            panic!("argument is being set more than once");
         }
         self.arg = Argument::from_candid(tuple);
         self
@@ -319,7 +319,7 @@ impl<'agent, 'canister: 'agent> AsyncCallBuilder<'agent, 'canister> {
     /// Set the argument with multiple arguments as tuple. Can be called at most once.
     pub fn with_args(mut self, tuple: impl ArgumentEncoder) -> AsyncCallBuilder<'agent, 'canister> {
         if self.arg.0.is_some() {
-            panic!("argument is being set for more than once");
+            panic!("argument is being set more than once");
         }
         self.arg = Argument::from_candid(tuple);
         self

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -135,14 +135,14 @@ pub struct Argument(Result<Vec<u8>, AgentError>);
 
 impl Argument {
     /// Set an IDL Argument, replacing existing arguments. If the current value is an error, will do nothing.
-    pub fn push_idl_arg<A: CandidType>(&mut self, arg: A) {
+    pub fn set_idl_arg<A: CandidType>(&mut self, arg: A) {
         if self.0.is_ok() {
             self.0 = Encode!(&arg).map_err(|e| e.into());
         }
     }
 
     /// Set an IDLValue Argument, replacing existing arguments. If the current value is an error, will do nothing.
-    pub fn push_value_arg(&mut self, arg: IDLValue) {
+    pub fn set_value_arg(&mut self, arg: IDLValue) {
         if self.0.is_ok() {
             let mut builder = IDLBuilder::new();
             let result = builder
@@ -226,7 +226,7 @@ impl<'agent, 'canister: 'agent> SyncCallBuilder<'agent, 'canister> {
     where
         Argument: CandidType + Sync + Send,
     {
-        self.arg.push_idl_arg(arg);
+        self.arg.set_idl_arg(arg);
         self
     }
 
@@ -234,7 +234,7 @@ impl<'agent, 'canister: 'agent> SyncCallBuilder<'agent, 'canister> {
     ///
     /// TODO: make this method unnecessary ([#132](https://github.com/dfinity/agent-rs/issues/132))
     pub fn with_value_arg(mut self, arg: IDLValue) -> SyncCallBuilder<'agent, 'canister> {
-        self.arg.push_value_arg(arg);
+        self.arg.set_value_arg(arg);
         self
     }
 
@@ -304,7 +304,7 @@ impl<'agent, 'canister: 'agent> AsyncCallBuilder<'agent, 'canister> {
     where
         Argument: CandidType + Sync + Send,
     {
-        self.arg.push_idl_arg(arg);
+        self.arg.set_idl_arg(arg);
         self
     }
 

--- a/ic-utils/src/canister.rs
+++ b/ic-utils/src/canister.rs
@@ -131,7 +131,7 @@ impl<'agent> Canister<'agent> {
 
 /// A buffer to hold canister argument blob.
 #[derive(Debug, Default)]
-pub struct Argument(Option<Result<Vec<u8>, AgentError>>);
+pub struct Argument(pub(crate) Option<Result<Vec<u8>, AgentError>>);
 
 impl Argument {
     /// Set an IDL Argument. Can only be called at most once.

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -399,7 +399,7 @@ impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
     /// which will be passed to the init method of the canister. Can be called at most once.
     pub fn with_args(mut self, tuple: impl candid::utils::ArgumentEncoder) -> Self {
         if self.arg.0.is_some() {
-            panic!("argument is being set for more than once");
+            panic!("argument is being set more than once");
         }
         self.arg = Argument::from_candid(tuple);
         self

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -1,10 +1,7 @@
 //! Builder interfaces for some method calls of the management canister.
 
 use crate::{
-    call::{AsyncCall, BoxFuture},
-    canister::Argument,
-    interfaces::management_canister::MgmtMethod,
-    Canister,
+    call::AsyncCall, canister::Argument, interfaces::management_canister::MgmtMethod, Canister,
 };
 use async_trait::async_trait;
 use candid::{CandidType, Deserialize, Nat};
@@ -440,20 +437,15 @@ impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
     }
 }
 
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<'agent, 'canister: 'agent> AsyncCall<()> for InstallCodeBuilder<'agent, 'canister> {
-    fn call<'async_trait>(self) -> BoxFuture<'async_trait, Result<RequestId, AgentError>>
-    where
-        Self: 'async_trait,
-    {
-        let call_res = self.build();
-        Box::pin(async move { call_res?.call().await })
+    async fn call(self) -> Result<RequestId, AgentError> {
+        self.build()?.call().await
     }
-    fn call_and_wait<'async_trait>(self) -> BoxFuture<'async_trait, Result<(), AgentError>>
-    where
-        Self: 'async_trait,
-    {
-        let call_res = self.build();
-        Box::pin(async move { call_res?.call_and_wait().await })
+
+    async fn call_and_wait(self) -> Result<(), AgentError> {
+        self.build()?.call_and_wait().await
     }
 }
 

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -392,7 +392,7 @@ impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
         mut self,
         arg: Argument,
     ) -> InstallCodeBuilder<'agent, 'canister> {
-        self.arg.push_idl_arg(arg);
+        self.arg.set_idl_arg(arg);
         self
     }
 

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -386,8 +386,8 @@ impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
         }
     }
 
-    /// Add an argument to the installation, which will be passed to the init
-    /// method of the canister.
+    /// Set the argument to the installation, which will be passed to the init
+    /// method of the canister. Can be called at most once.
     pub fn with_arg<Argument: CandidType + Sync + Send>(
         mut self,
         arg: Argument,
@@ -395,8 +395,16 @@ impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
         self.arg.set_idl_arg(arg);
         self
     }
-
-    /// Override the argument passed in to the canister with raw bytes.
+    /// Set the argument with multiple arguments as tuple to the installation,
+    /// which will be passed to the init method of the canister. Can be called at most once.
+    pub fn with_args(mut self, tuple: impl candid::utils::ArgumentEncoder) -> Self {
+        if self.arg.0.is_some() {
+            panic!("argument is being set for more than once");
+        }
+        self.arg = Argument::from_candid(tuple);
+        self
+    }
+    /// Set the argument passed in to the canister with raw bytes. Can be called at most once.
     pub fn with_raw_arg(mut self, arg: Vec<u8>) -> InstallCodeBuilder<'agent, 'canister> {
         self.arg.set_raw_arg(arg);
         self

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -56,8 +56,7 @@ impl<'agent, 'canister: 'agent, Out> CallForwarder<'agent, 'canister, Out>
 where
     Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
 {
-    /// Add an argument to the candid argument list. This requires Candid arguments, if
-    /// there is a raw argument set (using [`with_arg_raw`](CallForwarder::with_arg_raw)), this will fail.
+    /// Set the argument with candid argument. Can be called at most once.
     pub fn with_arg<Argument>(mut self, arg: Argument) -> Self
     where
         Argument: CandidType + Sync + Send,
@@ -65,9 +64,16 @@ where
         self.arg.set_idl_arg(arg);
         self
     }
+    /// Set the argument with multiple arguments as tuple. Can be called at most once.
+    pub fn with_args(mut self, tuple: impl candid::utils::ArgumentEncoder) -> Self {
+        if self.arg.0.is_some() {
+            panic!("argument is being set for more than once");
+        }
+        self.arg = Argument::from_candid(tuple);
+        self
+    }
 
-    /// Replace the argument with raw argument bytes. This will overwrite the current
-    /// argument set, so calling this method twice will discard the first argument.
+    /// Set the argument with raw argument bytes. Can be called at most once.
     pub fn with_arg_raw(mut self, arg: Vec<u8>) -> Self {
         self.arg.set_raw_arg(arg);
         self

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -2,10 +2,10 @@
 //!
 //! [cycles wallet]: https://github.com/dfinity/cycles-wallet
 
-use std::{future::Future, ops::Deref};
+use std::ops::Deref;
 
 use crate::{
-    call::{AsyncCall, BoxFuture, SyncCall},
+    call::{AsyncCall, SyncCall},
     canister::Argument,
     interfaces::management_canister::{
         attributes::{ComputeAllocation, FreezingThreshold, MemoryAllocation},
@@ -13,6 +13,7 @@ use crate::{
     },
     Canister,
 };
+use async_trait::async_trait;
 use candid::{decode_args, utils::ArgumentDecoder, CandidType, Deserialize, Nat};
 use ic_agent::{agent::RejectCode, export::Principal, Agent, AgentError, RequestId};
 use once_cell::sync::Lazy;
@@ -110,34 +111,28 @@ where
     }
 
     /// Calls the forwarded canister call on the wallet canister. Equivalent to `.build().call()`.
-    pub fn call(self) -> impl Future<Output = Result<RequestId, AgentError>> + 'agent {
-        let call_res = self.build();
-        async move { call_res?.call().await }
+    pub async fn call(self) -> Result<RequestId, AgentError> {
+        self.build()?.call().await
     }
 
     /// Calls the forwarded canister call on the wallet canister, and waits for the result. Equivalent to `.build().call_and_wait()`.
-    pub fn call_and_wait(self) -> impl Future<Output = Result<Out, AgentError>> + 'agent {
-        let call_res = self.build();
-        async move { call_res?.call_and_wait().await }
+    pub async fn call_and_wait(self) -> Result<Out, AgentError> {
+        self.build()?.call_and_wait().await
     }
 }
 
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<'agent, 'canister: 'agent, Out> AsyncCall<Out> for CallForwarder<'agent, 'canister, Out>
 where
     Out: for<'de> ArgumentDecoder<'de> + Send + Sync,
 {
-    fn call<'async_trait>(self) -> BoxFuture<'async_trait, Result<RequestId, AgentError>>
-    where
-        Self: 'async_trait,
-    {
-        Box::pin(self.call())
+    async fn call(self) -> Result<RequestId, AgentError> {
+        self.call().await
     }
 
-    fn call_and_wait<'async_trait>(self) -> BoxFuture<'async_trait, Result<Out, AgentError>>
-    where
-        Self: 'async_trait,
-    {
-        Box::pin(self.call_and_wait())
+    async fn call_and_wait(self) -> Result<Out, AgentError> {
+        self.call_and_wait().await
     }
 }
 

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -62,7 +62,7 @@ where
     where
         Argument: CandidType + Sync + Send,
     {
-        self.arg.push_idl_arg(arg);
+        self.arg.set_idl_arg(arg);
         self
     }
 

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -67,7 +67,7 @@ where
     /// Set the argument with multiple arguments as tuple. Can be called at most once.
     pub fn with_args(mut self, tuple: impl candid::utils::ArgumentEncoder) -> Self {
         if self.arg.0.is_some() {
-            panic!("argument is being set for more than once");
+            panic!("argument is being set more than once");
         }
         self.arg = Argument::from_candid(tuple);
         self


### PR DESCRIPTION
# Description

* Remove argument builder from `ic-utils` to prevent requiring `Send` for `candid::Type`. It's never correct to use `IDLBuilder` in the argument builder, as Candid uses `thread_local` to resolve `TypeId`, which is not `Send`.
* Reverts #454 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
