### PR TITLE
feat: add call_with_verification and call_without_verification methods to QueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Added `QueryBuilder::call_with_verification()` and `QueryBuilder::call_without_verification()` which always/never verify query signatures
+  regardless the Agent level configuration from `AgentBuilder::with_verify_query_signatures`.
+
 ## [0.34.0] - 2024-03-18
 
 * Changed `AgentError::ReplicaError` to `CertifiedReject` or `UncertifiedReject`. `CertifiedReject`s went through consensus, and `UncertifiedReject`s did not. If your code uses `ReplicaError`:

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -69,6 +69,7 @@ async fn query() -> Result<(), AgentError> {
             vec![],
             None,
             false,
+            None,
         )
         .await;
 
@@ -94,6 +95,7 @@ async fn query_error() -> Result<(), AgentError> {
             vec![],
             None,
             false,
+            None,
         )
         .await;
 
@@ -135,6 +137,7 @@ async fn query_rejected() -> Result<(), AgentError> {
             vec![],
             None,
             false,
+            None,
         )
         .await;
 


### PR DESCRIPTION
# Description

* Added `QueryBuilder::call_with_verification()` and `QueryBuilder::call_without_verification()` which always/never verify query signatures
  regardless the Agent level configuration from `AgentBuilder::with_verify_query_signatures`.

Part of SDK-1505

# How Has This Been Tested?

The [sdk PR](https://github.com/dfinity/sdk/pull/3668) is using the new method `call_without_verification()` which was tested in the sdk e2e tests.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
