### PR TITLE
feat: Add Prime256v1Identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Added a prime256v1-based `Identity` impl to complement the ed25519 and secp256k1 `Identity` impls.
+
 ## [0.32.0] - 2024-01-18
 
 * Added the chunked wasm API to ic-utils. Existing code that uses `install_code` should probably update to `install`, which works the same but silently handles large wasm modules.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,7 @@ dependencies = [
  "k256",
  "leb128",
  "mockito",
+ "p256",
  "pem",
  "pkcs8",
  "rand",
@@ -1560,6 +1561,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.7",
+]
+
+[[package]]
 name = "pairing"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1713,15 @@ dependencies = [
  "arrayvec",
  "typed-arena",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7dbe9ed3b56368bd99483eb32fe9c17fdd3730aebadc906918ce78d54c7eeb4"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -27,6 +27,7 @@ ic-certification = { workspace = true }
 ic-transport-types = { workspace = true }
 ic-verify-bls-signature = "0.1"
 k256 = { version = "0.13.1", features = ["pem"] }
+p256 = { version = "0.13.2", features = ["pem"] }
 leb128 = { workspace = true }
 pkcs8 = { version = "0.10.2", features = ["std"] }
 sec1 = { version = "0.7.2", features = ["pem"] }

--- a/ic-agent/src/identity/error.rs
+++ b/ic-agent/src/identity/error.rs
@@ -8,8 +8,8 @@ pub enum PemError {
     Io(#[from] std::io::Error),
 
     /// An unsupported curve was detected
-    #[error("Only secp256k1 curve is supported: {0:?}")]
-    UnsupportedKeyCurve(Vec<u8>),
+    #[error("Only {0} curve is supported: {1:?}")]
+    UnsupportedKeyCurve(String, Vec<u8>),
 
     /// An error occurred while reading the file in PEM format.
     #[cfg(feature = "pem")]

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -6,6 +6,7 @@ use crate::{agent::EnvelopeContent, export::Principal};
 pub(crate) mod anonymous;
 pub(crate) mod basic;
 pub(crate) mod delegated;
+pub(crate) mod prime256v1;
 pub(crate) mod secp256k1;
 
 #[cfg(feature = "pem")]
@@ -19,6 +20,8 @@ pub use basic::BasicIdentity;
 pub use delegated::DelegatedIdentity;
 #[doc(inline)]
 pub use ic_transport_types::{Delegation, SignedDelegation};
+#[doc(inline)]
+pub use prime256v1::Prime256v1Identity;
 #[doc(inline)]
 pub use secp256k1::Secp256k1Identity;
 

--- a/ic-agent/src/identity/prime256v1.rs
+++ b/ic-agent/src/identity/prime256v1.rs
@@ -3,7 +3,7 @@ use crate::{agent::EnvelopeContent, export::Principal, Identity, Signature};
 #[cfg(feature = "pem")]
 use crate::identity::error::PemError;
 
-use k256::{
+use p256::{
     ecdsa::{self, signature::Signer, SigningKey, VerifyingKey},
     pkcs8::{Document, EncodePublicKey},
     SecretKey,
@@ -13,17 +13,17 @@ use std::{fs::File, io, path::Path};
 
 use super::Delegation;
 
-/// A cryptographic identity based on the Secp256k1 elliptic curve.
+/// A cryptographic identity based on the Prime256v1 elliptic curve.
 ///
 /// The caller will be represented via [`Principal::self_authenticating`], which contains the SHA-224 hash of the public key.
 #[derive(Clone, Debug)]
-pub struct Secp256k1Identity {
+pub struct Prime256v1Identity {
     private_key: SigningKey,
     _public_key: VerifyingKey,
     der_encoded_public_key: Document,
 }
 
-impl Secp256k1Identity {
+impl Prime256v1Identity {
     /// Creates an identity from a PEM file. Shorthand for calling `from_pem` with `std::fs::read`.
     #[cfg(feature = "pem")]
     pub fn from_pem_file<P: AsRef<Path>>(file_path: P) -> Result<Self, PemError> {
@@ -36,14 +36,14 @@ impl Secp256k1Identity {
         use sec1::{pem::PemLabel, EcPrivateKey};
 
         const EC_PARAMETERS: &str = "EC PARAMETERS";
-        const SECP256K1: &[u8] = b"\x06\x05\x2b\x81\x04\x00\x0a";
+        const PRIME256V1: &[u8] = b"\x06\x08\x2a\x86\x48\xce\x3d\x03\x01\x07";
 
         let contents = pem_reader.bytes().collect::<Result<Vec<u8>, io::Error>>()?;
 
         for pem in pem::parse_many(contents)? {
-            if pem.tag() == EC_PARAMETERS && pem.contents() != SECP256K1 {
+            if pem.tag() == EC_PARAMETERS && pem.contents() != PRIME256V1 {
                 return Err(PemError::UnsupportedKeyCurve(
-                    "secp256k1".to_string(),
+                    "prime256v1".to_string(),
                     pem.contents().to_vec(),
                 ));
             }
@@ -63,7 +63,7 @@ impl Secp256k1Identity {
         let public_key = private_key.public_key();
         let der_encoded_public_key = public_key
             .to_public_key_der()
-            .expect("Cannot DER encode secp256k1 public key.");
+            .expect("Cannot DER encode prime256v1 public key.");
         Self {
             private_key: private_key.into(),
             _public_key: public_key.into(),
@@ -72,7 +72,7 @@ impl Secp256k1Identity {
     }
 }
 
-impl Identity for Secp256k1Identity {
+impl Identity for Prime256v1Identity {
     fn sender(&self) -> Result<Principal, String> {
         Ok(Principal::self_authenticating(
             self.der_encoded_public_key.as_ref(),
@@ -95,12 +95,12 @@ impl Identity for Secp256k1Identity {
         let ecdsa_sig: ecdsa::Signature = self
             .private_key
             .try_sign(content)
-            .map_err(|err| format!("Cannot create secp256k1 signature: {}", err))?;
+            .map_err(|err| format!("Cannot create prime256v1 signature: {}", err))?;
         let r = ecdsa_sig.r().as_ref().to_bytes();
         let s = ecdsa_sig.s().as_ref().to_bytes();
         let mut bytes = [0u8; 64];
         if r.len() > 32 || s.len() > 32 {
-            return Err("Cannot create secp256k1 signature: malformed signature.".to_string());
+            return Err("Cannot create prime256v1 signature: malformed signature.".to_string());
         }
         bytes[(32 - r.len())..32].clone_from_slice(&r);
         bytes[32 + (32 - s.len())..].clone_from_slice(&s);
@@ -119,7 +119,7 @@ impl Identity for Secp256k1Identity {
 mod test {
     use super::*;
     use candid::Encode;
-    use k256::{
+    use p256::{
         ecdsa::{signature::Verifier, Signature},
         elliptic_curve::PrimeField,
         FieldBytes, Scalar,
@@ -127,9 +127,10 @@ mod test {
 
     // WRONG_CURVE_IDENTITY_FILE is generated from the following command:
     // > openssl ecparam -name secp160r2 -genkey
-    // it uses hte secp160r2 curve instead of secp256k1 and should
-    // therefore be rejected by Secp256k1Identity when loading an identity
-    const WRONG_CURVE_IDENTITY_FILE: &str = "-----BEGIN EC PARAMETERS-----
+    // it uses the secp160r2 curve instead of prime256v1 and should
+    // therefore be rejected by Prime256v1Identity when loading an identity
+    const WRONG_CURVE_IDENTITY_FILE: &str = "\
+-----BEGIN EC PARAMETERS-----
 BgUrgQQAHg==
 -----END EC PARAMETERS-----
 -----BEGIN EC PRIVATE KEY-----
@@ -140,61 +141,60 @@ oGSXVWaGxcQhQWlFG4pbnOG+93xXzfRD7eKWOdmun2bKxQ==
 
     // WRONG_CURVE_IDENTITY_FILE_NO_PARAMS is generated from the following command:
     // > openssl ecparam -name secp160r2 -genkey -noout
-    // it uses hte secp160r2 curve instead of secp256k1 and should
-    // therefore be rejected by Secp256k1Identity when loading an identity
-    const WRONG_CURVE_IDENTITY_FILE_NO_PARAMS: &str = "-----BEGIN EC PRIVATE KEY-----
+    // it uses the secp160r2 curve instead of prime256v1 and should
+    // therefore be rejected by Prime256v1Identity when loading an identity
+    const WRONG_CURVE_IDENTITY_FILE_NO_PARAMS: &str = "\
+-----BEGIN EC PRIVATE KEY-----
 MFACAQEEFI9cF6zXxMKhtjn1gBD7AHPbzehfoAcGBSuBBAAeoSwDKgAEh5NXszgR
 oGSXVWaGxcQhQWlFG4pbnOG+93xXzfRD7eKWOdmun2bKxQ==
 -----END EC PRIVATE KEY-----
 ";
 
     // IDENTITY_FILE was generated from the the following commands:
-    // > openssl ecparam -name secp256k1 -genkey -noout -out identity.pem
+    // > openssl ecparam -name prime256v1 -genkey -noout -out identity.pem
     // > cat identity.pem
-    const IDENTITY_FILE: &str = "-----BEGIN EC PARAMETERS-----
-BgUrgQQACg==
------END EC PARAMETERS-----
+    const IDENTITY_FILE: &str = "\
 -----BEGIN EC PRIVATE KEY-----
-MHQCAQEEIAgy7nZEcVHkQ4Z1Kdqby8SwyAiyKDQmtbEHTIM+WNeBoAcGBSuBBAAK
-oUQDQgAEgO87rJ1ozzdMvJyZQ+GABDqUxGLvgnAnTlcInV3NuhuPv4O3VGzMGzeB
-N3d26cRxD99TPtm8uo2OuzKhSiq6EQ==
+MHcCAQEEIL1ybmbwx+uKYsscOZcv71MmKhrNqfPP0ke1unET5AY4oAoGCCqGSM49
+AwEHoUQDQgAEUbbZV4NerZTPWfbQ749/GNLu8TaH8BUS/I7/+ipsu+MPywfnBFIZ
+Sks4xGbA/ZbazsrMl4v446U5UIVxCGGaKw==
 -----END EC PRIVATE KEY-----
 ";
 
     // DER_ENCODED_PUBLIC_KEY was generated from the the following commands:
     // > openssl ec -in identity.pem -pubout -outform DER -out public.der
     // > hexdump -ve '1/1 "%.2x"' public.der
-    const DER_ENCODED_PUBLIC_KEY: &str = "3056301006072a8648ce3d020106052b8104000a0342000480ef3bac9d68cf374cbc9c9943e180043a94c462ef8270274e57089d5dcdba1b8fbf83b7546ccc1b3781377776e9c4710fdf533ed9bcba8d8ebb32a14a2aba11";
+    const DER_ENCODED_PUBLIC_KEY: &str = "3059301306072a8648ce3d020106082a8648ce3d0301070342000451b6d957835ead94cf59f6d0ef8f7f18d2eef13687f01512fc8efffa2a6cbbe30fcb07e70452194a4b38c466c0fd96dacecacc978bf8e3a53950857108619a2b";
 
     #[test]
     #[should_panic(expected = "UnsupportedKeyCurve")]
-    fn test_secp256k1_reject_wrong_curve() {
-        Secp256k1Identity::from_pem(WRONG_CURVE_IDENTITY_FILE.as_bytes()).unwrap();
+    fn test_prime256v1_reject_wrong_curve() {
+        Prime256v1Identity::from_pem(WRONG_CURVE_IDENTITY_FILE.as_bytes()).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "KeyMalformed")]
-    fn test_secp256k1_reject_wrong_curve_no_id() {
-        Secp256k1Identity::from_pem(WRONG_CURVE_IDENTITY_FILE_NO_PARAMS.as_bytes()).unwrap();
+    fn test_prime256v1_reject_wrong_curve_no_id() {
+        Prime256v1Identity::from_pem(WRONG_CURVE_IDENTITY_FILE_NO_PARAMS.as_bytes()).unwrap();
     }
 
     #[test]
-    fn test_secp256k1_public_key() {
-        // Create a secp256k1 identity from a PEM file.
-        let identity = Secp256k1Identity::from_pem(IDENTITY_FILE.as_bytes())
-            .expect("Cannot create secp256k1 identity from PEM file.");
+    fn test_prime256v1_public_key() {
+        // Create a prime256v1 identity from a PEM file.
+        let identity = Prime256v1Identity::from_pem(IDENTITY_FILE.as_bytes())
+            .expect("Cannot create prime256v1 identity from PEM file.");
 
-        // Assert the DER-encoded secp256k1 public key matches what we would expect.
+        // Assert the DER-encoded prime256v1 public key matches what we would expect.
         assert!(DER_ENCODED_PUBLIC_KEY == hex::encode(identity.der_encoded_public_key));
     }
 
     #[test]
-    fn test_secp256k1_signature() {
-        // Create a secp256k1 identity from a PEM file.
-        let identity = Secp256k1Identity::from_pem(IDENTITY_FILE.as_bytes())
-            .expect("Cannot create secp256k1 identity from PEM file.");
+    fn test_prime256v1_signature() {
+        // Create a prime256v1 identity from a PEM file.
+        let identity = Prime256v1Identity::from_pem(IDENTITY_FILE.as_bytes())
+            .expect("Cannot create prime256v1 identity from PEM file.");
 
-        // Create a secp256k1 signature for a hello-world canister.
+        // Create a prime256v1 signature for a hello-world canister.
         let message = EnvelopeContent::Call {
             nonce: None,
             ingress_expiry: 0,
@@ -205,24 +205,24 @@ N3d26cRxD99TPtm8uo2OuzKhSiq6EQ==
         };
         let signature = identity
             .sign(&message)
-            .expect("Cannot create secp256k1 signature.")
+            .expect("Cannot create prime256v1 signature.")
             .signature
-            .expect("Cannot find secp256k1 signature bytes.");
+            .expect("Cannot find prime256v1 signature bytes.");
 
-        // Import the secp256k1 signature into OpenSSL.
+        // Import the prime256v1 signature.
         let r: Scalar = Option::from(Scalar::from_repr(*FieldBytes::from_slice(
             &signature[0..32],
         )))
-        .expect("Cannot extract r component from secp256k1 signature bytes.");
+        .expect("Cannot extract r component from prime256v1 signature bytes.");
         let s: Scalar = Option::from(Scalar::from_repr(*FieldBytes::from_slice(&signature[32..])))
-            .expect("Cannot extract s component from secp256k1 signature bytes.");
+            .expect("Cannot extract s component from prime256v1 signature bytes.");
         let ecdsa_sig = Signature::from_scalars(r, s)
-            .expect("Cannot create secp256k1 signature from r and s components.");
+            .expect("Cannot create prime256v1 signature from r and s components.");
 
-        // Assert the secp256k1 signature is valid.
+        // Assert the prime256v1 signature is valid.
         identity
             ._public_key
             .verify(&message.to_request_id().signable(), &ecdsa_sig)
-            .expect("Cannot verify secp256k1 signature.");
+            .expect("Cannot verify prime256v1 signature.");
     }
 }

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -1,5 +1,5 @@
 use ic_agent::agent::http_transport::ReqwestTransport;
-use ic_agent::identity::Secp256k1Identity;
+use ic_agent::identity::{Prime256v1Identity, Secp256k1Identity};
 use ic_agent::{export::Principal, identity::BasicIdentity, Agent, Identity};
 use ic_identity_hsm::HardwareIdentity;
 use ic_utils::interfaces::{management_canister::builders::MemoryAllocation, ManagementCanister};
@@ -74,6 +74,22 @@ yeMC60IsMNxDjLqElV7+T7dkb5Ki7Q==
 
     let identity = Secp256k1Identity::from_pem(identity_file.as_bytes())
         .expect("Cannot create secp256k1 identity from PEM file.");
+    Ok(identity)
+}
+
+pub fn create_prime256v1_identity() -> Result<Prime256v1Identity, String> {
+    // generated from the following command:
+    // $ openssl ecparam -name prime256v1 -genkey -noout -out identity.pem
+    // $ cat identity.pem
+    let identity_file = "\
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIL1ybmbwx+uKYsscOZcv71MmKhrNqfPP0ke1unET5AY4oAoGCCqGSM49
+AwEHoUQDQgAEUbbZV4NerZTPWfbQ749/GNLu8TaH8BUS/I7/+ipsu+MPywfnBFIZ
+Sks4xGbA/ZbazsrMl4v446U5UIVxCGGaKw==
+-----END EC PRIVATE KEY-----";
+
+    let identity = Prime256v1Identity::from_pem(identity_file.as_bytes())
+        .expect("Cannot create prime256v1 identity from PEM file.");
     Ok(identity)
 }
 


### PR DESCRIPTION
The IC supports ed25519, secp256k1, and prime256v1 curves. agent-rs has the first two, but the only way to use the latter is ic-identity-hsm. This PR adds an in-memory prime256v1 `Identity` impl to complement the other two.