### PR TITLE
chore: Release 0.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.30.1] - 2023-11-15
+
 * Fixed `HyperTransport` endpoint construction (`//` in the format `/api/v2//canister/5v3p4-iyaaa-aaaaa-qaaaa-cai/query`)
 
 ## [0.30.0] - 2023-11-07

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "backoff",
  "cached",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "candid",
  "hex",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "candid",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "candid",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.30.0"
+version = "0.30.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
@@ -21,9 +21,9 @@ rust-version = "1.70.0"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-ic-agent = { path = "ic-agent", version = "0.30.0", default-features = false }
-ic-utils = { path = "ic-utils", version = "0.30.0" }
-ic-transport-types = { path = "ic-transport-types", version = "0.30.0" }
+ic-agent = { path = "ic-agent", version = "0.30.1", default-features = false }
+ic-utils = { path = "ic-utils", version = "0.30.1" }
+ic-transport-types = { path = "ic-transport-types", version = "0.30.1" }
 
 ic-certification = "1.2.0"
 candid = "0.9.5"


### PR DESCRIPTION
Includes the fix for HyperTransport URLs.