### PR TITLE
fix: Revert: Add serialization traits to Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added node metrics, ECDSA, and Bitcoin functions to `MgmtMethod`. Most do not have wrappers in `ManagementCanister` because only canisters can call these functions.
 * Added `FetchCanisterLogs` function to `MgmtMethod` and a corresponding wrapper to `ManagementCanister`.
 * Updated the `ring` crate to 0.17.7.  `ring` 0.16 has a bug where it requires incorrect Ed25519 PEM encoding. 0.17.7 fixes that and is backwards compatible.
+* Removed serde and candid serialization traits from the `Status` type.
 
 ## [0.33.0] - 2024-02-08
 
 * Changed the return type of `stored_chunks` to a struct.
 * Added a prime256v1-based `Identity` impl to complement the ed25519 and secp256k1 `Identity` impls.
-* Added serde and candid serialization traits to the `Status` type.
 * Changed the type of `InstallMode.skip_pre_upgrade` from `bool` to `Option<bool>` to match the interface specification.
 
 ## [0.32.0] - 2024-01-18

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -80,7 +80,6 @@ web-sys = { version = "0.3", features = ["Window"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.79"
-candid = { workspace = true, features = ["value"]}
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tokio = { version = "1.24.2", features = ["full"] }


### PR DESCRIPTION
# Description

This is a breaking change.

https://github.com/dfinity/agent-rs/pull/499 added the CandidType, Serialize, and Deserialized traits to Status, in support of `dfx ping` to output json.

However, Status isn't really appropriate for any of these.  The `values` map contains every field in the status.  But the other fields are populated during cbor deserialization.  It's true that technically, you could serialize a Status and then deserialize it, even to and from candid.  But when formatted to json, with the default serializer, a Status might look like this:
```
{
  "impl_hash": "a380266e4b6977b7cce447aa5f784efdba0bb45820d51f39b9e7908f7fbb1aa1",
  "replica_health_status": "healthy",
  "root_key": [ 48, 129, 130 ],
  "values": {
    "certified_height": {
      "Integer": 948674
    },
    "ic_api_version": {
      "String": "0.18.0"
    },
    "impl_hash": {
      "String": "a380266e4b6977b7cce447aa5f784efdba0bb45820d51f39b9e7908f7fbb1aa1"
    },
    "impl_version": {
      "String": "0.9.0"
    },
    "replica_health_status": {
      "String": "healthy"
    },
    "root_key": {
      "Bytes": [
        48,
        129,
        130
      ]
    }
  }
}
```

This reverts commit f216c74cc1130ebb1654ab132e77994911f9eb34(https://github.com/dfinity/agent-rs/pull/499).  We'll address the output of `dfx ping` in another way.

# How Has This Been Tested?

The reversion removed the related test.
# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
