### PR TITLE
chore: Update to 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.30.0] = 2023-11-07
+
 * Added node signature certification to query calls, for protection against rogue boundary nodes. This can be disabled with `with_verify_query_signatures`.
 * Added `with_nonce_generation` to `QueryBuilder` for precise cache control.
-* feat: An instance of the `Agent` can now dispatch subsequent requests to URLs, which are generated dynamically, thanks to the new `RouteProvider` trait, which is added to the `HyperTransport` and `ReqwestTransport`. Also a simple `RoundRobinRouteProvider` implementation of the `RouteProvider` trait is provided. This provider generates routing URLs from an input list in a simple, fair and predictable way.
+* Added the ability to dispatch to multiple URLs to `ReqwestTransport` and `HyperTransport`, with a `RouteProvider` trait and a provided `RoundRobinRouteProvider` implementation.
 * Added `read_subnet_state_raw` to `Agent` and `read_subnet_state` to `Transport` for looking up raw state by subnet ID instead of canister ID.
 * Added `read_state_subnet_metrics` to `Agent` to access subnet metrics, such as total spent cycles.
 * Types passed to the `to_request_id` function can now contain nested structs, signed integers, and externally tagged enums.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.30.0] = 2023-11-07
+## [0.30.0] - 2023-11-07
 
 * Added node signature certification to query calls, for protection against rogue boundary nodes. This can be disabled with `with_verify_query_signatures`.
 * Added `with_nonce_generation` to `QueryBuilder` for precise cache control.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -350,7 +350,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -399,7 +399,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -794,7 +794,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "backoff",
  "cached",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "candid",
  "hex",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -1380,7 +1380,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1520,7 +1520,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2105,7 +2105,7 @@ checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2127,7 +2127,7 @@ checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2382,7 +2382,7 @@ checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2465,7 +2465,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2657,7 +2657,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -2691,7 +2691,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.29.0"
+version = "0.30.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
@@ -21,9 +21,9 @@ rust-version = "1.70.0"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-ic-agent = { path = "ic-agent", version = "0.29.0", default-features = false }
-ic-utils = { path = "ic-utils", version = "0.29.0" }
-ic-transport-types = { path = "ic-transport-types", version = "0.29.0" }
+ic-agent = { path = "ic-agent", version = "0.30.0", default-features = false }
+ic-utils = { path = "ic-utils", version = "0.30.0" }
+ic-transport-types = { path = "ic-transport-types", version = "0.30.0" }
 
 ic-certification = "1.2.0"
 candid = "0.9.5"

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -30,7 +30,8 @@ pub struct HyperTransport<B1, S = Client<HttpsConnector<HttpConnector>, B1>> {
 }
 
 #[doc(hidden)]
-pub use HyperTransport as HyperReplicaV2Transport; // deprecate after 0.24
+#[deprecated(since = "0.30.0", note = "use HyperTransport")]
+pub use HyperTransport as HyperReplicaV2Transport; // delete after 0.31
 
 /// Trait representing the contraints on [`HttpBody`] that [`HyperTransport`] requires
 pub trait HyperBody:

--- a/ic-agent/src/agent/http_transport/mod.rs
+++ b/ic-agent/src/agent/http_transport/mod.rs
@@ -6,10 +6,6 @@ pub mod reqwest_transport;
 #[cfg(feature = "reqwest")]
 #[doc(inline)]
 pub use reqwest_transport::ReqwestTransport;
-#[cfg(feature = "reqwest")]
-#[doc(hidden)]
-#[deprecated]
-pub use reqwest_transport::*; // remove after 0.25
 
 #[cfg(feature = "hyper")]
 pub mod hyper_transport;
@@ -17,10 +13,6 @@ pub mod hyper_transport;
 #[cfg(feature = "hyper")]
 #[doc(inline)]
 pub use hyper_transport::HyperTransport;
-#[cfg(feature = "hyper")]
-#[doc(hidden)]
-#[deprecated]
-pub use hyper_transport::*; // remove after 0.25
 
 #[allow(dead_code)]
 const IC0_DOMAIN: &str = "ic0.app";

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -29,7 +29,8 @@ pub struct ReqwestTransport {
 }
 
 #[doc(hidden)]
-pub use ReqwestTransport as ReqwestHttpReplicaV2Transport; // deprecate after 0.24
+#[deprecated(since = "0.30.0", note = "use ReqwestTransport")]
+pub use ReqwestTransport as ReqwestHttpReplicaV2Transport; // delete after 0.31
 
 impl ReqwestTransport {
     /// Creates a replica transport from a HTTP URL.


### PR DESCRIPTION
This includes deprecations of previous doc(hidden) symbols, and deletions of previous deprecated symbols. 