### PR TITLE
fix: fmt::Display output for Status is now valid JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `FetchCanisterLogs` function to `MgmtMethod` and a corresponding wrapper to `ManagementCanister`.
 * Updated the `ring` crate to 0.17.7.  `ring` 0.16 has a bug where it requires incorrect Ed25519 PEM encoding. 0.17.7 fixes that and is backwards compatible.
 * Removed serde and candid serialization traits from the `Status` type.
+* Added commas and newlines to the `Status` fmt::Display output. It is valid JSON now (it was close before).
 
 ## [0.33.0] - 2024-02-08
 

--- a/ic-agent/src/agent/status.rs
+++ b/ic-agent/src/agent/status.rs
@@ -58,7 +58,13 @@ pub struct Status {
 impl std::fmt::Display for Status {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("{\n")?;
+        let mut first = true;
         for (key, value) in &self.values {
+            if first {
+                first = false;
+            } else {
+                f.write_str(",\n")?;
+            }
             f.write_fmt(format_args!(r#"  "{}": "#, key.escape_debug()))?;
             std::fmt::Display::fmt(&value, f)?;
         }


### PR DESCRIPTION
# Description

Added a comma and newline in between fields.  

Fixes https://dfinity.atlassian.net/browse/SDK-1457

# How Has This Been Tested?

Tested locally with a modified dfx
```
$ cargo run ping ic
{
  "ic_api_version": "0.18.0",
  "replica_health_status": "healthy",
  "root_key": [48, 129, 130, 48, 29, 6, 13, 43, 6, 1, 4, 1, 130, 220, 124, 5, 3, 1, 2, 1, 6, 12, 43, 6, 1, 4, 1, 130, 220, 124, 5, 3, 2, 1, 3, 97, 0, 129, 76, 14, 110, 199, 31, 171, 88, 59, 8, 189, 129, 55, 60, 37, 92, 60, 55, 27, 46, 132, 134, 60, 152, 164, 241, 224, 139, 116, 35, 93, 20, 251, 93, 156, 12, 213, 70, 217, 104, 95, 145, 58, 12, 11, 44, 197, 52, 21, 131, 191, 75, 67, 146, 228, 103, 219, 150, 214, 91, 155, 180, 203, 113, 113, 18, 248, 71, 46, 13, 90, 77, 20, 80, 95, 253, 116, 132, 176, 18, 145, 9, 28, 95, 135, 185, 136, 131, 70, 63, 152, 9, 26, 11, 170, 174]
}
```

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
