### PR TITLE
feat: add pre signed read state call wait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,6 +1822,7 @@ version = "0.0.0"
 dependencies = [
  "candid",
  "ic-agent",
+ "ic-certification",
  "ic-identity-hsm",
  "ic-utils",
  "ring",

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -671,7 +671,7 @@ impl Agent {
         effective_canister_id: Principal,
         signed_request_status: Vec<u8>,
     ) -> Result<Vec<u8>, AgentError> {
-        let mut retry_policy = get_retry_policy();
+        let mut retry_policy = Self::get_retry_policy();
 
         let mut request_accepted = false;
         loop {
@@ -715,7 +715,7 @@ impl Agent {
         request_id: RequestId,
         effective_canister_id: Principal,
     ) -> Result<Vec<u8>, AgentError> {
-        let mut retry_policy = get_retry_policy();
+        let mut retry_policy = Self::get_retry_policy();
 
         let mut request_accepted = false;
         loop {

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -33,6 +33,7 @@ use crate::{
     identity::Identity,
     to_request_id, RequestId,
 };
+use backoff::exponential::ExponentialBackoff;
 use backoff::{backoff::Backoff, ExponentialBackoffBuilder};
 use ic_certification::{Certificate, Delegation, Label};
 use ic_transport_types::{
@@ -667,7 +668,7 @@ impl Agent {
 
     pub async fn wait_signed(
         &self,
-        request_id: RequestId,
+        request_id: &RequestId,
         effective_canister_id: Principal,
         signed_request_status: Vec<u8>,
     ) -> Result<Vec<u8>, AgentError> {
@@ -676,7 +677,7 @@ impl Agent {
         let mut request_accepted = false;
         loop {
             match self
-                .request_status_signed(&request_id, effective_canister_id, signed_request_status)
+                .request_status_signed(request_id, effective_canister_id, signed_request_status)
                 .await?
             {
                 RequestStatusResponse::Unknown => {}

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -17,3 +17,4 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 serde_cbor = { workspace = true }
+ic-certification = { workspace = true }


### PR DESCRIPTION
This MR proposes the following changes:

Currently, the agent can only be used with a private key that is known to the agent. If someone wants to sign their request outside of the agent, they cannot forward this signed request using the agent. 

The agent already offers a method that lets a user forward a signed `Envelope` of `EnvelopeContent::Call` to the IC. This MR adds the same functionality for a signed `Envelope` of EnvelopeContent::ReadState to the IC. 

The method that is added is similar to the already existing `wait(..)` method but also takes in the signed request. 