### PR TITLE
feat: drop senders field from user delegations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Types passed to the `to_request_id` function can now contain nested structs, signed integers, and externally tagged enums.
 * `Envelope` struct is public also outside of the crate.
 * Remove non-optional `ic_api_version` field (whose value is not meaningfully populated by the replica) and optional `impl_source` and `impl_revision` fields (that are not populated by the replica) from the expected `/api/v2/status` endpoint response.
+* Drop `senders` field from user delegations (type `Delegation`).
 
 ## [0.29.0] - 2023-09-29
 

--- a/ic-transport-types/src/lib.rs
+++ b/ic-transport-types/src/lib.rs
@@ -218,9 +218,6 @@ pub struct Delegation {
     /// If present, this delegation only applies to requests sent to one of these canisters.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub targets: Option<Vec<Principal>>,
-    /// If present, this delegation only applies to requests originating from one of these principals.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub senders: Option<Vec<Principal>>,
 }
 
 const IC_REQUEST_DELEGATION_DOMAIN_SEPARATOR: &[u8] = b"\x1Aic-request-auth-delegation";

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -607,7 +607,6 @@ mod identity {
             expiration: i64::MAX as u64,
             pubkey: signing_identity.public_key().unwrap(),
             targets: None,
-            senders: None,
         };
         let signature = sending_identity.sign_delegation(&delegation).unwrap();
         let delegated_identity = DelegatedIdentity::new(


### PR DESCRIPTION
The senders field in user delegations is not (going to be) supported in the replica implementation and thus this PR removes this field from the agent implementation.

Specification PR: https://github.com/dfinity/interface-spec/pull/246