### PR TITLE
chore: Raise MSRV to 1.70.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,10 +23,6 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
-      - name: Install Rust
-        uses: ructions/toolchain@v2
-        with:
-          profile: minimal
 
       - name: Provision Darwin
         if: contains(matrix.os, 'macos')

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-latest, ubuntu-latest ]
-        rust: [ '1.65.0' ]
         dfx: [ '0.8.4', '0.9.2', '0.10.1', '0.11.1' ]
 
     steps:
@@ -25,10 +24,9 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
       - name: Install Rust
-        run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
-          rustup component add rustfmt
+        uses: ructions/toolchain@v2
+        with:
+          profile: minimal
 
       - name: Provision Darwin
         if: contains(matrix.os, 'macos')

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.65.0"]
         os: [ubuntu-latest]
 
     steps:
@@ -24,10 +23,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
       - name: Install Rust
-        run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
-          rustup component add rustfmt
+        uses: ructions/toolchain@v2
+        with:
+          profile: minimal
+          components: rustfmt
       - name: Run Cargo Fmt
         run: cargo fmt --all -- --check
         env:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -22,11 +22,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
-      - name: Install Rust
-        uses: ructions/toolchain@v2
-        with:
-          profile: minimal
-          components: rustfmt
       - name: Run Cargo Fmt
         run: cargo fmt --all -- --check
         env:

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -24,8 +24,6 @@ jobs:
           node-version: 16
 
       - uses: actions/checkout@v2
-        with:
-          path: main
 
       - name: Install dfx
         uses: dfinity/setup-dfx@main
@@ -65,7 +63,6 @@ jobs:
           export IC_REF_PORT=$(dfx info replica-port)
           export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
           export IC_WALLET_CANISTER_PATH=$HOME/wallet.wasm
-          cd main
           cargo test --all-features -- --ignored
           dfx stop
         env:
@@ -92,7 +89,7 @@ jobs:
           export IC_REF_PORT=$(dfx info replica-port)
           export IC_UNIVERSAL_CANISTER_PATH=$HOME/canister.wasm
           export IC_WALLET_CANISTER_PATH=$HOME/wallet.wasm
-          cd main/ref-tests
+          cd ref-tests
           cargo test --all-features -- --ignored --nocapture --test-threads=1
           dfx stop
         env:
@@ -109,7 +106,6 @@ jobs:
           dfx start --background --clean
           sleep 1
           export IC_REF_PORT=$(dfx info replica-port)
-          cd main
           cargo test --all-features --doc -- --ignored
           dfx stop
         env:

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -39,11 +39,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install Rust
-        uses: ructions/toolchain@v2
-        with:
-          profile: minimal
-
       - name: Download cycles-wallet canister
         run: |
           wget https://github.com/dfinity/cycles-wallet/releases/download/${{ matrix.wallet-tag }}/wallet.wasm

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -17,7 +17,6 @@ jobs:
             ic-hs-ref: "3d71032e"
             wallet-tag: "20230308"
             os: ubuntu-latest
-            rust: "1.65.0"
 
     steps:
       - uses: actions/setup-node@v3
@@ -43,10 +42,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Rust
-        run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
-          rustup target add wasm32-unknown-unknown
+        uses: ructions/toolchain@v2
+        with:
+          profile: minimal
 
       - name: Download cycles-wallet canister
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,11 +21,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install Rust
-        uses: ructions/toolchain@v2
-        with:
-          profile: minimal
-          components: clippy
       - name: Run Lint
         run: cargo clippy --verbose --tests --benches -- -D warnings
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.65.0"]
         os: [ubuntu-latest]
 
     steps:
@@ -23,17 +22,16 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Rust
-        run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup component add clippy
-          rustup default ${{ matrix.rust }}
-          rustup target add wasm32-unknown-unknown
+        uses: ructions/toolchain@v2
+        with:
+          profile: minimal
+          components: clippy
       - name: Run Lint
         run: cargo clippy --verbose --tests --benches -- -D warnings
         env:
           RUST_BACKTRACE: 1
       - name: Run Lint (WASM)
-        run: CARGO_TARGET_DIR=target/wasm cargo clippy --target wasm32-unknown-unknown -p ic-agent --features wasm-bindgen -p ic-utils --verbose -- -D clippy::all
+        run: CARGO_TARGET_DIR=target/wasm cargo clippy --target wasm32-unknown-unknown -p ic-agent --features wasm-bindgen -p ic-utils --verbose -- -D warnings
   aggregate:
     name: lint:required
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   build:
@@ -14,11 +15,13 @@ jobs:
         include:
           - os: ubuntu-latest
             name: linux
+            target: x86_64-unknown-linux-musl
             binary_path: target/x86_64-unknown-linux-musl/release
             binary_files: icx
           - os: macos-latest
             name: macos
-            binary_path: target/release
+            target: x86_64-apple-darwin
+            binary_path: target/x86_64-apple-darwin/release
             binary_files: icx
     steps:
     - uses: actions/checkout@master
@@ -41,7 +44,7 @@ jobs:
       uses: ructions/cargo@v1
       with:
         command: build
-        args: --target x86_64-unknown-linux-musl ${{ env.cargo_build_ARGS }}
+        args: --target ${{ matrix.target }} ${{ env.cargo_build_ARGS }}
         use-cross: ${{ contains(matrix.os, 'ubuntu') }}
 
     - name: Strip binaries
@@ -58,9 +61,11 @@ jobs:
       if: contains(matrix.os, 'macos')
 
     - name: Create tarball of binaries
+      if: ${{ github.ref_type == 'tag' }}
       run: tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz ${{ matrix.binary_files }}
 
     - name: Upload tarball
+      if: ${{ github.ref_type == 'tag' }}
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        name: ['linux', 'macos']
         include:
           - os: ubuntu-latest
             name: linux
@@ -61,11 +62,11 @@ jobs:
       if: contains(matrix.os, 'macos')
 
     - name: Create tarball of binaries
-      if: ${{ github.ref_type == 'tag' }}
+      if: ${{ github.event_name == 'push' }}
       run: tar -zcC ${{ matrix.binary_path }} -f binaries.tar.gz ${{ matrix.binary_files }}
 
     - name: Upload tarball
-      if: ${{ github.ref_type == 'tag' }}
+      if: ${{ github.event_name == 'push' }}
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,6 @@ jobs:
         echo "--locked --release $binaries" >> $GITHUB_ENV
         echo "END" >> $GITHUB_ENV
 
-    - name: Install Rust toolchain
-      uses: ructions/toolchain@v2
-      with:
-        profile: minimal
-
     - name: Build
       uses: ructions/cargo@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,10 @@ jobs:
             name: linux
             binary_path: target/x86_64-unknown-linux-musl/release
             binary_files: icx
-            rust: '1.65.0'
           - os: macos-latest
             name: macos
             binary_path: target/release
             binary_files: icx
-            rust: '1.65.0'
     steps:
     - uses: actions/checkout@master
 
@@ -34,11 +32,17 @@ jobs:
         echo "--locked --release $binaries" >> $GITHUB_ENV
         echo "END" >> $GITHUB_ENV
 
-    - name: Static build
-      uses: dfinity/rust-musl-action@master
+    - name: Install Rust toolchain
+      uses: ructions/toolchain@v2
       with:
-        args: cargo build --target x86_64-unknown-linux-musl ${{ env.cargo_build_ARGS }}
-      if: contains(matrix.os, 'ubuntu')
+        profile: minimal
+
+    - name: Build
+      uses: ructions/cargo@v1
+      with:
+        command: build
+        args: --target x86_64-unknown-linux-musl ${{ env.cargo_build_ARGS }}
+        use-cross: ${{ contains(matrix.os, 'ubuntu') }}
 
     - name: Strip binaries
       run: |
@@ -47,17 +51,8 @@ jobs:
         strip ${{ matrix.binary_files }}
       if: contains(matrix.os, 'ubuntu')
 
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.rust }}
-        override: true
-      if: contains(matrix.os, 'macos')
-
-    - name: Dynamic build
+    - name: Check linkage
       run: |
-        cargo build ${{ env.cargo_build_ARGS }}
         cd ${{ matrix.binary_path }}
         otool -L ${{ matrix.binary_files }}
       if: contains(matrix.os, 'macos')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust: ["1.65.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
@@ -26,10 +25,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
       - name: Install Rust
-        run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
-          rustup target add wasm32-unknown-unknown
+        uses: ructions/toolchain@v2
+        with:
+          profile: minimal
 
       - name: Install wasm-pack
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -52,7 +50,7 @@ jobs:
       - name: Run Tests (WASM)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          CARGO_TARGET_DIR=../target/wasm wasm-pack test --chrome --headless ic-agent --features wasm-bindgen
+          CARGO_TARGET_DIR=target/wasm wasm-pack test --chrome --headless ic-agent --features wasm-bindgen
 
       - name: Purge for OSX
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
 
-      - name: Install Rust
-        uses: ructions/toolchain@v2
-        with:
-          profile: minimal
-
       - name: Install wasm-pack
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -340,9 +340,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.3"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,12 +634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
-
-[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,21 +664,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -979,19 +958,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki-roots 0.23.1",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -1408,24 +1374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,48 +1474,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.29",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "pairing"
@@ -1688,12 +1598,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -1880,12 +1784,10 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1895,7 +1797,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -2362,19 +2263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall 0.3.5",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,16 +2382,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.29",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2652,12 +2530,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
 # MSRV
 # Avoid updating this field unless we use new Rust features
-# Sync rust-version in following CI files:
-rust-version = "1.65.0"
+# Sync rust-version in rust-toolchain.toml
+rust-version = "1.70.0"
 license = "Apache-2.0"
 
 [workspace.dependencies]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,0 @@
-[target.x86_64-unknown-linux-musl]
-pre-build = [
-    "dpkg --add-architecture $CROSS_DEB_ARCH",
-    "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH",
-]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-musl]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH",
+]

--- a/icx-cert/Cargo.toml
+++ b/icx-cert/Cargo.toml
@@ -23,7 +23,10 @@ clap = { workspace = true, features = ["derive", "cargo", "color"] }
 hex = { workspace = true }
 ic-certification = { workspace = true }
 leb128 = "0.2.4"
-reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = [
+    "blocking",
+    "rustls-tls",
+] }
 sha2 = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = { workspace = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
-channel = "1.71.1"
+# MSRV
+# Avoid updating this field unless we use new Rust features
+# Sync rust-version in workspace Cargo.toml
+channel = "1.70.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
-
-# The version only influences the local develop environment.
-# No need to sync with Cargo.toml and CI.


### PR DESCRIPTION
This PR raises the MSRV to 1.70 following several dependencies doing the same. Particular to 1.70 is the support for the sparse Cargo registry, to accelerate this update in particular. It also removes the distinction between the CI version and the local dev version, letting CI pick the version up from rust-toolchain.toml.