### PR TITLE
feat: [IC-272] add fetch_canister_logs method to management canister

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* Added ECDSA and Bitcoin functions to MgmtMethod. There are no new wrappers in ManagementCanister because only canisters can call these functions.
+* Added ECDSA and Bitcoin functions to `MgmtMethod`. There are no new wrappers in `ManagementCanister` because only canisters can call these functions.
+* Added `FetchCanisterLogs` function to `MgmtMethod` and a corresponding wrapper to `ManagementCanister`.
 
 ## [0.33.0] - 2024-02-08
 

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -199,16 +199,22 @@ impl std::fmt::Display for CanisterStatus {
     }
 }
 
+/// A log record of a canister.
 #[derive(Default, Clone, CandidType, Deserialize, Debug, PartialEq, Eq)]
 pub struct CanisterLogRecord {
+    /// The index of the log record.
     pub idx: u64,
+    /// The timestamp of the log record.
     pub timestamp_nanos: u64,
+    /// The content of the log record.
     #[serde(with = "serde_bytes")]
     pub content: Vec<u8>,
 }
 
+/// The result of a [`ManagementCanister::fetch_canister_logs`] call.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, CandidType)]
 pub struct FetchCanisterLogsResponse {
+    /// The logs of the canister.
     pub canister_log_records: Vec<CanisterLogRecord>,
 }
 

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -64,6 +64,8 @@ pub enum MgmtMethod {
     StoredChunks,
     /// See [`ManagementCanister::install_chunked_code`].
     InstallChunkedCode,
+    /// See [`ManagementCanister::fetch_canister_logs`].
+    FetchCanisterLogs,
     /// There is no corresponding agent function as only canisters can call it.
     EcdsaPublicKey,
     /// There is no corresponding agent function as only canisters can call it.
@@ -80,8 +82,6 @@ pub enum MgmtMethod {
     BitcoinSendTransaction,
     /// There is no corresponding agent function as only canisters can call it.
     BitcoinGetCurrentFeePercentiles,
-    /// See [`ManagementCanister::fetch_canister_logs`].
-    FetchCanisterLogs,
 }
 
 impl<'agent> ManagementCanister<'agent> {

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -459,6 +459,7 @@ impl<'agent> ManagementCanister<'agent> {
             canister_id: Principal,
         }
 
+        // `fetch_canister_logs` is only supported in non-replicated mode.
         self.query(MgmtMethod::FetchCanisterLogs.as_ref())
             .with_arg(In {
                 canister_id: *canister_id,

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -211,11 +211,23 @@ pub struct CanisterLogRecord {
     pub content: Vec<u8>,
 }
 
+impl std::fmt::Display for CanisterLogRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
 /// The result of a [`ManagementCanister::fetch_canister_logs`] call.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, CandidType)]
 pub struct FetchCanisterLogsResponse {
     /// The logs of the canister.
     pub canister_log_records: Vec<CanisterLogRecord>,
+}
+
+impl std::fmt::Display for FetchCanisterLogsResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
 }
 
 /// A SHA-256 hash of a WASM chunk.

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -464,7 +464,7 @@ impl<'agent> ManagementCanister<'agent> {
             .with_arg(In {
                 canister_id: *canister_id,
             })
-            .with_effective_canister_id(canister_id.to_owned())
+            .with_effective_canister_id(*canister_id)
             .build()
     }
 }

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -80,6 +80,8 @@ pub enum MgmtMethod {
     BitcoinSendTransaction,
     /// There is no corresponding agent function as only canisters can call it.
     BitcoinGetCurrentFeePercentiles,
+    /// See [`ManagementCanister::fetch_canister_logs`].
+    FetchCanisterLogs,
 }
 
 impl<'agent> ManagementCanister<'agent> {

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -211,23 +211,11 @@ pub struct CanisterLogRecord {
     pub content: Vec<u8>,
 }
 
-impl std::fmt::Display for CanisterLogRecord {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(self, f)
-    }
-}
-
 /// The result of a [`ManagementCanister::fetch_canister_logs`] call.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, CandidType)]
 pub struct FetchCanisterLogsResponse {
     /// The logs of the canister.
     pub canister_log_records: Vec<CanisterLogRecord>,
-}
-
-impl std::fmt::Display for FetchCanisterLogsResponse {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(self, f)
-    }
 }
 
 /// A SHA-256 hash of a WASM chunk.

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -293,7 +293,8 @@ pub fn get_effective_canister_id(
             | MgmtMethod::ProvisionalTopUpCanister
             | MgmtMethod::UploadChunk
             | MgmtMethod::ClearChunkStore
-            | MgmtMethod::StoredChunks => {
+            | MgmtMethod::StoredChunks
+            | MgmtMethod::FetchCanisterLogs => {
                 #[derive(CandidType, Deserialize)]
                 struct In {
                     canister_id: Principal,


### PR DESCRIPTION
# Description

This PR adds a new `MgmtMethod::FetchCanisterLogs` item to the management canister methods enum with a corresponding `ManagementCanister::fetch_canister_logs()` wrapper and a `FetchCanisterLogsResponse` as a result type. Note that this method can only be called in non-replicated mode.

# How Has This Been Tested?

Regular CI.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
