### PR TITLE
feat: Add support for reserved_cycles and reserved_cycles_limit

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dfx
         uses: dfinity/setup-dfx@main
         with:
-          dfx-version: "0.15.0"
+          dfx-version: "0.15.1-beta.0"
 
       - name: Cargo cache
         uses: actions/cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Added `reserved_cycles_limit` to canister creation and canister setting update options.
+* Added `reserved_cycles` and `reserved_cycles_limit` to canister status call result.
+
 ## [0.28.0] - 2023-09-21
 
 * Added `DelegatedIdentity`, an `Identity` implementation for consuming delegations such as those from Internet Identity.

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -74,7 +74,7 @@ impl<'agent> ManagementCanister<'agent> {
 
 /// The complete canister status information of a canister. This includes
 /// the CanisterStatus, a hash of the module installed on the canister (None if nothing installed),
-/// the contoller of the canister, the canisters memory size, and its balance in cycles.
+/// the controller of the canister, the canister's memory size, and its balance in cycles.
 #[derive(Clone, Debug, Deserialize, CandidType)]
 pub struct StatusCallResult {
     /// The status of the canister.
@@ -87,6 +87,8 @@ pub struct StatusCallResult {
     pub memory_size: Nat,
     /// The canister's cycle balance.
     pub cycles: Nat,
+    /// The canister's reserved cycles balance.
+    pub reserved_cycles: Nat,
 }
 
 /// The concrete settings of a canister.
@@ -100,6 +102,8 @@ pub struct DefiniteCanisterSettings {
     pub memory_allocation: Nat,
     /// The IC will freeze a canister protectively if it will likely run out of cycles before this amount of time, in seconds (up to `u64::MAX`), has passed.
     pub freezing_threshold: Nat,
+    /// The upper limit of the canister's reserved cycles balance.
+    pub reserved_cycles_limit: Option<Nat>,
 }
 
 impl std::fmt::Display for StatusCallResult {

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -685,6 +685,7 @@ impl<'agent> WalletCanister<'agent> {
             compute_allocation: compute_allocation.map(u8::from).map(Nat::from),
             memory_allocation: memory_allocation.map(u64::from).map(Nat::from),
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
+            reserved_cycles_limit: None,
         };
 
         self.update("wallet_create_canister")
@@ -713,6 +714,7 @@ impl<'agent> WalletCanister<'agent> {
             compute_allocation: compute_allocation.map(u8::from).map(Nat::from),
             memory_allocation: memory_allocation.map(u64::from).map(Nat::from),
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
+            reserved_cycles_limit: None,
         };
 
         self.update("wallet_create_canister128")
@@ -722,6 +724,10 @@ impl<'agent> WalletCanister<'agent> {
     }
 
     /// Create a canister through the wallet.
+    ///
+    /// This method does not have a `reserved_cycles_limit` parameter,
+    /// as the wallet does not support the setting.  If you need to create a canister
+    /// with a `reserved_cycles_limit` set, use the management canister.
     pub async fn wallet_create_canister<'canister: 'agent>(
         &'canister self,
         cycles: u128,
@@ -831,6 +837,7 @@ impl<'agent> WalletCanister<'agent> {
             compute_allocation: compute_allocation.map(u8::from).map(Nat::from),
             memory_allocation: memory_allocation.map(u64::from).map(Nat::from),
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
+            reserved_cycles_limit: None,
         };
 
         self.update("wallet_create_wallet")
@@ -859,6 +866,7 @@ impl<'agent> WalletCanister<'agent> {
             compute_allocation: compute_allocation.map(u8::from).map(Nat::from),
             memory_allocation: memory_allocation.map(u64::from).map(Nat::from),
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
+            reserved_cycles_limit: None,
         };
 
         self.update("wallet_create_wallet128")


### PR DESCRIPTION
# Description

Added support for `reserved_cycles` and `reserved_cycles_limit`.

Part of https://dfinity.atlassian.net/browse/SDK-1243

# How Has This Been Tested?

Added tests

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
