### PR TITLE
chore: bump ic-certification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "1.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c04340437a32c8b9c80d36f09715909c1e0a755327503a2e2906dcd662ba4e"
+checksum = "1bb2219eb25be014287ff2e355b762c93952028401a4444031ef904535dc776e"
 dependencies = [
  "hex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ic-agent = { path = "ic-agent", version = "0.31.0", default-features = false }
 ic-utils = { path = "ic-utils", version = "0.31.0" }
 ic-transport-types = { path = "ic-transport-types", version = "0.31.0" }
 
-ic-certification = "1.3.0"
+ic-certification = "2.2"
 candid = "0.10.1"
 candid_parser = "0.1.1"
 clap = "4.4.3"


### PR DESCRIPTION
# Description

I need to bump `ic-certification` to remove some git commit hash references.

# How Has This Been Tested?

🙃

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
