### PR TITLE
chore: Release version 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-##  Unreleased
+## Unreleased
+
+## [0.27.0] - 2023-08-30
 
 * Breaking change: Remove argument builder form `ic-utils`. `CallBuilder::with_arg` sets a single argument, instead of pushing a new argument to the list. This function can be called at most once. If it's called multiple times, it panics. If you have multiple arguments, use `CallBuilder::with_args((arg1, arg2))` or `CallBuilder::set_raw_arg(candid::Encode!(arg1, arg2)?)`.
 * feat: Added `public_key`, `sign_arbitrary`, `sign_delegation` functions to `Identity`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,9 +246,9 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "candid"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31e5ab22cdcd093b93b02bdff4ba18ffee324b05e669b25cdd93fdb8402d207"
+checksum = "762aa04e3a889d47a1773b74ee3b13438a9bc895954fff79ebf7f308c3744a6c"
 dependencies = [
  "anyhow",
  "binread",
@@ -455,12 +455,6 @@ dependencies = [
  "pem-rfc7468",
  "zeroize",
 ]
-
-[[package]]
-name = "deranged"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 
 [[package]]
 name = "diff"
@@ -967,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "backoff",
  "candid",
@@ -1010,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "hex",
  "serde",
@@ -1021,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1033,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -1064,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -1081,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -2405,11 +2399,10 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.27"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb39ee79a6d8de55f48f2293a830e040392f1c5f16e336bdd1788cd0aadce07"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
- "deranged",
  "itoa",
  "js-sys",
  "serde",
@@ -2425,9 +2418,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.13"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733d258752e9303d392b94b75230d07b0b9c489350c69b851fc6c065fde3e8f9"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.26.1"
+version = "0.27.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
@@ -21,11 +21,11 @@ rust-version = "1.65.0"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-ic-agent = { path = "ic-agent", version = "0.26.1", default-features = false }
-ic-utils = { path = "ic-utils", version = "0.26.1" }
-ic-certification = { path = "ic-certification", version = "0.26.1" }
+ic-agent = { path = "ic-agent", version = "0.27.0", default-features = false }
+ic-utils = { path = "ic-utils", version = "0.27.0" }
+ic-certification = { path = "ic-certification", version = "0.27.0" }
 
-candid = "0.9.0"
+candid = "0.9.5"
 hex = "0.4.3"
 ring = "0.16.20"
 serde = "1.0.162"


### PR DESCRIPTION
Includes the latest candid changes to eliminate arc_type.