### PR TITLE
fix: fetch_root_key refuses to play along if called on the mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added node metrics, ECDSA, and Bitcoin functions to `MgmtMethod`. Most do not have wrappers in `ManagementCanister` because only canisters can call these functions.
 * Added `FetchCanisterLogs` function to `MgmtMethod` and a corresponding wrapper to `ManagementCanister`.
 * Updated the `ring` crate to 0.17.7.  `ring` 0.16 has a bug where it requires incorrect Ed25519 PEM encoding. 0.17.7 fixes that and is backwards compatible.
+* Agent::fetch_root_key() now returns an error, and sets its root key to an empty vector, if called on the mainnet.
 
 ## [0.33.0] - 2024-02-08
 

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -201,6 +201,11 @@ pub enum AgentError {
     /// Route provider failed to generate a url for some reason.
     #[error("Route provider failed to generate url: {0}")]
     RouteProviderError(String),
+
+    /// It's an error to fetch the root key on the mainnet.
+    /// Doing so would enable a man-in-the-middle attack.
+    #[error("Never fetch the root key on the mainnet")]
+    NeverFetchRootKeyOnMainNet(),
 }
 
 impl PartialEq for AgentError {

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -44,6 +44,21 @@ fn make_certifying_agent(url: &str) -> Agent {
 
 #[cfg_attr(not(target_family = "wasm"), tokio::test)]
 #[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+async fn refuse_to_install_mainnet_root_key() -> Result<(), AgentError> {
+    let url = "https://icp0.io";
+
+    let agent = make_agent(&url);
+    let result = agent.fetch_root_key().await;
+    assert!(matches!(
+        result,
+        Err(AgentError::NeverFetchRootKeyOnMainNet())
+    ));
+    assert_eq!(agent.read_root_key(), Vec::<u8>::new());
+    Ok(())
+}
+
+#[cfg_attr(not(target_family = "wasm"), tokio::test)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
 async fn query() -> Result<(), AgentError> {
     let blob = Vec::from("Hello World");
     let response = QueryResponse::Replied {

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -330,6 +330,11 @@ impl Agent {
         }
         let status = self.status().await?;
         let root_key = match status.root_key {
+            Some(key) if key[..] == IC_ROOT_KEY[..] => {
+                // even if the caller ignores this error, we're done here.
+                self.set_root_key(vec![]);
+                return Err(AgentError::NeverFetchRootKeyOnMainNet());
+            }
             Some(key) => key,
             None => return Err(AgentError::NoRootKeyInStatus(status)),
         };
@@ -340,7 +345,7 @@ impl Agent {
     /// By default, the agent is configured to talk to the main Internet Computer, and verifies
     /// responses using a hard-coded public key.
     ///
-    /// Using this function you can set the root key to a known one if you know if beforehand.
+    /// Using this function you can set the root key to a known one if you know it beforehand.
     pub fn set_root_key(&self, root_key: Vec<u8>) {
         *self.root_key.write().unwrap() = root_key;
     }


### PR DESCRIPTION
# Description

It's a mistake to call `Agent.fetch_root_key()` on the mainnet.  This makes it also an error, and also zeroes out the root key so that the agent would fail to verify any signatures even if the caller ignored the error. 

# How Has This Been Tested?

Added a test

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
