### PR TITLE
feat: add idle_cycles_burned_per_day field to StatusCallResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * Breaking change: Bump candid to 0.10. Downstream libraries need to bump Candid to 0.10 as well.
+* Feat: add `idle_cycles_burned_per_day` field to `StatusCallResult`.
 
 ## [0.30.2] = 20223-11-16
 

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -89,6 +89,9 @@ pub struct StatusCallResult {
     pub cycles: Nat,
     /// The canister's reserved cycles balance.
     pub reserved_cycles: Nat,
+    /// The cycles burned by the canister in one day for its resource usage
+    /// (compute and memory allocation and memory usage).
+    pub idle_cycles_burned_per_day: Nat,
 }
 
 /// The concrete settings of a canister.


### PR DESCRIPTION
This PR adds the `idle_cycles_burned_per_day` field to `StatusCallResult` of the management canister's `canister_status` method. This field is useful to compute the number of cycles the canisters burns during its `freezing_threshold`.