### PR TITLE
chore: make Envelope struct public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * Types passed to the `to_request_id` function can now contain nested structs, signed integers, and externally tagged enums.
+* `Envelope` struct is public also outside of the crate.
 
 ## [0.29.0] - 2023-09-29
 

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -12,7 +12,7 @@ pub use agent_error::AgentError;
 pub use builder::AgentBuilder;
 #[doc(inline)]
 pub use ic_transport_types::{
-    signed, EnvelopeContent, RejectCode, RejectResponse, ReplyResponse, RequestStatusResponse,
+    signed, Envelope, EnvelopeContent, RejectCode, RejectResponse, ReplyResponse, RequestStatusResponse,
 };
 pub use nonce::{NonceFactory, NonceGenerator};
 use time::OffsetDateTime;
@@ -33,7 +33,7 @@ use backoff::{backoff::Backoff, ExponentialBackoffBuilder};
 use ic_certification::{Certificate, Delegation, Label};
 use ic_transport_types::{
     signed::{SignedQuery, SignedRequestStatus, SignedUpdate},
-    Envelope, QueryResponse, ReadStateResponse,
+    QueryResponse, ReadStateResponse,
 };
 use serde::Serialize;
 use status::Status;


### PR DESCRIPTION
# Description

For the [IC WebSocket Gateway](https://github.com/omnia-network/ic-websocket-gateway) [we need](https://github.com/omnia-network/ic-websocket-gateway/blob/3cc3499e21eb8314f499a29bcc55a79fe359c3c9/src/ic-websocket-gateway/src/client_connection_handler.rs#L37) the `Envelope` struct to be public also outside the `ic-agent` crate as the gateway needs to deserialize messages coming from clients and containing a serialized envelope.

# How Has This Been Tested?
Only made `Envelope` struct public.
