### PR TITLE
feat: ReqwestTransport and HyperTransport allow for shared RouteProvider ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `QueryBuilder::call_with_verification()` and `QueryBuilder::call_without_verification()` which always/never verify query signatures
   regardless the Agent level configuration from `AgentBuilder::with_verify_query_signatures`.
 * Function `Agent::fetch_api_boundary_nodes()` is split into two functions: `fetch_api_boundary_nodes_by_canister_id()` and `fetch_api_boundary_nodes_by_subnet_id()`.
-
+* `ReqwestTransport` and `HyperTransport` structures storing the trait object `route_provider: Box<dyn RouteProvider>` have been modified to allow for shared ownership via `Arc<dyn RouteProvider>`.
+ 
 ## [0.34.0] - 2024-03-18
 
 * Changed `AgentError::ReplicaError` to `CertifiedReject` or `UncertifiedReject`. `CertifiedReject`s went through consensus, and `UncertifiedReject`s did not. If your code uses `ReplicaError`:

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -1,6 +1,8 @@
 //! A [`Transport`] that connects using a [`reqwest`] client.
 #![cfg(feature = "reqwest")]
 
+use std::sync::Arc;
+
 use ic_transport_types::RejectResponse;
 pub use reqwest;
 
@@ -23,7 +25,7 @@ use crate::{
 /// A [`Transport`] using [`reqwest`] to make HTTP calls to the Internet Computer.
 #[derive(Debug)]
 pub struct ReqwestTransport {
-    route_provider: Box<dyn RouteProvider>,
+    route_provider: Arc<dyn RouteProvider>,
     client: Client,
     max_response_body_size: Option<usize>,
 }
@@ -53,13 +55,13 @@ impl ReqwestTransport {
 
     /// Creates a replica transport from a HTTP URL and a [`reqwest::Client`].
     pub fn create_with_client<U: Into<String>>(url: U, client: Client) -> Result<Self, AgentError> {
-        let route_provider = Box::new(RoundRobinRouteProvider::new(vec![url.into()])?);
+        let route_provider = Arc::new(RoundRobinRouteProvider::new(vec![url.into()])?);
         Self::create_with_client_route(route_provider, client)
     }
 
     /// Creates a replica transport from a [`RouteProvider`] and a [`reqwest::Client`].
     pub fn create_with_client_route(
-        route_provider: Box<dyn RouteProvider>,
+        route_provider: Arc<dyn RouteProvider>,
         client: Client,
     ) -> Result<Self, AgentError> {
         Ok(Self {


### PR DESCRIPTION
# Description

Current design of the `ReqwestTransport` and `HyperTransport` is based on the single ownership of the `RouteProvider` trait object. This has several downsides: 
- One can't create multiple `agent` instances sharing the same `RouteProvider` instance
- One can't modify `RouteProvider` state after an `agent` is created, e.g.:
```
let route_provider = SomeRouteProvider::new();
route_provider.run().await;
let transport = ReqwestTransport::create_with_client_route(Box::new(route_provider), client).unwrap();
let agent = Agent::builder().with_transport(transport).build().unwrap("");
... // do stuff with agent
route_provider.stop().await; // gracefully stop (impossible)
```

Using `Arc` instead of `Box` should allow for shared ownership of `RouteProvider` and rectify the  aforementioned limitations:
```
pub struct ReqwestTransport {
    route_provider: Arc<dyn RouteProvider> (use Arc instead of Box)
}
```

# How Has This Been Tested?
On the CI and manually by creating an agent and querying canister in the mainnet.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
