### PR TITLE
fix: Status now serializes to json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added node metrics, ECDSA, and Bitcoin functions to `MgmtMethod`. Most do not have wrappers in `ManagementCanister` because only canisters can call these functions.
 * Added `FetchCanisterLogs` function to `MgmtMethod` and a corresponding wrapper to `ManagementCanister`.
 * Updated the `ring` crate to 0.17.7.  `ring` 0.16 has a bug where it requires incorrect Ed25519 PEM encoding. 0.17.7 fixes that and is backwards compatible.
+* Fixed Status serializing to json. It now serializes the values map, and does not include the types of each entry.
 
 ## [0.33.0] - 2024-02-08
 

--- a/ic-agent/src/agent/status.rs
+++ b/ic-agent/src/agent/status.rs
@@ -119,20 +119,31 @@ fn can_serialize_status_as_json_with_non_null() {
         Text("replica_health_status".to_string()),
         Text("healthy".to_string()),
     );
-    map.insert(Text("certified_height".to_string()), serde_cbor::value::Value::Integer(654275));
+    map.insert(
+        Text("certified_height".to_string()),
+        serde_cbor::value::Value::Integer(654275),
+    );
     map.insert(
         Text("arbitrary".to_string()),
         serde_cbor::value::Value::Null,
     );
-    map.insert(Text("root_key".to_string()), serde_cbor::value::Value::Bytes(vec![1, 2, 3, 4]));
-    map.insert(Text("truthy".to_string()), serde_cbor::value::Value::Bool(true));
+    map.insert(
+        Text("root_key".to_string()),
+        serde_cbor::value::Value::Bytes(vec![1, 2, 3, 4]),
+    );
+    map.insert(
+        Text("truthy".to_string()),
+        serde_cbor::value::Value::Bool(true),
+    );
     let mut submap = BTreeMap::new();
     submap.insert(Text("foo".to_string()), Text("bar".to_string()));
-    map.insert(Text("submap".to_string()), serde_cbor::value::Value::Map(submap));
+    map.insert(
+        Text("submap".to_string()),
+        serde_cbor::value::Value::Map(submap),
+    );
     let cbor = serde_cbor::Value::Map(map);
     let status = Status::try_from(&cbor).expect("Failed to convert from cbor");
-    let expected_json =
-        r#"{"arbitrary":null,"certified_height":654275,"impl_version":"0.19.2","replica_health_status":"healthy","root_key":[1,2,3,4],"submap":{"foo":"bar"},"truthy":true}"#;
+    let expected_json = r#"{"arbitrary":null,"certified_height":654275,"impl_version":"0.19.2","replica_health_status":"healthy","root_key":[1,2,3,4],"submap":{"foo":"bar"},"truthy":true}"#;
     let actual_json = serde_json::to_string(&status).expect("Failed to serialize as JSON");
     assert_eq!(expected_json, actual_json);
 }

--- a/ic-agent/src/agent/status.rs
+++ b/ic-agent/src/agent/status.rs
@@ -97,20 +97,6 @@ impl Serialize for Status {
 
 #[test]
 fn can_serialize_status_as_json() {
-    let status = Status {
-        impl_version: None,
-        replica_health_status: None,
-        root_key: None,
-        values: BTreeMap::new(),
-    };
-    let expected_json =
-        r#"{"impl_version":null,"replica_health_status":null,"root_key":null,"values":{}}"#;
-    let actual_json = serde_json::to_string(&status).expect("Failed to serialize as JSON");
-    assert_eq!(expected_json, actual_json);
-}
-
-#[test]
-fn can_serialize_status_as_json_with_non_null() {
     use serde_cbor::value::Value::Text;
 
     let mut map: BTreeMap<serde_cbor::value::Value, serde_cbor::value::Value> = BTreeMap::new();
@@ -131,6 +117,7 @@ fn can_serialize_status_as_json_with_non_null() {
         Text("root_key".to_string()),
         serde_cbor::value::Value::Bytes(vec![1, 2, 3, 4]),
     );
+    map.insert(Text("nully".to_string()), serde_cbor::value::Value::Null);
     map.insert(
         Text("truthy".to_string()),
         serde_cbor::value::Value::Bool(true),
@@ -143,7 +130,7 @@ fn can_serialize_status_as_json_with_non_null() {
     );
     let cbor = serde_cbor::Value::Map(map);
     let status = Status::try_from(&cbor).expect("Failed to convert from cbor");
-    let expected_json = r#"{"arbitrary":null,"certified_height":654275,"impl_version":"0.19.2","replica_health_status":"healthy","root_key":[1,2,3,4],"submap":{"foo":"bar"},"truthy":true}"#;
+    let expected_json = r#"{"arbitrary":null,"certified_height":654275,"impl_version":"0.19.2","nully":null,"replica_health_status":"healthy","root_key":[1,2,3,4],"submap":{"foo":"bar"},"truthy":true}"#;
     let actual_json = serde_json::to_string(&status).expect("Failed to serialize as JSON");
     assert_eq!(expected_json, actual_json);
 }


### PR DESCRIPTION
# Description

Status now serializes to json everything in the values map, without the enum types

Part of https://dfinity.atlassian.net/browse/SDK-1457

Prior, serializing to json looked like this:
```json
{
  "impl_hash": "a380266e4b6977b7cce447aa5f784efdba0bb45820d51f39b9e7908f7fbb1aa1",
  "replica_health_status": "healthy",
  "root_key": [ 48, 129, 130 ],
  "values": {
    "certified_height": {
      "Integer": 948674
    },
    "ic_api_version": {
      "String": "0.18.0"
    },
    "impl_hash": {
      "String": "a380266e4b6977b7cce447aa5f784efdba0bb45820d51f39b9e7908f7fbb1aa1"
    },
    "impl_version": {
      "String": "0.9.0"
    },
    "replica_health_status": {
      "String": "healthy"
    },
    "root_key": {
      "Bytes": [
        48,
        129,
        130
      ]
    }
  }
}
```


# How Has This Been Tested?

Changed the test to build the Status from cbor, in order to populate the values the way that actually happens.  Also tested locally with dfx ping:
```
$ dfx ping
{"certified_height":953309,"ic_api_version":"0.18.0","impl_hash":"a380266e4b6977b7cce447aa5f784efdba0bb45820d51f39b9e7908f7fbb1aa1","impl_version":"0.9.0","replica_health_status":"healthy","root_key":[48,129,130,48,29,6,13,43,6,1,4,1,130,220,124,5,3,1,2,1,6,12,43,6,1,4,1,130,220,124,5,3,2,1,3,97,0,141,112,44,49,204,10,52,103,112,50,213,52,220,171,58,218,10,234,157,59,85,7,80,99,161,109,225,44,206,32,66,199,182,184,50,240,80,243,131,149,39,55,219,247,20,71,75,63,16,9,217,12,111,97,242,112,231,229,216,169,214,145,220,61,185,28,221,211,199,38,126,171,26,207,140,210,43,188,187,142,140,38,131,73,28,195,49,117,148,138,203,72,51,45,93,5]}
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
