### PR TITLE
update ic-certification version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "0.27.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1120544357d4d2f7540dd5290b952c6305afe24c9620d423e2239560adca2535"
+checksum = "a59dc342d11b2067e19d0f146bdec3674de921303ffc762f114d201ebbe0e68a"
 dependencies = [
  "hex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ic-agent = { path = "ic-agent", version = "0.28.0", default-features = false }
 ic-utils = { path = "ic-utils", version = "0.28.0" }
 ic-transport-types = { path = "ic-transport-types", version = "0.28.0" }
 
-ic-certification = "0.27.0"
+ic-certification = "1.2.0"
 candid = "0.9.5"
 clap = "4.4.3"
 hex = "0.4.3"


### PR DESCRIPTION
The version of `ic-certification` in the dfinity/response-verification repository is 1.2.0 and thus we should change the dependency of `agent-rs` to that version.