### PR TITLE
chore!: bump candid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* Bump candid to 0.10
+* Breaking change: Bump candid to 0.10. Downstream libraries need to bump Candid to 0.10 as well.
 
 ## [0.30.2] = 20223-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Bump candid to 0.10
+
 ## [0.30.2] = 20223-11-16
 
 * Fixed a spurious certificate validation error in the five minutes after a node is added to a subnet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,9 +294,9 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -313,44 +319,56 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.9.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762aa04e3a889d47a1773b74ee3b13438a9bc895954fff79ebf7f308c3744a6c"
+checksum = "a2525ab7a58543c132da8c780abe3aa1ba394ddcc1888a4ad2ba4f5100906ebe"
 dependencies = [
  "anyhow",
  "binread",
  "byteorder",
  "candid_derive",
- "codespan-reporting",
- "crc32fast",
- "data-encoding",
  "hex",
- "lalrpop",
- "lalrpop-util",
+ "ic_principal",
  "leb128",
- "logos",
  "num-bigint 0.4.3",
  "num-traits",
- "num_enum",
  "paste",
  "pretty",
  "serde",
  "serde_bytes",
- "sha2 0.10.7",
  "stacker",
  "thiserror",
 ]
 
 [[package]]
 name = "candid_derive"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810b3bd60244f282090652ffc7c30a9d23892e72dfe443e46ee55569044f7dd5"
+checksum = "970c220da8aa2fa6f7ef5dbbf3ea5b620a59eb3ac107cfb95ae8c6eebdfb7a08"
 dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
  "syn 2.0.32",
+]
+
+[[package]]
+name = "candid_parser"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a152b737c1c2681d4ed3359f15016b499f2ddc59aef9fdce0be82f483c11e700"
+dependencies = [
+ "anyhow",
+ "candid",
+ "codespan-reporting",
+ "convert_case",
+ "hex",
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+ "num-bigint 0.4.3",
+ "pretty",
+ "thiserror",
 ]
 
 [[package]]
@@ -450,6 +468,15 @@ name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1147,11 +1174,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic_principal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899a4e8ddada85b91a2fe32b4dc6c0d475ef7bfef3f51cf2aecb26ee4ac4724f"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "data-encoding",
+ "hex",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.7",
+ "thiserror",
+]
+
+[[package]]
 name = "icx"
 version = "0.30.2"
 dependencies = [
  "anyhow",
  "candid",
+ "candid_parser",
  "clap",
  "hex",
  "humantime",
@@ -1503,27 +1547,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "object"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,16 +1714,6 @@ dependencies = [
  "arrayvec",
  "typed-arena",
  "unicode-segmentation",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit",
 ]
 
 [[package]]
@@ -2493,23 +2506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
-
-[[package]]
-name = "toml_edit"
-version = "0.19.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
-dependencies = [
- "indexmap 2.0.0",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2860,15 +2856,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "winnow"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "backoff",
  "cached",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "candid",
  "hex",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "async-trait",
  "candid",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "candid",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.30.3"
+version = "0.30.2"
 dependencies = [
  "backoff",
  "cached",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.30.3"
+version = "0.30.2"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.30.3"
+version = "0.30.2"
 dependencies = [
  "candid",
  "hex",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.30.3"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "candid",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.30.3"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "candid",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.30.3"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.30.3"
+version = "0.30.2"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.30.2"
+version = "0.30.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ ic-utils = { path = "ic-utils", version = "0.30.2" }
 ic-transport-types = { path = "ic-transport-types", version = "0.30.2" }
 
 ic-certification = "1.2.0"
-candid = "0.9.5"
+candid = "0.10.0"
+candid_parser = "0.1.0"
 clap = "4.4.3"
 hex = "0.4.3"
 leb128 = "0.2.5"

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -422,7 +422,7 @@ async fn wrong_subnet_query_certificate() {
         Some("application/cbor"),
     )
     .await;
-    let blob = Encode!(&Nat::from(12)).unwrap();
+    let blob = Encode!(&Nat::from(12u8)).unwrap();
     let response = QueryResponse::Replied {
         reply: ReplyResponse { arg: blob.clone() },
         signatures: vec![NodeSignature {
@@ -468,7 +468,7 @@ async fn no_cert() {
         Some("application/cbor"),
     )
     .await;
-    let blob = Encode!(&Nat::from(12)).unwrap();
+    let blob = Encode!(&Nat::from(12u8)).unwrap();
     let response = QueryResponse::Replied {
         reply: ReplyResponse { arg: blob.clone() },
         signatures: vec![],

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -18,7 +18,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
 async-trait = "0.1.68"
-candid = { workspace = true }
+candid = { workspace = true, features = ["value"] }
 ic-agent = { workspace = true, default-features = false }
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -594,7 +594,7 @@ mod test {
             }));
             assert!(fields.contains(&IDLField {
                 id: Label::Named("index".into()),
-                val: IDLValue::Nat(42.into())
+                val: IDLValue::Nat(42u8.into())
             }));
             assert!(fields.contains(&IDLField {
                 id: Label::Named("sha256".into()),
@@ -615,7 +615,7 @@ mod test {
                 token: pre_update_legacy::Token {
                     key: "foo".into(),
                     content_encoding: "bar".into(),
-                    index: 42.into(),
+                    index: 42u8.into(),
                     sha256: None,
                 },
             })),
@@ -641,7 +641,7 @@ mod test {
                 token: pre_update_legacy::Token {
                     key: "foo".into(),
                     content_encoding: "bar".into(),
-                    index: 42.into(),
+                    index: 42u8.into(),
                     sha256: None,
                 },
             })),
@@ -661,7 +661,7 @@ mod test {
             token: Some(pre_update_legacy::Token {
                 key: "foo".into(),
                 content_encoding: "bar".into(),
-                index: 42.into(),
+                index: 42u8.into(),
                 sha256: None,
             }),
         })
@@ -683,7 +683,7 @@ mod test {
         }));
         assert!(fields.contains(&IDLField {
             id: Label::Named("index".into()),
-            val: IDLValue::Nat(42.into())
+            val: IDLValue::Nat(42u8.into())
         }));
         assert!(fields.contains(&IDLField {
             id: Label::Named("sha256".into()),

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -20,7 +20,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
-candid = { workspace = true, features = ["parser"] }
+candid = { workspace = true, features = ["value"] }
+candid_parser = { workspace = true }
 clap = { workspace = true, features = ["derive", "cargo", "color"] }
 hex = { workspace = true }
 humantime = "2.0.1"

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -1,10 +1,10 @@
 use anyhow::{bail, Context, Result};
 use candid::{
-    check_prog,
     types::value::IDLValue,
     types::{Function, Type, TypeInner},
-    CandidType, Decode, Deserialize, IDLArgs, IDLProg, TypeEnv,
+    CandidType, Decode, Deserialize, IDLArgs, TypeEnv,
 };
+use candid_parser::{check_prog, parse_idl_args, parse_idl_value, IDLProg};
 use clap::{crate_authors, crate_version, Parser, ValueEnum};
 use ic_agent::{
     agent::{self, signed::SignedUpdate},
@@ -194,7 +194,7 @@ fn blob_from_arguments(
         }
         ArgType::Idl => {
             let arguments = arguments.unwrap_or("()");
-            let args = arguments.parse::<IDLArgs>();
+            let args = parse_idl_args(arguments);
             let typed_args = match method_type {
                 None => args
                     .context("Failed to parse arguments with no method type info")?
@@ -210,7 +210,7 @@ fn blob_from_arguments(
                             if &TypeInner::Text == func.args[0].as_ref() && !is_quote {
                                 Ok(IDLValue::Text(arguments.to_string()))
                             } else {
-                                arguments.parse::<IDLValue>()
+                                parse_idl_value(arguments)
                             }
                             .map(|v| IDLArgs::new(&[v]))
                         } else {


### PR DESCRIPTION
# Description

Bump Candid to 0.10. Downstream libraries need to bump Candid to 0.10 as well.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
