### PR TITLE
chore: update ic-ref test to use dfx 0.16.1; update gh action versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,9 +14,9 @@ jobs:
         dfx: [ '0.8.4', '0.9.2', '0.10.1', '0.11.1' ]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Cache Cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -11,10 +11,10 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Cache Cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - latest-dfx
   pull_request:
 
 jobs:
@@ -26,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install dfx
-        uses: dfinity/setup-dfx@main
+        uses: dfinity/setup-dfx@use-dfxvm
         with:
           dfx-version: "0.15.3-largewasm.0"
 

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -32,7 +32,7 @@ jobs:
           dfx-version: "0.16.1"
 
       - name: Cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - latest-dfx
   pull_request:
 
 jobs:
@@ -27,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dfx
-        uses: dfinity/setup-dfx@use-dfxvm
+        uses: dfinity/setup-dfx@main
         with:
           dfx-version: "0.16.1"
 

--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -20,16 +20,16 @@ jobs:
             os: ubuntu-latest
 
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install dfx
         uses: dfinity/setup-dfx@use-dfxvm
         with:
-          dfx-version: "0.15.3-largewasm.0"
+          dfx-version: "0.16.1"
 
       - name: Cargo cache
         uses: actions/cache@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,9 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
             binary_path: target/x86_64-apple-darwin/release
             binary_files: icx
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - name: Setup environment variables
       run: |

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,7 @@ jobs:
     # ubuntu-latest has shellcheck 0.4.6, while macos-latest has 0.7.1
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install shellcheck
         run: |
           mkdir $HOME/bin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
Also updated github actions versions due to Node deprecations.
