### PR TITLE
feat: remove fields in expected status endpoint response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `read_state_subnet_metrics` to `Agent` to access subnet metrics, such as total spent cycles.
 * Types passed to the `to_request_id` function can now contain nested structs, signed integers, and externally tagged enums.
 * `Envelope` struct is public also outside of the crate.
+* Remove non-optional `ic_api_version` field (whose value is not meaningfully populated by the replica) and optional `impl_source` and `impl_revision` fields (that are not populated by the replica) from the expected `/api/v2/status` endpoint response.
 
 ## [0.29.0] - 2023-09-29
 

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -226,12 +226,7 @@ async fn call_rejected_without_error_code() -> Result<(), AgentError> {
 #[cfg_attr(not(target_family = "wasm"), tokio::test)]
 #[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
 async fn status() -> Result<(), AgentError> {
-    let ic_api_version = "1.2.3".to_string();
-    let mut map = BTreeMap::new();
-    map.insert(
-        serde_cbor::Value::Text("ic_api_version".to_owned()),
-        serde_cbor::Value::Text(ic_api_version.clone()),
-    );
+    let map = BTreeMap::new();
     let response = serde_cbor::Value::Map(map);
     let (read_mock, url) = mock(
         "GET",
@@ -248,7 +243,7 @@ async fn status() -> Result<(), AgentError> {
     let result = agent.status().await;
 
     assert_mock(read_mock).await;
-    assert!(matches!(result, Ok(Status { ic_api_version: v, .. }) if v == ic_api_version));
+    assert!(matches!(result, Ok(Status { .. })));
 
     Ok(())
 }
@@ -256,11 +251,7 @@ async fn status() -> Result<(), AgentError> {
 #[cfg_attr(not(target_family = "wasm"), tokio::test)]
 #[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
 async fn status_okay() -> Result<(), AgentError> {
-    let mut map = BTreeMap::new();
-    map.insert(
-        serde_cbor::Value::Text("ic_api_version".to_owned()),
-        serde_cbor::Value::Text("1.2.3".to_owned()),
-    );
+    let map = BTreeMap::new();
     let response = serde_cbor::Value::Map(map);
     let (read_mock, url) = mock(
         "GET",

--- a/ic-agent/src/agent/status.rs
+++ b/ic-agent/src/agent/status.rs
@@ -42,23 +42,8 @@ impl std::fmt::Display for Value {
 /// by the status endpoint of a replica.
 #[derive(Debug, Ord, PartialOrd, PartialEq, Eq)]
 pub struct Status {
-    /// Identifies the interface version supported, i.e. the version of the present document that
-    /// the internet computer aims to support, e.g. 0.8.1. The implementation may also return
-    /// unversioned to indicate that it does not comply to a particular version, e.g. in between
-    /// releases.
-    pub ic_api_version: String,
-
-    /// Optional. Identifies the implementation of the Internet Computer, by convention with the
-    /// canonical location of the source code.
-    pub impl_source: Option<String>,
-
-    /// Optional. If the user is talking to a released version of an Internet Computer
-    /// implementation, this is the version number. For non-released versions, output of
-    /// `git describe` like 0.1.13-13-g2414721 would also be very suitable.
+    /// Optional. The precise git revision of the Internet Computer Protocol implementation.
     pub impl_version: Option<String>,
-
-    /// Optional. The precise git revision of the Internet Computer implementation.
-    pub impl_revision: Option<String>,
 
     /// Optional.  The health status of the replica.  One hopes it's "healthy".
     pub replica_health_status: Option<String>,
@@ -121,29 +106,7 @@ impl std::convert::TryFrom<&serde_cbor::Value> for Status {
 
         match v {
             Value::Map(map) => {
-                // This field is not optional.
-                let ic_api_version = map.get("ic_api_version").ok_or(()).and_then(|v| {
-                    if let Value::String(s) = v.as_ref() {
-                        Ok(s.to_owned())
-                    } else {
-                        Err(())
-                    }
-                })?;
-                let impl_source = map.get("impl_source").and_then(|v| {
-                    if let Value::String(s) = v.as_ref() {
-                        Some(s.to_owned())
-                    } else {
-                        None
-                    }
-                });
                 let impl_version: Option<String> = map.get("impl_version").and_then(|v| {
-                    if let Value::String(s) = v.as_ref() {
-                        Some(s.to_owned())
-                    } else {
-                        None
-                    }
-                });
-                let impl_revision: Option<String> = map.get("impl_revision").and_then(|v| {
                     if let Value::String(s) = v.as_ref() {
                         Some(s.to_owned())
                     } else {
@@ -167,10 +130,7 @@ impl std::convert::TryFrom<&serde_cbor::Value> for Status {
                 });
 
                 Ok(Status {
-                    ic_api_version,
-                    impl_source,
                     impl_version,
-                    impl_revision,
                     replica_health_status,
                     root_key,
                     values: map,

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -13,8 +13,6 @@
 //! use case being tested).
 use ref_tests::{universal_canister, with_agent};
 
-const EXPECTED_IC_API_VERSION: &str = "0.18.0";
-
 #[ignore]
 #[test]
 fn status_endpoint() {
@@ -22,18 +20,6 @@ fn status_endpoint() {
         agent.status().await?;
         Ok(())
     })
-}
-
-#[ignore]
-#[test]
-fn spec_compliance_claimed() {
-    with_agent(|agent| async move {
-        let status = agent.status().await?;
-
-        assert_eq!(status.ic_api_version, EXPECTED_IC_API_VERSION);
-
-        Ok(())
-    });
 }
 
 mod management_canister {


### PR DESCRIPTION
This PR removes non-optional `ic_api_version` field (whose value is not meaningfully populated by the replica) and optional `impl_source` and `impl_revision` fields (that are not populated by the replica) from the expected `/api/v2/status` endpoint response.

Here's the corresponding specification [MR](https://github.com/dfinity/interface-spec/pull/234).
