### PR TITLE
fix: hyper-transport url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Fixed `HyperTransport` endpoint construction (`//` in the format `/api/v2//canister/5v3p4-iyaaa-aaaaa-qaaaa-cai/query`)
 
 ## [0.30.0] - 2023-11-07
 

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -211,7 +211,7 @@ where
     ) -> AgentFuture<()> {
         Box::pin(async move {
             let url = format!(
-                "{}/canister/{effective_canister_id}/call",
+                "{}canister/{effective_canister_id}/call",
                 self.route_provider.route()?
             );
             self.request(Method::POST, url, Some(envelope)).await?;
@@ -226,7 +226,7 @@ where
     ) -> AgentFuture<Vec<u8>> {
         Box::pin(async move {
             let url = format!(
-                "{}/canister/{effective_canister_id}/read_state",
+                "{}canister/{effective_canister_id}/read_state",
                 self.route_provider.route()?
             );
             self.request(Method::POST, url, Some(envelope)).await
@@ -236,7 +236,7 @@ where
     fn read_subnet_state(&self, subnet_id: Principal, envelope: Vec<u8>) -> AgentFuture<Vec<u8>> {
         Box::pin(async move {
             let url = format!(
-                "{}/subnet/{subnet_id}/read_state",
+                "{}subnet/{subnet_id}/read_state",
                 self.route_provider.route()?
             );
             self.request(Method::POST, url, Some(envelope)).await
@@ -246,7 +246,7 @@ where
     fn query(&self, effective_canister_id: Principal, envelope: Vec<u8>) -> AgentFuture<Vec<u8>> {
         Box::pin(async move {
             let url = format!(
-                "{}/canister/{effective_canister_id}/query",
+                "{}canister/{effective_canister_id}/query",
                 self.route_provider.route()?
             );
             self.request(Method::POST, url, Some(envelope)).await
@@ -255,7 +255,7 @@ where
 
     fn status(&self) -> AgentFuture<Vec<u8>> {
         Box::pin(async move {
-            let url = format!("{}/status", self.route_provider.route()?);
+            let url = format!("{}status", self.route_provider.route()?);
             self.request(Method::GET, url, None).await
         })
     }


### PR DESCRIPTION
# Description

Hyper transport produced a url with a double slash, namely: `/api/v2//canister/5v3p4-iyaaa-aaaaa-qaaaa-cai/query`

# How Has This Been Tested?

It seems hyper transport is not tested e2e.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
