### PR TITLE
fix: effective_canister_id of bitcoin queries

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,8 +40,8 @@ jobs:
               echo "DFX_NO_WALLET=--no-wallet" >> "$GITHUB_ENV"
           fi
 
-      - name: 'Run tests'
-        run: bats e2e/bash/icx.bash 
+      # - name: 'Run tests'
+      #   run: bats e2e/bash/icx.bash 
 
   aggregate:
     name: e2e:required

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,8 +40,8 @@ jobs:
               echo "DFX_NO_WALLET=--no-wallet" >> "$GITHUB_ENV"
           fi
 
-      # - name: 'Run tests'
-      #   run: bats e2e/bash/icx.bash 
+      - name: 'Run tests'
+        run: bats e2e/bash/icx.bash 
 
   aggregate:
     name: e2e:required

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -232,22 +232,11 @@ pub enum BitcoinNetwork {
     /// The TESTBTC network.
     #[serde(rename = "testnet")]
     Testnet,
-}
-
-impl BitcoinNetwork {
-    /// Gets the [effective canister ID](crate::call::SyncCallBuilder::with_effective_canister_id)
-    // to make `bitcoin_*` calls to.
-    pub fn effective_canister_id(&self) -> Principal {
-        const BITCOIN_MAINNET_CANISTER: Principal =
-            Principal::from_slice(b"\x00\x00\x00\x00\x01\xa0\x00\x04\x01\x01"); // ghsi2-tqaaa-aaaan-aaaca-cai
-        const BITCOIN_TESTNET_CANISTER: Principal =
-            Principal::from_slice(b"\x00\x00\x00\x00\x01\xa0\x00\x01\x01\x01"); // g4xu7-jiaaa-aaaan-aaaaq-cai
-
-        match self {
-            Self::Mainnet => BITCOIN_MAINNET_CANISTER,
-            Self::Testnet => BITCOIN_TESTNET_CANISTER,
-        }
-    }
+    /// The REGTEST network.
+    ///
+    /// This is only available when developing with local replica.
+    #[serde(rename = "regtest")]
+    Regtest,
 }
 
 /// Defines how to filter results from [`bitcoin_get_utxos_query`](ManagementCanister::bitcoin_get_utxos_query).
@@ -562,7 +551,7 @@ impl<'agent> ManagementCanister<'agent> {
                 network,
                 min_confirmations,
             })
-            .with_effective_canister_id(network.effective_canister_id())
+            .with_effective_canister_id(Principal::management_canister())
             .build()
     }
 
@@ -589,7 +578,7 @@ impl<'agent> ManagementCanister<'agent> {
                 network,
                 filter,
             })
-            .with_effective_canister_id(network.effective_canister_id())
+            .with_effective_canister_id(Principal::management_canister())
             .build()
     }
 }

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -18,7 +18,7 @@ use ic_agent::{
 };
 use ic_utils::interfaces::management_canister::{
     builders::{CanisterInstall, CanisterSettings},
-    BitcoinNetwork, MgmtMethod,
+    MgmtMethod,
 };
 use ring::signature::Ed25519KeyPair;
 use std::{
@@ -324,13 +324,7 @@ pub fn get_effective_canister_id(
                 Ok(in_args.target_canister)
             }
             MgmtMethod::BitcoinGetBalanceQuery | MgmtMethod::BitcoinGetUtxosQuery => {
-                #[derive(CandidType, Deserialize)]
-                struct In {
-                    network: BitcoinNetwork,
-                }
-                let in_args = Decode!(arg_value, In)
-                    .with_context(|| format!("Argument is not valid for {method_name}"))?;
-                Ok(in_args.network.effective_canister_id())
+                Ok(Principal::management_canister())
             }
             MgmtMethod::BitcoinGetBalance
             | MgmtMethod::BitcoinGetUtxos


### PR DESCRIPTION
# Description

In short, the effectice_canister_id should be `aaaaa-aa` (management canister).
The same issue was found in dfx: https://github.com/dfinity/sdk/pull/3660
So apply the same fix.

# How Has This Been Tested?

The API was added without any tests. We may add it in a later PR.
The sdk PR above gives somewhat confidence.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
