### PR TITLE
feat: remove `effective_canister_id` from `fn fetch_api_boundary_nodes()` signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `QueryBuilder::call_with_verification()` and `QueryBuilder::call_without_verification()` which always/never verify query signatures
   regardless the Agent level configuration from `AgentBuilder::with_verify_query_signatures`.
+* Function `Agent::fetch_api_boundary_nodes()` is modified and split into two: `fetch_api_boundary_nodes_mainnet()` and `fetch_api_boundary_nodes(subnet_id)` (now uses `subnet_id` instead of `effective_canister_id`).
 
 ## [0.34.0] - 2024-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `WalletCanister::from_canister/create`'s version check to not rely on the reject code.
 * Added `QueryBuilder::call_with_verification()` and `QueryBuilder::call_without_verification()` which always/never verify query signatures
   regardless the Agent level configuration from `AgentBuilder::with_verify_query_signatures`.
-* Function `Agent::fetch_api_boundary_nodes()` is modified and split into two: `fetch_api_boundary_nodes_mainnet()` and `fetch_api_boundary_nodes(subnet_id)` (now uses `subnet_id` instead of `effective_canister_id`).
+* Function `Agent::fetch_api_boundary_nodes(effective_canister_id)` is modified into `fetch_api_boundary_nodes(resolver: ApiBoundaryNodesResolver)`.
 
 ## [0.34.0] - 2024-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `WalletCanister::from_canister/create`'s version check to not rely on the reject code.
 * Added `QueryBuilder::call_with_verification()` and `QueryBuilder::call_without_verification()` which always/never verify query signatures
   regardless the Agent level configuration from `AgentBuilder::with_verify_query_signatures`.
-* Function `Agent::fetch_api_boundary_nodes(effective_canister_id)` is modified into `fetch_api_boundary_nodes(resolver: ApiBoundaryNodesResolver)`.
+* Function `Agent::fetch_api_boundary_nodes()` is split into two functions: `fetch_api_boundary_nodes_by_canister_id()` and `fetch_api_boundary_nodes_by_subnet_id()`.
 
 ## [0.34.0] - 2024-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Added `QueryBuilder::call_with_verification()` and `QueryBuilder::call_without_verification()` which always/never verify query signatures
+  regardless the Agent level configuration from `AgentBuilder::with_verify_query_signatures`.
+
 ## [0.34.0] - 2024-03-18
 
 * Changed `AgentError::ReplicaError` to `CertifiedReject` or `UncertifiedReject`. `CertifiedReject`s went through consensus, and `UncertifiedReject`s did not. If your code uses `ReplicaError`:

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -69,6 +69,7 @@ async fn query() -> Result<(), AgentError> {
             vec![],
             None,
             false,
+            None,
         )
         .await;
 
@@ -94,6 +95,7 @@ async fn query_error() -> Result<(), AgentError> {
             vec![],
             None,
             false,
+            None,
         )
         .await;
 
@@ -135,6 +137,7 @@ async fn query_rejected() -> Result<(), AgentError> {
             vec![],
             None,
             false,
+            None,
         )
         .await;
 

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1129,15 +1129,11 @@ impl Agent {
     }
 
     /// Retrieve all existing API boundary nodes from the state tree.
-    pub async fn fetch_api_boundary_nodes(
-        &self,
-        effective_canister_id: Principal,
-    ) -> Result<Vec<ApiBoundaryNode>, AgentError> {
+    pub async fn fetch_api_boundary_nodes(&self) -> Result<Vec<ApiBoundaryNode>, AgentError> {
+        // Here we use root canister_id, but any other 'permanent' canister in the root subnet can be used too.
+        let root_canister_id = Principal::from_text("r7inp-6aaaa-aaaaa-aaabq-cai").unwrap();
         let certificate = self
-            .read_state_raw(
-                vec![vec!["api_boundary_nodes".into()]],
-                effective_canister_id,
-            )
+            .read_state_raw(vec![vec!["api_boundary_nodes".into()]], root_canister_id)
             .await?;
         let api_boundary_nodes = lookup_api_boundary_nodes(certificate)?;
         Ok(api_boundary_nodes)

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1133,7 +1133,7 @@ impl Agent {
     pub async fn fetch_api_boundary_nodes_mainnet(
         &self,
     ) -> Result<Vec<ApiBoundaryNode>, AgentError> {
-        // While the id of the root subnet is utilized here, it's important to note that an ID of any existing subnet could also be employed.
+        // While the id of the root subnet is utilized here, it's important to note that an id of any existing subnet could also be employed.
         let root_subnet_id =
             Principal::from_text("tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe")
                 .expect("failed to parse principle");
@@ -1143,7 +1143,7 @@ impl Agent {
         Ok(api_boundary_nodes)
     }
 
-    /// Retrieve all existing API boundary nodes from the state tree using a custom existing subnet_id.
+    /// Retrieve all existing API boundary nodes from the state tree using a custom id of an existing subnet.
     /// Endpoint /api/v2/subnet/<subnet_id>/read_state is called internally.
     pub async fn fetch_api_boundary_nodes(
         &self,

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1128,28 +1128,29 @@ impl Agent {
         }
     }
 
-    /// Retrieve all existing API boundary nodes from the state tree using a hard-coded `effective_canister_id`.
-    pub async fn fetch_api_boundary_nodes(&self) -> Result<Vec<ApiBoundaryNode>, AgentError> {
-        // Here we use root canister_id, but any other 'permanent' canister in the root subnet can be used too.
-        let root_canister_id = Principal::from_text("r7inp-6aaaa-aaaaa-aaabq-cai").unwrap();
-        let certificate = self
-            .read_state_raw(vec![vec!["api_boundary_nodes".into()]], root_canister_id)
-            .await?;
+    /// Retrieve all existing API boundary nodes from the state tree using a hard-coded id of the root subnet in mainnet.
+    /// Endpoint /api/v2/subnet/<subnet_id>/read_state is called internally.
+    pub async fn fetch_api_boundary_nodes_mainnet(
+        &self,
+    ) -> Result<Vec<ApiBoundaryNode>, AgentError> {
+        // While the id of the root subnet is utilized here, it's important to note that an ID of any existing subnet could also be employed.
+        let root_subnet_id =
+            Principal::from_text("tdb26-jop6k-aogll-7ltgs-eruif-6kk7m-qpktf-gdiqx-mxtrf-vb5e6-eqe")
+                .expect("failed to parse principle");
+        let paths = vec![vec!["api_boundary_nodes".into()]];
+        let certificate = self.read_subnet_state_raw(paths, root_subnet_id).await?;
         let api_boundary_nodes = lookup_api_boundary_nodes(certificate)?;
         Ok(api_boundary_nodes)
     }
 
-    /// Retrieve all existing API boundary nodes from the state tree using a custom `effective_canister_id`.
-    pub async fn fetch_api_boundary_nodes_by_canister_id(
+    /// Retrieve all existing API boundary nodes from the state tree using a custom existing subnet_id.
+    /// Endpoint /api/v2/subnet/<subnet_id>/read_state is called internally.
+    pub async fn fetch_api_boundary_nodes(
         &self,
-        effective_canister_id: Principal,
+        subnet_id: Principal,
     ) -> Result<Vec<ApiBoundaryNode>, AgentError> {
-        let certificate = self
-            .read_state_raw(
-                vec![vec!["api_boundary_nodes".into()]],
-                effective_canister_id,
-            )
-            .await?;
+        let paths = vec![vec!["api_boundary_nodes".into()]];
+        let certificate = self.read_subnet_state_raw(paths, subnet_id).await?;
         let api_boundary_nodes = lookup_api_boundary_nodes(certificate)?;
         Ok(api_boundary_nodes)
     }

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1128,12 +1128,27 @@ impl Agent {
         }
     }
 
-    /// Retrieve all existing API boundary nodes from the state tree.
+    /// Retrieve all existing API boundary nodes from the state tree using a hard-coded `effective_canister_id`.
     pub async fn fetch_api_boundary_nodes(&self) -> Result<Vec<ApiBoundaryNode>, AgentError> {
         // Here we use root canister_id, but any other 'permanent' canister in the root subnet can be used too.
         let root_canister_id = Principal::from_text("r7inp-6aaaa-aaaaa-aaabq-cai").unwrap();
         let certificate = self
             .read_state_raw(vec![vec!["api_boundary_nodes".into()]], root_canister_id)
+            .await?;
+        let api_boundary_nodes = lookup_api_boundary_nodes(certificate)?;
+        Ok(api_boundary_nodes)
+    }
+
+    /// Retrieve all existing API boundary nodes from the state tree using a custom `effective_canister_id`.
+    pub async fn fetch_api_boundary_nodes_by_canister_id(
+        &self,
+        effective_canister_id: Principal,
+    ) -> Result<Vec<ApiBoundaryNode>, AgentError> {
+        let certificate = self
+            .read_state_raw(
+                vec![vec!["api_boundary_nodes".into()]],
+                effective_canister_id,
+            )
             .await?;
         let api_boundary_nodes = lookup_api_boundary_nodes(certificate)?;
         Ok(api_boundary_nodes)

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1469,7 +1469,7 @@ pub(crate) struct Subnet {
 }
 
 /// API boundary node, which routes /api calls to IC replica nodes.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ApiBoundaryNode {
     /// Domain name
     pub domain: String,


### PR DESCRIPTION
# Description

Following the [spec](https://internetcomputer.org/docs/current/references/ic-interface-spec#http-read-state), it would make sense to split `fn fetch_api_boundary_nodes(effective_canister_id)` into two functions:
```
pub async fn fetch_api_boundary_nodes_by_canister_id(canister_id)
pub async fn fetch_api_boundary_nodes_by_subnet_id(subnet_id)
```

# How Has This Been Tested?
1. Testing against mainnent is not yet possible, [this](https://gitlab.com/dfinity-lab/public/ic/-/merge_requests/18438) MR needs to be released.
2. Functions were tested in `system-tests` with respective `canister_id/subnet_id`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
