### PR TITLE
feat: Add `wasm_memory_limit` to canister settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regardless the Agent level configuration from `AgentBuilder::with_verify_query_signatures`.
 * Function `Agent::fetch_api_boundary_nodes()` is split into two functions: `fetch_api_boundary_nodes_by_canister_id()` and `fetch_api_boundary_nodes_by_subnet_id()`.
 * `ReqwestTransport` and `HyperTransport` structures storing the trait object `route_provider: Box<dyn RouteProvider>` have been modified to allow for shared ownership via `Arc<dyn RouteProvider>`.
+* Added `wasm_memory_limit` to canister creation and canister setting update options.
  
 ## [0.34.0] - 2024-03-18
 

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -157,6 +157,8 @@ pub struct DefiniteCanisterSettings {
     pub freezing_threshold: Nat,
     /// The upper limit of the canister's reserved cycles balance.
     pub reserved_cycles_limit: Option<Nat>,
+    /// A soft limit on the Wasm memory usage of the canister in bytes (up to 256TiB).
+    pub wasm_memory_limit: Option<Nat>,
 }
 
 impl std::fmt::Display for StatusCallResult {

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -1,9 +1,8 @@
 //! Builder interfaces for some method calls of the management canister.
 
-use super::attributes::WasmMemoryLimit;
 #[doc(inline)]
 pub use super::attributes::{
-    ComputeAllocation, FreezingThreshold, MemoryAllocation, ReservedCyclesLimit,
+    ComputeAllocation, FreezingThreshold, MemoryAllocation, ReservedCyclesLimit, WasmMemoryLimit,
 };
 use super::{ChunkHash, ManagementCanister};
 use crate::{

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -658,6 +658,7 @@ impl<'agent> WalletCanister<'agent> {
             memory_allocation: memory_allocation.map(u64::from).map(Nat::from),
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
             reserved_cycles_limit: None,
+            wasm_memory_limit: None,
         };
 
         self.update("wallet_create_canister")
@@ -687,6 +688,7 @@ impl<'agent> WalletCanister<'agent> {
             memory_allocation: memory_allocation.map(u64::from).map(Nat::from),
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
             reserved_cycles_limit: None,
+            wasm_memory_limit: None,
         };
 
         self.update("wallet_create_canister128")
@@ -700,6 +702,10 @@ impl<'agent> WalletCanister<'agent> {
     /// This method does not have a `reserved_cycles_limit` parameter,
     /// as the wallet does not support the setting.  If you need to create a canister
     /// with a `reserved_cycles_limit` set, use the management canister.
+    ///
+    /// This method does not have a `wasm_memory_limit` parameter,
+    /// as the wallet does not support the setting.  If you need to create a canister
+    /// with a `wasm_memory_limit` set, use the management canister.
     pub async fn wallet_create_canister(
         &self,
         cycles: u128,
@@ -810,6 +816,7 @@ impl<'agent> WalletCanister<'agent> {
             memory_allocation: memory_allocation.map(u64::from).map(Nat::from),
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
             reserved_cycles_limit: None,
+            wasm_memory_limit: None,
         };
 
         self.update("wallet_create_wallet")
@@ -839,6 +846,7 @@ impl<'agent> WalletCanister<'agent> {
             memory_allocation: memory_allocation.map(u64::from).map(Nat::from),
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
             reserved_cycles_limit: None,
+            wasm_memory_limit: None,
         };
 
         self.update("wallet_create_wallet128")

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -424,6 +424,7 @@ fn wallet_create_wallet() {
                 memory_allocation: None,
                 freezing_threshold: None,
                 reserved_cycles_limit: None,
+                wasm_memory_limit: None,
             },
         };
         let args = Argument::from_candid((create_args,));


### PR DESCRIPTION
# Description

This add a new `wasm_memory_field` to canister settings.
Both canister creation and updating of canister settings now have the new field.

Part of https://dfinity.atlassian.net/browse/SDK-1588

# How Has This Been Tested?

Added new tests.

# Checklist:

- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
