### PR TITLE
feat: change `RouteProvider` trait into async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `QueryBuilder::call_with_verification()` and `QueryBuilder::call_without_verification()` which always/never verify query signatures
   regardless the Agent level configuration from `AgentBuilder::with_verify_query_signatures`.
 * Function `Agent::fetch_api_boundary_nodes()` is split into two functions: `fetch_api_boundary_nodes_by_canister_id()` and `fetch_api_boundary_nodes_by_subnet_id()`.
+* `RouteProvider` trait and its function `fn route()` is changed to `async fn`.
 
 ## [0.34.0] - 2024-03-18
 

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -18,6 +18,7 @@ include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 backoff = "0.4.0"
 cached = { version = "0.46", features = ["ahash"], default-features = false }
 candid = { workspace = true }
+async-trait = "0.1.79"
 ed25519-consensus = { version = "2" }
 futures-util = { workspace = true }
 hex = { workspace = true }

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -15,10 +15,10 @@ keywords = ["internet-computer", "agent", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
+async-trait = "0.1.68"
 backoff = "0.4.0"
 cached = { version = "0.46", features = ["ahash"], default-features = false }
 candid = { workspace = true }
-async-trait = "0.1.79"
 ed25519-consensus = { version = "2" }
 futures-util = { workspace = true }
 hex = { workspace = true }

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -278,9 +278,9 @@ mod test {
     use std::collections::VecDeque;
     use url::Url;
 
-    #[test]
-    fn redirect() {
-        fn test(base: &str, result: &str) {
+    #[tokio::test]
+    async fn redirect() {
+        async fn test(base: &str, result: &str) {
             let connector = HttpsConnectorBuilder::new()
                 .with_webpki_roots()
                 .https_or_http()
@@ -292,28 +292,28 @@ mod test {
             let url: Url = base.parse().unwrap();
             let t = HyperTransport::create_with_service(url, client).unwrap();
             assert_eq!(
-                t.route_provider.route().unwrap().as_str(),
+                t.route_provider.route().await.unwrap().as_str(),
                 result,
                 "{}",
                 base
             );
         }
 
-        test("https://ic0.app", "https://ic0.app/api/v2/");
-        test("https://IC0.app", "https://ic0.app/api/v2/");
-        test("https://foo.ic0.app", "https://ic0.app/api/v2/");
-        test("https://foo.IC0.app", "https://ic0.app/api/v2/");
-        test("https://foo.Ic0.app", "https://ic0.app/api/v2/");
-        test("https://foo.iC0.app", "https://ic0.app/api/v2/");
-        test("https://foo.bar.ic0.app", "https://ic0.app/api/v2/");
-        test("https://ic0.app/foo/", "https://ic0.app/foo/api/v2/");
-        test("https://foo.ic0.app/foo/", "https://ic0.app/foo/api/v2/");
+        test("https://ic0.app", "https://ic0.app/api/v2/").await;
+        test("https://IC0.app", "https://ic0.app/api/v2/").await;
+        test("https://foo.ic0.app", "https://ic0.app/api/v2/").await;
+        test("https://foo.IC0.app", "https://ic0.app/api/v2/").await;
+        test("https://foo.Ic0.app", "https://ic0.app/api/v2/").await;
+        test("https://foo.iC0.app", "https://ic0.app/api/v2/").await;
+        test("https://foo.bar.ic0.app", "https://ic0.app/api/v2/").await;
+        test("https://ic0.app/foo/", "https://ic0.app/foo/api/v2/").await;
+        test("https://foo.ic0.app/foo/", "https://ic0.app/foo/api/v2/").await;
 
-        test("https://ic1.app", "https://ic1.app/api/v2/");
-        test("https://foo.ic1.app", "https://foo.ic1.app/api/v2/");
-        test("https://ic0.app.ic1.app", "https://ic0.app.ic1.app/api/v2/");
+        test("https://ic1.app", "https://ic1.app/api/v2/").await;
+        test("https://foo.ic1.app", "https://foo.ic1.app/api/v2/").await;
+        test("https://ic0.app.ic1.app", "https://ic0.app.ic1.app/api/v2/").await;
 
-        test("https://fooic0.app", "https://fooic0.app/api/v2/");
-        test("https://fooic0.app.ic0.app", "https://ic0.app/api/v2/");
+        test("https://fooic0.app", "https://fooic0.app/api/v2/").await;
+        test("https://fooic0.app.ic0.app", "https://ic0.app/api/v2/").await;
     }
 }

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -218,7 +218,7 @@ where
         Box::pin(async move {
             let url = format!(
                 "{}canister/{effective_canister_id}/call",
-                self.route_provider.route()?
+                self.route_provider.route().await?
             );
             self.request(Method::POST, url, Some(envelope)).await?;
             Ok(())
@@ -233,7 +233,7 @@ where
         Box::pin(async move {
             let url = format!(
                 "{}canister/{effective_canister_id}/read_state",
-                self.route_provider.route()?
+                self.route_provider.route().await?
             );
             self.request(Method::POST, url, Some(envelope)).await
         })
@@ -243,7 +243,7 @@ where
         Box::pin(async move {
             let url = format!(
                 "{}subnet/{subnet_id}/read_state",
-                self.route_provider.route()?
+                self.route_provider.route().await?
             );
             self.request(Method::POST, url, Some(envelope)).await
         })
@@ -253,7 +253,7 @@ where
         Box::pin(async move {
             let url = format!(
                 "{}canister/{effective_canister_id}/query",
-                self.route_provider.route()?
+                self.route_provider.route().await?
             );
             self.request(Method::POST, url, Some(envelope)).await
         })
@@ -261,7 +261,7 @@ where
 
     fn status(&self) -> AgentFuture<Vec<u8>> {
         Box::pin(async move {
-            let url = format!("{}status", self.route_provider.route()?);
+            let url = format!("{}status", self.route_provider.route().await?);
             self.request(Method::GET, url, None).await
         })
     }

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -220,58 +220,62 @@ mod test {
 
     use super::ReqwestTransport;
 
-    #[cfg_attr(not(target_family = "wasm"), test)]
+    #[cfg_attr(not(target_family = "wasm"), tokio::test)]
     #[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
-    fn redirect() {
-        fn test(base: &str, result: &str) {
+    async fn redirect() {
+        async fn test(base: &str, result: &str) {
             let t = ReqwestTransport::create(base).unwrap();
             assert_eq!(
-                t.route_provider.route().unwrap().as_str(),
+                t.route_provider.route().await.unwrap().as_str(),
                 result,
                 "{}",
                 base
             );
         }
 
-        test("https://ic0.app", "https://ic0.app/api/v2/");
-        test("https://IC0.app", "https://ic0.app/api/v2/");
-        test("https://foo.ic0.app", "https://ic0.app/api/v2/");
-        test("https://foo.IC0.app", "https://ic0.app/api/v2/");
-        test("https://foo.Ic0.app", "https://ic0.app/api/v2/");
-        test("https://foo.iC0.app", "https://ic0.app/api/v2/");
-        test("https://foo.bar.ic0.app", "https://ic0.app/api/v2/");
-        test("https://ic0.app/foo/", "https://ic0.app/foo/api/v2/");
-        test("https://foo.ic0.app/foo/", "https://ic0.app/foo/api/v2/");
+        test("https://ic0.app", "https://ic0.app/api/v2/").await;
+        test("https://IC0.app", "https://ic0.app/api/v2/").await;
+        test("https://foo.ic0.app", "https://ic0.app/api/v2/").await;
+        test("https://foo.IC0.app", "https://ic0.app/api/v2/").await;
+        test("https://foo.Ic0.app", "https://ic0.app/api/v2/").await;
+        test("https://foo.iC0.app", "https://ic0.app/api/v2/").await;
+        test("https://foo.bar.ic0.app", "https://ic0.app/api/v2/").await;
+        test("https://ic0.app/foo/", "https://ic0.app/foo/api/v2/").await;
+        test("https://foo.ic0.app/foo/", "https://ic0.app/foo/api/v2/").await;
         test(
             "https://ryjl3-tyaaa-aaaaa-aaaba-cai.ic0.app",
             "https://ic0.app/api/v2/",
-        );
+        )
+        .await;
 
-        test("https://ic1.app", "https://ic1.app/api/v2/");
-        test("https://foo.ic1.app", "https://foo.ic1.app/api/v2/");
-        test("https://ic0.app.ic1.app", "https://ic0.app.ic1.app/api/v2/");
+        test("https://ic1.app", "https://ic1.app/api/v2/").await;
+        test("https://foo.ic1.app", "https://foo.ic1.app/api/v2/").await;
+        test("https://ic0.app.ic1.app", "https://ic0.app.ic1.app/api/v2/").await;
 
-        test("https://fooic0.app", "https://fooic0.app/api/v2/");
-        test("https://fooic0.app.ic0.app", "https://ic0.app/api/v2/");
+        test("https://fooic0.app", "https://fooic0.app/api/v2/").await;
+        test("https://fooic0.app.ic0.app", "https://ic0.app/api/v2/").await;
 
-        test("https://icp0.io", "https://icp0.io/api/v2/");
+        test("https://icp0.io", "https://icp0.io/api/v2/").await;
         test(
             "https://ryjl3-tyaaa-aaaaa-aaaba-cai.icp0.io",
             "https://icp0.io/api/v2/",
-        );
-        test("https://ic0.app.icp0.io", "https://icp0.io/api/v2/");
+        )
+        .await;
+        test("https://ic0.app.icp0.io", "https://icp0.io/api/v2/").await;
 
-        test("https://icp-api.io", "https://icp-api.io/api/v2/");
+        test("https://icp-api.io", "https://icp-api.io/api/v2/").await;
         test(
             "https://ryjl3-tyaaa-aaaaa-aaaba-cai.icp-api.io",
             "https://icp-api.io/api/v2/",
-        );
-        test("https://icp0.io.icp-api.io", "https://icp-api.io/api/v2/");
+        )
+        .await;
+        test("https://icp0.io.icp-api.io", "https://icp-api.io/api/v2/").await;
 
-        test("http://localhost:4943", "http://localhost:4943/api/v2/");
+        test("http://localhost:4943", "http://localhost:4943/api/v2/").await;
         test(
             "http://ryjl3-tyaaa-aaaaa-aaaba-cai.localhost:4943",
             "http://localhost:4943/api/v2/",
-        );
+        )
+        .await;
     }
 }

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -126,7 +126,7 @@ impl ReqwestTransport {
         endpoint: &str,
         body: Option<Vec<u8>>,
     ) -> Result<Vec<u8>, AgentError> {
-        let url = self.route_provider.route()?.join(endpoint)?;
+        let url = self.route_provider.route().await?.join(endpoint)?;
         let mut http_request = Request::new(method, url);
         http_request
             .headers_mut()

--- a/ic-agent/src/agent/http_transport/route_provider.rs
+++ b/ic-agent/src/agent/http_transport/route_provider.rs
@@ -1,4 +1,5 @@
 //! A [`RouteProvider`] for dynamic generation of routing urls.
+use async_trait::async_trait;
 use std::{
     str::FromStr,
     sync::atomic::{AtomicUsize, Ordering},
@@ -14,9 +15,10 @@ use crate::agent::{
 };
 
 /// A [`RouteProvider`] for dynamic generation of routing urls.
+#[async_trait]
 pub trait RouteProvider: std::fmt::Debug + Send + Sync {
     /// Generate next routing url
-    fn route(&self) -> Result<Url, AgentError>;
+    async fn route(&self) -> Result<Url, AgentError>;
 }
 
 /// A simple implementation of the [`RouteProvider`] which produces an even distribution of the urls from the input ones.
@@ -26,8 +28,9 @@ pub struct RoundRobinRouteProvider {
     current_idx: AtomicUsize,
 }
 
+#[async_trait]
 impl RouteProvider for RoundRobinRouteProvider {
-    fn route(&self) -> Result<Url, AgentError> {
+    async fn route(&self) -> Result<Url, AgentError> {
         if self.routes.is_empty() {
             return Err(AgentError::RouteProviderError(
                 "No routing urls provided".to_string(),

--- a/ic-agent/src/agent/http_transport/route_provider.rs
+++ b/ic-agent/src/agent/http_transport/route_provider.rs
@@ -76,19 +76,19 @@ impl RoundRobinRouteProvider {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_empty_routes() {
+    #[tokio::test]
+    async fn test_empty_routes() {
         let provider = RoundRobinRouteProvider::new::<&str>(vec![])
             .expect("failed to create a route provider");
-        let result = provider.route().unwrap_err();
+        let result = provider.route().await.unwrap_err();
         assert_eq!(
             result,
             AgentError::RouteProviderError("No routing urls provided".to_string())
         );
     }
 
-    #[test]
-    fn test_routes_rotation() {
+    #[tokio::test]
+    async fn test_routes_rotation() {
         let provider = RoundRobinRouteProvider::new(vec!["https://url1.com", "https://url2.com"])
             .expect("failed to create a route provider");
         let url_strings = vec![
@@ -100,9 +100,9 @@ mod tests {
             .iter()
             .map(|url_str| Url::parse(url_str).expect("Invalid URL"))
             .collect();
-        let urls: Vec<Url> = (0..3)
-            .map(|_| provider.route().expect("failed to get next url"))
-            .collect();
-        assert_eq!(expected_urls, urls);
+        for url_expected in expected_urls {
+            let url = provider.route().await.expect("failed to get next url");
+            assert_eq!(url_expected, url);
+        }
     }
 }


### PR DESCRIPTION
# Description

More sophisticated implementations (than [RoundRobinRouteProvider](https://github.com/dfinity/agent-rs/blob/140bd77346ca6331755dc1a1ca205bf6fe13a358/ic-agent/src/agent/http_transport/route_provider.rs#L24))  of the `RouteProvider` trait would benefit from having `fn route()` to be `async fn route()`. 

For example, a route provider implementation, which internally performs health checks of the urls, would naturally be implemented in the `async` way. Thus having `fn route()` (currently `sync`) imposes a need for calling `async` functions within the `sync` context. This leads to the problem of handling the execution runtime properly and also potential thread blocking problems arise. Having `async fn route()` rectifies all of the aforementioned issues.

# How Has This Been Tested?
On CI.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
