### PR TITLE
fix: Remove `DestinationInvalid` check from `WalletCanister::from_canister`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Changed `WalletCanister::from_canister/create`'s version check to not rely on the reject code.
 * Added `QueryBuilder::call_with_verification()` and `QueryBuilder::call_without_verification()` which always/never verify query signatures
   regardless the Agent level configuration from `AgentBuilder::with_verify_query_signatures`.
 

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use candid::{decode_args, utils::ArgumentDecoder, CandidType, Deserialize, Nat};
-use ic_agent::{agent::RejectCode, export::Principal, Agent, AgentError, RequestId};
+use ic_agent::{export::Principal, Agent, AgentError, RequestId};
 use once_cell::sync::Lazy;
 use semver::{Version, VersionReq};
 
@@ -437,13 +437,12 @@ impl<'agent> WalletCanister<'agent> {
             canister.query("wallet_api_version").build().call().await;
         let version = match version {
             Err(AgentError::UncertifiedReject(replica_error))
-                if replica_error.reject_code == RejectCode::DestinationInvalid
-                    && (replica_error
+                if replica_error
+                    .reject_message
+                    .contains(REPLICA_ERROR_NO_SUCH_QUERY_METHOD)
+                    || replica_error
                         .reject_message
-                        .contains(REPLICA_ERROR_NO_SUCH_QUERY_METHOD)
-                        || replica_error
-                            .reject_message
-                            .contains(IC_REF_ERROR_NO_SUCH_QUERY_METHOD)) =>
+                        .contains(IC_REF_ERROR_NO_SUCH_QUERY_METHOD) =>
             {
                 DEFAULT_VERSION.clone()
             }


### PR DESCRIPTION
New replica versions report it as CanisterError instead; removing the check entirely is easier than doing this again in the future.