### PR TITLE
feat: Add unsupported methods to MgmtMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* Added ECDSA and Bitcoin functions to MgmtMethod. There are no new wrappers in ManagementCanister because only canisters can call these functions.
+
 ## [0.33.0] - 2024-02-08
 
 * Changed the return type of `stored_chunks` to a struct.

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -6,7 +6,7 @@ use crate::{call::AsyncCall, Canister};
 use candid::{CandidType, Deserialize, Nat};
 use ic_agent::{export::Principal, Agent};
 use std::{convert::AsRef, ops::Deref};
-use strum_macros::{AsRefStr, EnumString};
+use strum_macros::{AsRefStr, Display, EnumString};
 
 pub mod attributes;
 pub mod builders;
@@ -29,7 +29,7 @@ impl<'agent> Deref for ManagementCanister<'agent> {
 }
 
 /// All the known methods of the management canister.
-#[derive(AsRefStr, Debug, EnumString)]
+#[derive(AsRefStr, Debug, EnumString, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum MgmtMethod {
     /// See [`ManagementCanister::create_canister`].
@@ -64,6 +64,22 @@ pub enum MgmtMethod {
     StoredChunks,
     /// See [`ManagementCanister::install_chunked_code`].
     InstallChunkedCode,
+    /// There is no corresponding agent function as only canisters can call it.
+    EcdsaPublicKey,
+    /// There is no corresponding agent function as only canisters can call it.
+    SignWithEcdsa,
+    /// There is no corresponding agent function as only canisters can call it.
+    BitcoinGetBalance,
+    /// There is no corresponding agent function as only canisters can call it.
+    BitcoinGetBalanceQuery,
+    /// There is no corresponding agent function as only canisters can call it.
+    BitcoinGetUtxos,
+    /// There is no corresponding agent function as only canisters can call it.
+    BitcoinGetUtxosQuery,
+    /// There is no corresponding agent function as only canisters can call it.
+    BitcoinSendTransaction,
+    /// There is no corresponding agent function as only canisters can call it.
+    BitcoinGetCurrentFeePercentiles,
 }
 
 impl<'agent> ManagementCanister<'agent> {

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -322,6 +322,16 @@ pub fn get_effective_canister_id(
                     .context("Argument is not valid for InstallChunkedCode")?;
                 Ok(in_args.target_canister)
             }
+            MgmtMethod::BitcoinGetBalance
+            | MgmtMethod::BitcoinGetBalanceQuery
+            | MgmtMethod::BitcoinGetUtxos
+            | MgmtMethod::BitcoinGetUtxosQuery
+            | MgmtMethod::BitcoinSendTransaction
+            | MgmtMethod::BitcoinGetCurrentFeePercentiles
+            | MgmtMethod::EcdsaPublicKey
+            | MgmtMethod::SignWithEcdsa => {
+                bail!("Management canister method {method_name} can only be run from canisters");
+            }
         }
     } else {
         Ok(canister_id)


### PR DESCRIPTION
This adds the ECDSA and Bitcoin functions to MgmtMethod for completeness, but no wrapper functions in ManagementCanister because only canisters can call these functions.