### PR TITLE
feat: extend agent with a route provider feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* feat: An instance of the `Agent` can now dispatch subsequent requests to URLs, which are generated dynamically, thanks to the new `RouteProvider` trait, which is added to the `HyperTransport` and `ReqwestTransport`. Also a simple `RoundRobinRouteProvider` implementation of the `RouteProvider` trait is provided. This provider generates routing URLs from an input list in a simple, fair and predictable way.
 * Added `read_subnet_state_raw` to `Agent` and `read_subnet_state` to `Transport` for looking up raw state by subnet ID instead of canister ID.
 * Added `read_state_subnet_metrics` to `Agent` to access subnet metrics, such as total spent cycles.
 * Types passed to the `to_request_id` function can now contain nested structs, signed integers, and externally tagged enums.

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -163,6 +163,10 @@ pub enum AgentError {
     /// The rejected call had an invalid reject code (valid range 1..5).
     #[error(transparent)]
     InvalidRejectCode(#[from] InvalidRejectCodeError),
+
+    /// Route provider failed to generate a url for some reason.
+    #[error("Route provider failed to generate url: {0}")]
+    RouteProviderError(String),
 }
 
 impl PartialEq for AgentError {

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -3,21 +3,17 @@ pub use hyper;
 
 use std::{any, error::Error, future::Future, marker::PhantomData, sync::atomic::AtomicPtr};
 
-use http::uri::{Authority, PathAndQuery};
 use http_body::{LengthLimitError, Limited};
 use hyper::{
-    body::{Bytes, HttpBody},
-    client::HttpConnector,
-    header::CONTENT_TYPE,
-    service::Service,
-    Client, Method, Request, Response, Uri,
+    body::HttpBody, client::HttpConnector, header::CONTENT_TYPE, service::Service, Client, Method,
+    Request, Response,
 };
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 
 use crate::{
     agent::{
         agent_error::HttpErrorPayload,
-        http_transport::{IC0_DOMAIN, IC0_SUB_DOMAIN},
+        http_transport::route_provider::{RoundRobinRouteProvider, RouteProvider},
         AgentFuture, Transport,
     },
     export::Principal,
@@ -28,7 +24,7 @@ use crate::{
 #[derive(Debug)]
 pub struct HyperTransport<B1, S = Client<HttpsConnector<HttpConnector>, B1>> {
     _marker: PhantomData<AtomicPtr<B1>>,
-    url: Uri,
+    route_provider: Box<dyn RouteProvider>,
     max_response_body_size: Option<usize>,
     service: S,
 }
@@ -87,7 +83,7 @@ where
 
 impl<B1: HyperBody> HyperTransport<B1> {
     /// Creates a replica transport from a HTTP URL.
-    pub fn create<U: Into<Uri>>(url: U) -> Result<Self, AgentError> {
+    pub fn create<U: Into<String>>(url: U) -> Result<Self, AgentError> {
         let connector = HttpsConnectorBuilder::new()
             .with_webpki_roots()
             .https_or_http()
@@ -104,49 +100,19 @@ where
     S: HyperService<B1>,
 {
     /// Creates a replica transport from a HTTP URL and a [`HyperService`].
-    pub fn create_with_service<U: Into<Uri>>(url: U, service: S) -> Result<Self, AgentError> {
-        // Parse the url
-        let url = url.into();
-        let mut parts = url.clone().into_parts();
-        parts.authority = parts
-            .authority
-            .map(|v| {
-                let host = v.host();
-                let host = match host.len().checked_sub(IC0_SUB_DOMAIN.len()) {
-                    None => host,
-                    Some(start) if host[start..].eq_ignore_ascii_case(IC0_SUB_DOMAIN) => IC0_DOMAIN,
-                    Some(_) => host,
-                };
-                let port = v.port();
-                let (colon, port) = match port.as_ref() {
-                    Some(v) => (":", v.as_str()),
-                    None => ("", ""),
-                };
-                Authority::from_maybe_shared(Bytes::from(format!("{host}{colon}{port}")))
-            })
-            .transpose()
-            .map_err(|_| AgentError::InvalidReplicaUrl(format!("{url}")))?;
-        parts.path_and_query = Some(
-            parts
-                .path_and_query
-                .map_or(Ok(PathAndQuery::from_static("/api/v2")), |v| {
-                    let mut found = false;
-                    fn replace<T>(a: T, b: &mut T) -> T {
-                        std::mem::replace(b, a)
-                    }
-                    let v = v
-                        .path()
-                        .trim_end_matches(|c| !replace(found || c == '/', &mut found));
-                    PathAndQuery::from_maybe_shared(Bytes::from(format!("{v}/api/v2")))
-                })
-                .map_err(|_| AgentError::InvalidReplicaUrl(format!("{url}")))?,
-        );
-        let url =
-            Uri::from_parts(parts).map_err(|_| AgentError::InvalidReplicaUrl(format!("{url}")))?;
+    pub fn create_with_service<U: Into<String>>(url: U, service: S) -> Result<Self, AgentError> {
+        let route_provider = Box::new(RoundRobinRouteProvider::new(vec![url.into()])?);
+        Self::create_with_service_route(route_provider, service)
+    }
 
+    /// Creates a replica transport from a [`RouteProvider`] and a [`HyperService`].
+    pub fn create_with_service_route(
+        route_provider: Box<dyn RouteProvider>,
+        service: S,
+    ) -> Result<Self, AgentError> {
         Ok(Self {
             _marker: PhantomData,
-            url,
+            route_provider,
             service,
             max_response_body_size: None,
         })
@@ -243,7 +209,10 @@ where
         _request_id: RequestId,
     ) -> AgentFuture<()> {
         Box::pin(async move {
-            let url = format!("{}/canister/{effective_canister_id}/call", self.url);
+            let url = format!(
+                "{}/canister/{effective_canister_id}/call",
+                self.route_provider.route()?
+            );
             self.request(Method::POST, url, Some(envelope)).await?;
             Ok(())
         })
@@ -255,28 +224,37 @@ where
         envelope: Vec<u8>,
     ) -> AgentFuture<Vec<u8>> {
         Box::pin(async move {
-            let url = format!("{}/canister/{effective_canister_id}/read_state", self.url);
+            let url = format!(
+                "{}/canister/{effective_canister_id}/read_state",
+                self.route_provider.route()?
+            );
             self.request(Method::POST, url, Some(envelope)).await
         })
     }
 
     fn read_subnet_state(&self, subnet_id: Principal, envelope: Vec<u8>) -> AgentFuture<Vec<u8>> {
         Box::pin(async move {
-            let url = format!("{}/subnet/{subnet_id}/read_state", self.url);
+            let url = format!(
+                "{}/subnet/{subnet_id}/read_state",
+                self.route_provider.route()?
+            );
             self.request(Method::POST, url, Some(envelope)).await
         })
     }
 
     fn query(&self, effective_canister_id: Principal, envelope: Vec<u8>) -> AgentFuture<Vec<u8>> {
         Box::pin(async move {
-            let url = format!("{}/canister/{effective_canister_id}/query", self.url);
+            let url = format!(
+                "{}/canister/{effective_canister_id}/query",
+                self.route_provider.route()?
+            );
             self.request(Method::POST, url, Some(envelope)).await
         })
     }
 
     fn status(&self) -> AgentFuture<Vec<u8>> {
         Box::pin(async move {
-            let url = format!("{}/status", self.url);
+            let url = format!("{}/status", self.route_provider.route()?);
             self.request(Method::GET, url, None).await
         })
     }

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -263,32 +263,38 @@ where
 #[cfg(test)]
 mod test {
     use super::HyperTransport;
-    use hyper::{Client, Uri};
+    use hyper::Client;
+    use url::Url;
 
     #[test]
     fn redirect() {
         fn test(base: &str, result: &str) {
             let client: Client<_> = Client::builder().build_http();
-            let uri: Uri = base.parse().unwrap();
-            let t = HyperTransport::create_with_service(uri, client).unwrap();
-            assert_eq!(t.url, result, "{}", base);
+            let url: Url = base.parse().unwrap();
+            let t = HyperTransport::create_with_service(url, client).unwrap();
+            assert_eq!(
+                t.route_provider.route().unwrap().as_str(),
+                result,
+                "{}",
+                base
+            );
         }
 
-        test("https://ic0.app", "https://ic0.app/api/v2");
-        test("https://IC0.app", "https://ic0.app/api/v2");
-        test("https://foo.ic0.app", "https://ic0.app/api/v2");
-        test("https://foo.IC0.app", "https://ic0.app/api/v2");
-        test("https://foo.Ic0.app", "https://ic0.app/api/v2");
-        test("https://foo.iC0.app", "https://ic0.app/api/v2");
-        test("https://foo.bar.ic0.app", "https://ic0.app/api/v2");
-        test("https://ic0.app/foo/", "https://ic0.app/foo/api/v2");
-        test("https://foo.ic0.app/foo/", "https://ic0.app/foo/api/v2");
+        test("https://ic0.app", "https://ic0.app/api/v2/");
+        test("https://IC0.app", "https://ic0.app/api/v2/");
+        test("https://foo.ic0.app", "https://ic0.app/api/v2/");
+        test("https://foo.IC0.app", "https://ic0.app/api/v2/");
+        test("https://foo.Ic0.app", "https://ic0.app/api/v2/");
+        test("https://foo.iC0.app", "https://ic0.app/api/v2/");
+        test("https://foo.bar.ic0.app", "https://ic0.app/api/v2/");
+        test("https://ic0.app/foo/", "https://ic0.app/foo/api/v2/");
+        test("https://foo.ic0.app/foo/", "https://ic0.app/foo/api/v2/");
 
-        test("https://ic1.app", "https://ic1.app/api/v2");
-        test("https://foo.ic1.app", "https://foo.ic1.app/api/v2");
-        test("https://ic0.app.ic1.app", "https://ic0.app.ic1.app/api/v2");
+        test("https://ic1.app", "https://ic1.app/api/v2/");
+        test("https://foo.ic1.app", "https://foo.ic1.app/api/v2/");
+        test("https://ic0.app.ic1.app", "https://ic0.app.ic1.app/api/v2/");
 
-        test("https://fooic0.app", "https://fooic0.app/api/v2");
-        test("https://fooic0.app.ic0.app", "https://ic0.app/api/v2");
+        test("https://fooic0.app", "https://fooic0.app/api/v2/");
+        test("https://fooic0.app.ic0.app", "https://ic0.app/api/v2/");
     }
 }

--- a/ic-agent/src/agent/http_transport/mod.rs
+++ b/ic-agent/src/agent/http_transport/mod.rs
@@ -25,6 +25,17 @@ pub use hyper_transport::*; // remove after 0.25
 #[allow(dead_code)]
 const IC0_DOMAIN: &str = "ic0.app";
 #[allow(dead_code)]
+const ICP0_DOMAIN: &str = "icp0.io";
+#[allow(dead_code)]
+const ICP_API_DOMAIN: &str = "icp-api.io";
+#[allow(dead_code)]
+const LOCALHOST_DOMAIN: &str = "localhost";
+#[allow(dead_code)]
 const IC0_SUB_DOMAIN: &str = ".ic0.app";
-
+#[allow(dead_code)]
+const ICP0_SUB_DOMAIN: &str = ".icp0.io";
+#[allow(dead_code)]
+const ICP_API_SUB_DOMAIN: &str = ".icp-api.io";
+#[allow(dead_code)]
+const LOCALHOST_SUB_DOMAIN: &str = ".localhost";
 pub mod route_provider;

--- a/ic-agent/src/agent/http_transport/mod.rs
+++ b/ic-agent/src/agent/http_transport/mod.rs
@@ -26,3 +26,5 @@ pub use hyper_transport::*; // remove after 0.25
 const IC0_DOMAIN: &str = "ic0.app";
 #[allow(dead_code)]
 const IC0_SUB_DOMAIN: &str = ".ic0.app";
+
+pub mod route_provider;

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -270,7 +270,7 @@ mod test {
         test("http://localhost:4943", "http://localhost:4943/api/v2/");
         test(
             "http://ryjl3-tyaaa-aaaaa-aaaba-cai.localhost:4943",
-            "https://localhost:4943/api/v2/",
+            "http://localhost:4943/api/v2/",
         );
     }
 }

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -241,6 +241,10 @@ mod test {
         test("https://foo.bar.ic0.app", "https://ic0.app/api/v2/");
         test("https://ic0.app/foo/", "https://ic0.app/foo/api/v2/");
         test("https://foo.ic0.app/foo/", "https://ic0.app/foo/api/v2/");
+        test(
+            "https://ryjl3-tyaaa-aaaaa-aaaba-cai.ic0.app",
+            "https://ic0.app/api/v2/",
+        );
 
         test("https://ic1.app", "https://ic1.app/api/v2/");
         test("https://foo.ic1.app", "https://foo.ic1.app/api/v2/");
@@ -248,5 +252,25 @@ mod test {
 
         test("https://fooic0.app", "https://fooic0.app/api/v2/");
         test("https://fooic0.app.ic0.app", "https://ic0.app/api/v2/");
+
+        test("https://icp0.io", "https://icp0.io/api/v2/");
+        test(
+            "https://ryjl3-tyaaa-aaaaa-aaaba-cai.icp0.io",
+            "https://icp0.io/api/v2/",
+        );
+        test("https://ic0.app.icp0.io", "https://icp0.io/api/v2/");
+
+        test("https://icp-api.io", "https://icp-api.io/api/v2/");
+        test(
+            "https://ryjl3-tyaaa-aaaaa-aaaba-cai.icp-api.io",
+            "https://icp-api.io/api/v2/",
+        );
+        test("https://icp0.io.icp-api.io", "https://icp-api.io/api/v2/");
+
+        test("http://localhost:4943", "http://localhost:4943/api/v2/");
+        test(
+            "http://ryjl3-tyaaa-aaaaa-aaaba-cai.localhost:4943",
+            "https://localhost:4943/api/v2",
+        );
     }
 }

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 
 /// A [`Transport`] using [`reqwest`] to make HTTP calls to the Internet Computer.
+#[derive(Debug)]
 pub struct ReqwestTransport {
     route_provider: Box<dyn RouteProvider>,
     client: Client,

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -270,7 +270,7 @@ mod test {
         test("http://localhost:4943", "http://localhost:4943/api/v2/");
         test(
             "http://ryjl3-tyaaa-aaaaa-aaaba-cai.localhost:4943",
-            "https://localhost:4943/api/v2",
+            "https://localhost:4943/api/v2/",
         );
     }
 }

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -29,7 +29,7 @@ pub struct ReqwestTransport {
 }
 
 #[doc(hidden)]
-pub use ReqwestTransport as ReqwestHttpReplicaV2Transport;
+pub use ReqwestTransport as ReqwestHttpReplicaV2Transport; // deprecate after 0.24
 
 impl ReqwestTransport {
     /// Creates a replica transport from a HTTP URL.

--- a/ic-agent/src/agent/http_transport/route_provider.rs
+++ b/ic-agent/src/agent/http_transport/route_provider.rs
@@ -56,7 +56,6 @@ impl RoundRobinRouteProvider {
                             url.set_host(Some(ICP_API_DOMAIN))?
                         } else if domain.ends_with(LOCALHOST_SUB_DOMAIN) {
                             url.set_host(Some(LOCALHOST_DOMAIN))?;
-                            url.set_scheme("https").unwrap()
                         }
                     }
                     url.join("api/v2/")

--- a/ic-agent/src/agent/http_transport/route_provider.rs
+++ b/ic-agent/src/agent/http_transport/route_provider.rs
@@ -6,7 +6,10 @@ use std::{
 use url::Url;
 
 use crate::agent::{
-    http_transport::{IC0_DOMAIN, IC0_SUB_DOMAIN},
+    http_transport::{
+        IC0_DOMAIN, IC0_SUB_DOMAIN, ICP0_DOMAIN, ICP0_SUB_DOMAIN, ICP_API_DOMAIN,
+        ICP_API_SUB_DOMAIN, LOCALHOST_DOMAIN, LOCALHOST_SUB_DOMAIN,
+    },
     AgentError,
 };
 
@@ -47,6 +50,13 @@ impl RoundRobinRouteProvider {
                     if let Some(domain) = url.domain() {
                         if domain.ends_with(IC0_SUB_DOMAIN) {
                             url.set_host(Some(IC0_DOMAIN))?
+                        } else if domain.ends_with(ICP0_SUB_DOMAIN) {
+                            url.set_host(Some(ICP0_DOMAIN))?
+                        } else if domain.ends_with(ICP_API_SUB_DOMAIN) {
+                            url.set_host(Some(ICP_API_DOMAIN))?
+                        } else if domain.ends_with(LOCALHOST_SUB_DOMAIN) {
+                            url.set_host(Some(LOCALHOST_DOMAIN))?;
+                            url.set_scheme("https").unwrap()
                         }
                     }
                     url.join("api/v2/")

--- a/ic-agent/src/agent/http_transport/route_provider.rs
+++ b/ic-agent/src/agent/http_transport/route_provider.rs
@@ -1,0 +1,96 @@
+//! A [`RouteProvider`] for dynamic generation of routing urls.
+use std::{
+    str::FromStr,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+use url::Url;
+
+use crate::agent::{
+    http_transport::{IC0_DOMAIN, IC0_SUB_DOMAIN},
+    AgentError,
+};
+
+/// A [`RouteProvider`] for dynamic generation of routing urls.
+pub trait RouteProvider: std::fmt::Debug + Send + Sync {
+    /// Generate next routing url
+    fn route(&self) -> Result<Url, AgentError>;
+}
+
+/// A simple implementation of the [`RouteProvider``] which produces an even distribution of the urls from the input ones.
+#[derive(Debug)]
+pub struct RoundRobinRouteProvider {
+    routes: Vec<Url>,
+    current_idx: AtomicUsize,
+}
+
+impl RouteProvider for RoundRobinRouteProvider {
+    fn route(&self) -> Result<Url, AgentError> {
+        if self.routes.is_empty() {
+            return Err(AgentError::RouteProviderError(
+                "No routing urls provided".to_string(),
+            ));
+        }
+        // This operation wraps around an overflow, i.e. after max is reached the value is reset back to 0.
+        let prev_idx = self.current_idx.fetch_add(1, Ordering::Relaxed);
+        Ok(self.routes[prev_idx % self.routes.len()].clone())
+    }
+}
+
+impl RoundRobinRouteProvider {
+    /// Construct [`RoundRobinRouteProvider`] from a vector of urls.
+    pub fn new<T: AsRef<str>>(routes: Vec<T>) -> Result<Self, AgentError> {
+        let routes: Result<Vec<Url>, _> = routes
+            .into_iter()
+            .map(|url| {
+                Url::from_str(url.as_ref()).and_then(|mut url| {
+                    // rewrite *.ic0.app to ic0.app
+                    if let Some(domain) = url.domain() {
+                        if domain.ends_with(IC0_SUB_DOMAIN) {
+                            url.set_host(Some(IC0_DOMAIN))?
+                        }
+                    }
+                    url.join("api/v2/")
+                })
+            })
+            .collect();
+        Ok(Self {
+            routes: routes?,
+            current_idx: AtomicUsize::new(0),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_routes() {
+        let provider = RoundRobinRouteProvider::new::<&str>(vec![])
+            .expect("failed to create a route provider");
+        let result = provider.route().unwrap_err();
+        assert_eq!(
+            result,
+            AgentError::RouteProviderError("No routing urls provided".to_string())
+        );
+    }
+
+    #[test]
+    fn test_routes_rotation() {
+        let provider = RoundRobinRouteProvider::new(vec!["https://url1.com", "https://url2.com"])
+            .expect("failed to create a route provider");
+        let url_strings = vec![
+            "https://url1.com/api/v2/",
+            "https://url2.com/api/v2/",
+            "https://url1.com/api/v2/",
+        ];
+        let expected_urls: Vec<Url> = url_strings
+            .iter()
+            .map(|url_str| Url::parse(url_str).expect("Invalid URL"))
+            .collect();
+        let urls: Vec<Url> = (0..3)
+            .map(|_| provider.route().expect("failed to get next url"))
+            .collect();
+        assert_eq!(expected_urls, urls);
+    }
+}

--- a/ic-agent/src/agent/http_transport/route_provider.rs
+++ b/ic-agent/src/agent/http_transport/route_provider.rs
@@ -16,7 +16,7 @@ pub trait RouteProvider: std::fmt::Debug + Send + Sync {
     fn route(&self) -> Result<Url, AgentError>;
 }
 
-/// A simple implementation of the [`RouteProvider``] which produces an even distribution of the urls from the input ones.
+/// A simple implementation of the [`RouteProvider`] which produces an even distribution of the urls from the input ones.
 #[derive(Debug)]
 pub struct RoundRobinRouteProvider {
     routes: Vec<Url>,


### PR DESCRIPTION
# Description

_API Boundary Node (BN) Discovery Library_  (which is in a very recent [development](https://gitlab.com/dfinity-lab/public/ic/-/tree/master/rs/boundary_node/discower_bowndary?ref_type=heads)) is the prerequisite for the [IC-720: BN Decentralization Feature](https://forum.dfinity.org/t/boundary-node-roadmap/15562). This library will have two main responsibilities:
1. **Discovery of the API Boundary Nodes (domains)**.  Users (clients) of the IC need to know, which domains to use when "talking" to the IC. Currently, there is only one domain `ic0.app` owned by _Dfinity_. However, once BNs are decentralized, each BN will have it's own/unique domain. Moreover, BNs and their domain records could be added (or removed) from the IC registry via nns proposals. Thus, clients would need an api to discover, which domains currently belong to the IC ecosystem. _Note_: the exact BN domain discovery mechanism is still being discussed.  This could either be accomplished via [read_state](https://internetcomputer.org/docs/current/references/ic-interface-spec#http-read-state) calls or by fetching records from the registry canister.
3. **Routing - dynamically providing url (BN domain) on demand**

**Future usages of the library**:
- browsers
- http gateway
- icx proxy

The library is being developed within the [ic](https://gitlab.com/dfinity-lab/public/ic/-/tree/master/rs/boundary_node/discower_bowndary?ref_type=heads) repo and it uses `ic-agent` as a dependency. However, in the near future, `ic-agent` could/should include some functionalities of the library or even library as a whole.

This pull request kicks-off the first migration/integration step of the library with the `ic-agent`.
Namely,  `ic-agent` is extended with a custom `RouteProvider` feature.

# How Has This Been Tested?

- Existing tests should fully cover the e2e functionality of the `RoundRobinRouteProvider` which is now used as default route provider for the `agent`.
- In addition, several unit tests were added for the `RoundRobinRouteProvider`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
