### PR TITLE
feat: Round `ingress_expiry` to the minute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,10 +2310,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
 dependencies = [
+ "deranged",
  "itoa",
  "js-sys",
  "serde",
@@ -2317,15 +2324,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -84,9 +84,9 @@ impl AgentBuilder {
     /// at the time an update or query is made. The default expiry cannot be a
     /// fixed system time.
     ///
-    /// This duration may be rounded in order to reduce cache misses. The current
-    /// implementation rounds to the nearest minute if the expiry is more than a minute,
-    /// but this is not guaranteed.
+    /// The timestamp corresponding to this duration may be rounded in order to reduce
+    /// cache misses. The current implementation rounds to the nearest minute if the
+    /// expiry is more than a minute, but this is not guaranteed.
     pub fn with_ingress_expiry(mut self, ingress_expiry: Option<std::time::Duration>) -> Self {
         self.config.ingress_expiry = ingress_expiry;
         self

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -83,6 +83,10 @@ impl AgentBuilder {
     /// Provides a _default_ ingress expiry. This is the delta that will be applied
     /// at the time an update or query is made. The default expiry cannot be a
     /// fixed system time.
+    ///
+    /// This duration may be rounded in order to reduce cache misses. The current
+    /// implementation rounds to the nearest minute if the expiry is more than a minute,
+    /// but this is not guaranteed.
     pub fn with_ingress_expiry(mut self, ingress_expiry: Option<std::time::Duration>) -> Self {
         self.config.ingress_expiry = ingress_expiry;
         self

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1285,7 +1285,7 @@ impl<'agent> UpdateBuilder<'agent> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "reqwest"))]
 mod offline_tests {
     use super::*;
     // Any tests that involve the network should go in agent_test, not here.

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -331,19 +331,13 @@ impl Agent {
 
     fn get_expiry_date(&self) -> u64 {
         let expiry_raw = OffsetDateTime::now_utc() + self.ingress_expiry;
-        let rounded = if self.ingress_expiry.as_secs() > 60 {
-            let mut rounded_minute = expiry_raw
-                .replace_second(0)
-                .unwrap()
-                .replace_nanosecond(0)
-                .unwrap();
+        let mut rounded = expiry_raw.replace_nanosecond(0).unwrap();
+        if self.ingress_expiry.as_secs() > 60 {
+            rounded = rounded.replace_second(0).unwrap();
             if expiry_raw.second() >= 30 {
-                rounded_minute += Duration::from_secs(60);
+                rounded += Duration::from_secs(60);
             }
-            rounded_minute
-        } else {
-            expiry_raw.replace_nanosecond(0).unwrap()
-        };
+        }
         rounded.unix_timestamp_nanos() as u64
     }
 

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -330,12 +330,21 @@ impl Agent {
     }
 
     fn get_expiry_date(&self) -> u64 {
-        // TODO(hansl): evaluate if we need this on the agent side (my hunch is we don't).
-        let permitted_drift = Duration::from_secs(60);
-        self.ingress_expiry
-            .as_nanos()
-            .saturating_add(OffsetDateTime::now_utc().unix_timestamp_nanos() as u128)
-            .saturating_sub(permitted_drift.as_nanos()) as u64
+        let expiry_raw = OffsetDateTime::now_utc() + self.ingress_expiry;
+        let rounded = if self.ingress_expiry.as_secs() > 60 {
+            let mut rounded_minute = expiry_raw
+                .replace_second(0)
+                .unwrap()
+                .replace_nanosecond(0)
+                .unwrap();
+            if expiry_raw.second() >= 30 {
+                rounded_minute += Duration::from_secs(60);
+            }
+            rounded_minute
+        } else {
+            expiry_raw.replace_nanosecond(0).unwrap()
+        };
+        rounded.unix_timestamp_nanos() as u64
     }
 
     /// Return the principal of the identity.
@@ -1273,5 +1282,33 @@ impl<'agent> UpdateBuilder<'agent> {
             signed_update,
             request_id,
         })
+    }
+}
+
+#[cfg(test)]
+mod offline_tests {
+    use super::*;
+    // Any tests that involve the network should go in agent_test, not here.
+
+    #[test]
+    fn rounded_expiry() {
+        let agent = Agent::builder()
+            .with_url("http://not-a-real-url")
+            .build()
+            .unwrap();
+        let mut prev_expiry = None;
+        let mut num_timestamps = 0;
+        for _ in 0..6 {
+            let update = agent
+                .update(&Principal::management_canister(), "not_a_method")
+                .sign()
+                .unwrap();
+            if prev_expiry < Some(update.ingress_expiry) {
+                prev_expiry = Some(update.ingress_expiry);
+                num_timestamps += 1;
+            }
+        }
+        // in six requests, there should be no more than two timestamps
+        assert!(num_timestamps <= 2, "num_timestamps:{num_timestamps} > 2");
     }
 }


### PR DESCRIPTION
If the agent's configured ingress expiry duration is >1m, this rounds the ingress expiry *timestamp* to the closest minute (and otherwise, rounds down to the second). This will hopefully reduce cache misses, since a nanosecond difference in the ingress expiry timestamp means a different request ID and is thus uncacheable.

Implements SDK-1259.