### PR TITLE
test: run e2e/integration tests vs replica rather than ic-ref

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run Integration Tests
         run: |
           set -ex
-          dfx start --background
+          dfx start --background --clean
           sleep 1
           export IC_REF_PORT=$(dfx info replica-port)
           export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
@@ -90,7 +90,7 @@ jobs:
           # create key:
           pkcs11-tool -k --module $HSM_PKCS11_LIBRARY_PATH --login --slot-index $HSM_SLOT_INDEX -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
 
-          dfx start --background
+          dfx start --background --clean
           sleep 1
           export IC_REF_PORT=$(dfx info replica-port)
           export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
@@ -109,7 +109,7 @@ jobs:
       - name: Run Doc Tests
         run: |
           set -ex
-          dfx start --background
+          dfx start --background --clean
           sleep 1
           export IC_REF_PORT=$(dfx info replica-port)
           cd main

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ic-ref-to-replica
   pull_request:
 
 jobs:
@@ -28,6 +29,11 @@ jobs:
         with:
           path: main
 
+      - name: Install dfx
+        uses: dfinity/setup-dfx@main
+        with:
+          dfx-version: "0.15.0"
+
       - name: Cargo cache
         uses: actions/cache@v2
         with:
@@ -48,13 +54,8 @@ jobs:
           wget https://github.com/dfinity/cycles-wallet/releases/download/${{ matrix.wallet-tag }}/wallet.wasm
           mv wallet.wasm $HOME/wallet.wasm
 
-      - name: Download ic-ref and universal-canister
+      - name: Download universal-canister
         run: |
-          wget https://download.dfinity.systems/ic-ref/ic-ref-0.0.1-${{ matrix.ic-hs-ref }}-x86_64-linux.tar.gz
-          tar -xvf ic-ref-0.0.1-${{ matrix.ic-hs-ref }}-x86_64-linux.tar.gz ic-ref
-          mkdir -p $HOME/bin
-          mv ic-ref $HOME/bin/ic-ref
-
           wget https://download.dfinity.systems/ic-ref/ic-ref-test-0.0.1-${{ matrix.ic-hs-ref }}-x86_64-linux.tar.gz
           tar -xvf ic-ref-test-0.0.1-${{ matrix.ic-hs-ref }}-x86_64-linux.tar.gz test-data/universal-canister.wasm
           mv test-data/universal-canister.wasm $HOME/canister.wasm
@@ -62,14 +63,14 @@ jobs:
       - name: Run Integration Tests
         run: |
           set -ex
-          $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
+          dfx start --background
           sleep 1
-          export IC_REF_PORT=$(cat $HOME/ic_ref_port)
+          export IC_REF_PORT=$(dfx info replica-port)
           export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
           export IC_WALLET_CANISTER_PATH=$HOME/wallet.wasm
           cd main
           cargo test --all-features -- --ignored
-          killall ic-ref
+          dfx stop
         env:
           RUST_BACKTRACE: 1
 
@@ -89,14 +90,14 @@ jobs:
           # create key:
           pkcs11-tool -k --module $HSM_PKCS11_LIBRARY_PATH --login --slot-index $HSM_SLOT_INDEX -d $HSM_KEY_ID --key-type EC:prime256v1 --pin $HSM_PIN
 
-          $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
+          dfx start --background
           sleep 1
-          export IC_REF_PORT=$(cat $HOME/ic_ref_port)
+          export IC_REF_PORT=$(dfx info replica-port)
           export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
           export IC_WALLET_CANISTER_PATH=$HOME/wallet.wasm
           cd main/ref-tests
           cargo test --all-features -- --ignored --nocapture --test-threads=1
-          killall ic-ref
+          dfx stop
         env:
           RUST_BACKTRACE: 1
           HSM_PKCS11_LIBRARY_PATH: /usr/lib/softhsm/libsofthsm2.so
@@ -108,12 +109,12 @@ jobs:
       - name: Run Doc Tests
         run: |
           set -ex
-          $HOME/bin/ic-ref --pick-port --write-port-to $HOME/ic_ref_port &
+          dfx start --background
           sleep 1
-          export IC_REF_PORT=$(cat $HOME/ic_ref_port)
+          export IC_REF_PORT=$(dfx info replica-port)
           cd main
           cargo test --all-features --doc -- --ignored
-          killall ic-ref
+          dfx stop
         env:
           RUST_BACKTRACE: 1
 

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ic-ref-to-replica
   pull_request:
 
 jobs:

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -640,7 +640,12 @@ mod management_canister {
 
             let creation_fee = 8000000000;
             let (create_result,): (CreateResult,) = wallet
-                .call(Principal::management_canister(), "create_canister", args, creation_fee)
+                .call(
+                    Principal::management_canister(),
+                    "create_canister",
+                    args,
+                    creation_fee,
+                )
                 .call_and_wait()
                 .await?;
             let canister_id = create_result.canister_id;

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -929,7 +929,7 @@ mod extras {
                     reject_code: RejectCode::DestinationInvalid,
                     reject_message,
                     ..
-                })) if reject_message == "The specified_id of the created canister is already in use."));
+                })) if reject_message == "Canister iimsn-6yaaa-aaaaa-afiaa-cai is already installed"));
 
             Ok(())
         })

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -538,33 +538,45 @@ mod management_canister {
                 .start_canister(&canister_id)
                 .call_and_wait()
                 .await;
-            assert!(matches!(result, Err(AgentError::HttpError(payload))
-                if String::from_utf8(payload.content.clone()).expect("Expected utf8")
-                    == *"Wrong sender"));
+            assert!(matches!(result,
+                    Err(AgentError::ReplicaError(RejectResponse {
+                    reject_code: RejectCode::CanisterError,
+                    reject_message,
+                    ..
+                })) if reject_message == format!("Only controllers of canister {} can call ic00 method start_canister", canister_id)));
 
             // Stop as a wrong controller should fail.
             let result = other_ic00.stop_canister(&canister_id).call_and_wait().await;
-            assert!(matches!(result, Err(AgentError::HttpError(payload))
-                if String::from_utf8(payload.content.clone()).expect("Expected utf8")
-                    == *"Wrong sender"));
+            assert!(matches!(result,
+                    Err(AgentError::ReplicaError(RejectResponse {
+                    reject_code: RejectCode::CanisterError,
+                    reject_message,
+                    ..
+                })) if reject_message == format!("Only controllers of canister {} can call ic00 method stop_canister", canister_id)));
 
             // Get canister status as a wrong controller should fail.
             let result = other_ic00
                 .canister_status(&canister_id)
                 .call_and_wait()
                 .await;
-            assert!(matches!(result, Err(AgentError::HttpError(payload))
-                if String::from_utf8(payload.content.clone()).expect("Expected utf8")
-                    == *"Wrong sender"));
+            assert!(matches!(result,
+                    Err(AgentError::ReplicaError(RejectResponse {
+                    reject_code: RejectCode::CanisterError,
+                    reject_message,
+                    ..
+                })) if reject_message == format!("Only controllers of canister {} can call ic00 method canister_status", canister_id)));
 
             // Delete as a wrong controller should fail.
             let result = other_ic00
                 .delete_canister(&canister_id)
                 .call_and_wait()
                 .await;
-            assert!(matches!(result, Err(AgentError::HttpError(payload))
-                if String::from_utf8(payload.content.clone()).expect("Expected utf8")
-                    == *"Wrong sender"));
+            assert!(matches!(result,
+                    Err(AgentError::ReplicaError(RejectResponse {
+                    reject_code: RejectCode::CanisterError,
+                    reject_message,
+                    ..
+                })) if reject_message == format!("Only controllers of canister {} can call ic00 method delete_canister", canister_id)));
 
             Ok(())
         })

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -472,10 +472,7 @@ mod management_canister {
             );
 
             // Another start is a noop
-            let result = ic00.start_canister(&canister_id).call_and_wait().await;
-
-            // Delete a running canister should fail.
-            assert!(matches!(result, Err(AgentError::ReplicaError { .. })));
+            ic00.start_canister(&canister_id).call_and_wait().await?;
 
             // Stop should succeed.
             ic00.stop_canister(&canister_id).call_and_wait().await?;

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -637,8 +637,9 @@ mod management_canister {
 
             let args = Argument::from_candid((create_args,));
 
+            let creation_fee = 8000000000;
             let (create_result,): (CreateResult,) = wallet
-                .call(Principal::management_canister(), "create_canister", args, 0)
+                .call(Principal::management_canister(), "create_canister", args, creation_fee)
                 .call_and_wait()
                 .await?;
             let canister_id = create_result.canister_id;

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -65,7 +65,12 @@ mod management_canister {
 
     mod create_canister {
         use super::with_agent;
-        use ic_agent::{export::Principal, AgentError};
+        use ic_agent::{
+            agent::{RejectCode, RejectResponse},
+            export::Principal,
+            AgentError,
+        };
+
         use ic_utils::interfaces::ManagementCanister;
         use ref_tests::get_effective_canister_id;
         use std::str::FromStr;
@@ -103,13 +108,13 @@ mod management_canister {
                     .call_and_wait()
                     .await;
 
-                let payload_content =
-                    "canister does not exist: 75hes-oqbaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-q"
-                        .to_string();
-
                 assert!(matches!(result,
-                    Err(AgentError::HttpError(payload))
-                        if String::from_utf8(payload.content.clone()).expect("Expected utf8") == payload_content));
+                    Err(AgentError::ReplicaError(RejectResponse {
+                    reject_code: RejectCode::DestinationInvalid,
+                    reject_message,
+                    ..
+                })) if reject_message == "Canister 75hes-oqbaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-q not found"));
+
                 Ok(())
             })
         }

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -104,7 +104,10 @@ fn canister_reject_call() {
             result,
             Err(AgentError::ReplicaError(RejectResponse {
                 reject_code: RejectCode::DestinationInvalid,
-                reject_message: format!("Canister {} has no update method 'wallet_send'", alice.canister_id()),
+                reject_message: format!(
+                    "Canister {} has no update method 'wallet_send'",
+                    alice.canister_id()
+                ),
                 error_code: None
             }))
         );

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -148,7 +148,7 @@ fn wallet_canister_create_and_install() {
         let wallet = WalletCanister::create(&agent, wallet_id).await?;
 
         let create_result = wallet
-            .wallet_create_canister(1_000_000, None, None, None, None)
+            .wallet_create_canister(10_000_000_000, None, None, None, None)
             .await?;
 
         #[derive(CandidType)]

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -148,7 +148,7 @@ fn wallet_canister_create_and_install() {
         let wallet = WalletCanister::create(&agent, wallet_id).await?;
 
         let create_result = wallet
-            .wallet_create_canister(10_000_000_000, None, None, None, None)
+            .wallet_create_canister(100_000_000_000, None, None, None, None)
             .await?;
 
         #[derive(CandidType)]

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -104,7 +104,7 @@ fn canister_reject_call() {
             result,
             Err(AgentError::ReplicaError(RejectResponse {
                 reject_code: RejectCode::DestinationInvalid,
-                reject_message: "method does not exist: wallet_send".to_string(),
+                reject_message: format!("Canister {} has no update method 'wallet_send'", alice.canister_id()),
                 error_code: None
             }))
         );


### PR DESCRIPTION
# Description

Update the CI workflows that used ic-ref to instead run the replica.  Updated tests to account for differences seen when running against the replica rather than ic-ref.

This will allow us to add new tests for new replica functionality.

# How Has This Been Tested?

Updated the tests

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
