### PR TITLE
fix!: change type of skip_pre_upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed the return type of `stored_chunks` to a struct.
 * Added a prime256v1-based `Identity` impl to complement the ed25519 and secp256k1 `Identity` impls.
 * Added serde and candid serialization traits to the `Status` type.
+* Changed the type of `InstallMode.skip_pre_upgrade` from `bool` to `Option<bool>` to match the interface specification.
 
 ## [0.32.0] - 2024-01-18
 

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -33,7 +33,7 @@ pub struct CanisterSettings {
     pub controllers: Option<Vec<Principal>>,
     /// The allocation percentage (between 0 and 100 inclusive) for *guaranteed* compute capacity.
     ///
-    /// The settings update will be rejected if the IC can't commit to allocating this much compupte capacity.
+    /// The settings update will be rejected if the IC can't commit to allocating this much compute capacity.
     ///
     /// If unspecified and a canister is being created with these settings, defaults to 0, i.e. best-effort.
     pub compute_allocation: Option<Nat>,
@@ -392,7 +392,7 @@ pub enum InstallMode {
     #[serde(rename = "upgrade")]
     Upgrade {
         /// If true, skip a canister's `#[pre_upgrade]` function.
-        skip_pre_upgrade: bool,
+        skip_pre_upgrade: Option<bool>,
     },
 }
 
@@ -419,7 +419,7 @@ impl FromStr for InstallMode {
             "install" => Ok(InstallMode::Install),
             "reinstall" => Ok(InstallMode::Reinstall),
             "upgrade" => Ok(InstallMode::Upgrade {
-                skip_pre_upgrade: false,
+                skip_pre_upgrade: Some(false),
             }),
             &_ => Err(format!("Invalid install mode: {}", s)),
         }

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -162,7 +162,7 @@ mod management_canister {
             // Upgrade should succeed.
             ic00.install_code(&canister_id, &canister_wasm)
                 .with_mode(InstallMode::Upgrade {
-                    skip_pre_upgrade: false,
+                    skip_pre_upgrade: None,
                 })
                 .call_and_wait()
                 .await?;
@@ -171,7 +171,7 @@ mod management_canister {
             let result = other_ic00
                 .install_code(&canister_id, &canister_wasm)
                 .with_mode(InstallMode::Upgrade {
-                    skip_pre_upgrade: false,
+                    skip_pre_upgrade: None,
                 })
                 .call_and_wait()
                 .await;
@@ -486,7 +486,7 @@ mod management_canister {
             // Upgrade should succeed
             ic00.install_code(&canister_id, &canister_wasm)
                 .with_mode(InstallMode::Upgrade {
-                    skip_pre_upgrade: false,
+                    skip_pre_upgrade: None,
                 })
                 .call_and_wait()
                 .await?;


### PR DESCRIPTION
# Description

Tried to add `--skip-pre-upgrade` to dfx and noticed it doesn't work. Turns out the type is wrong

# How Has This Been Tested?

Not tested.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
