### PR TITLE
fix: lookup path is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Polling the status of a request before the request appears in the state tree no longer results in an `AgentError::LookupPathAbsent` and instead is treated as `RequestStatus::Unknown`.
+
 ## [0.34.0] - 2024-03-18
 
 * Changed `AgentError::ReplicaError` to `CertifiedReject` or `UncertifiedReject`. `CertifiedReject`s went through consensus, and `UncertifiedReject`s did not. If your code uses `ReplicaError`:

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1033,9 +1033,11 @@ impl Agent {
         let paths: Vec<Vec<Label>> =
             vec![vec!["request_status".into(), request_id.to_vec().into()]];
 
-        let cert = self.read_state_raw(paths, effective_canister_id).await?;
-
-        lookup_request_status(cert, request_id)
+        match self.read_state_raw(paths, effective_canister_id).await {
+            Ok(cert) => lookup_request_status(cert, request_id),
+            Err(AgentError::LookupPathAbsent(_)) => Ok(RequestStatusResponse::Unknown),
+            Err(err) => Err(err),
+        }
     }
 
     /// Send the signed request_status to the network. Will return [`RequestStatusResponse`].


### PR DESCRIPTION
# Description

Occasionally, various operations in dfx fail with `Lookup path is absent`. Current best guess: After submitting a request the request id doesn't always appear quickly enough in the state tree. This should not result in an error because there is no guarantee that the request id appears in the state tree within a very short time

(Hopefully) fixes [SDK-1396](https://dfinity.atlassian.net/browse/SDK-1396)

# How Has This Been Tested?

TBD

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.


[SDK-1396]: https://dfinity.atlassian.net/browse/SDK-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ