### PR TITLE
feat: client-side ratelimiting and auto-retrying 429s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Added a limit to the concurrent requests an agent will make at once. This should make server-side ratelimiting much rarer to encounter, even when sending a high volume of requests (for example, a large `ic_utils::ManagementCanister::install` call).
+* The agent will now automatically retry 429 Too Many Requests responses after a short delay.
 * BREAKING: Changed Chunk Store API to conform to the interface specification:
   * `ChunkHash` was changed from `[u8; 32]` to a struct.
   * Return types of `ManagementCanister::stored_chunks()` and `ManagementCanister::upload_chunk()`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +465,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +531,12 @@ checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -722,6 +748,27 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1174,6 +1221,7 @@ dependencies = [
 name = "ic-agent"
 version = "0.34.0"
 dependencies = [
+ "async-lock",
  "backoff",
  "cached",
  "candid",
@@ -1705,6 +1753,12 @@ checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
 dependencies = [
  "group 0.12.1",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -62,12 +62,16 @@ optional = true
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 http-body-to-bytes = { version = "0.2.0", optional = true }
 http-body-util = { version = "0.1.0", optional = true }
-hyper-util = { version = "0.1.3", features = ["client", "client-legacy", "http2"], optional = true }
+hyper-util = { version = "0.1.3", features = [
+    "client",
+    "client-legacy",
+    "http2",
+], optional = true }
 hyper-rustls = { version = "0.26.0", features = [
     "webpki-roots",
     "http2",
 ], optional = true }
-tokio = { version = "1.24.2", features = ["time"] }
+tokio = { version = "1.24.2", features = ["time", "sync"] }
 tower = { version = "0.4.13", optional = true }
 rustls-webpki = "0.101.4"
 
@@ -98,7 +102,14 @@ web-sys = { version = "0.3", features = [
 [features]
 default = ["pem", "reqwest"]
 reqwest = ["dep:reqwest"]
-hyper = ["dep:hyper", "dep:hyper-rustls", "dep:http-body-to-bytes", "dep:http-body-util", "dep:hyper-util", "dep:tower"]
+hyper = [
+    "dep:hyper",
+    "dep:hyper-rustls",
+    "dep:http-body-to-bytes",
+    "dep:http-body-util",
+    "dep:hyper-util",
+    "dep:tower",
+]
 ic_ref_tests = [
     "default",
 ] # Used to separate integration tests for ic-ref which need a server running.

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["internet-computer", "agent", "icp", "dfinity"]
 include = ["src", "Cargo.toml", "../LICENSE", "README.md"]
 
 [dependencies]
+async-lock = "3.3"
 backoff = "0.4.0"
 cached = { version = "0.46", features = ["ahash"], default-features = false }
 candid = { workspace = true }
@@ -71,7 +72,7 @@ hyper-rustls = { version = "0.26.0", features = [
     "webpki-roots",
     "http2",
 ], optional = true }
-tokio = { version = "1.24.2", features = ["time", "sync"] }
+tokio = { version = "1.24.2", features = ["time"] }
 tower = { version = "0.4.13", optional = true }
 rustls-webpki = "0.101.4"
 

--- a/ic-agent/src/agent/agent_config.rs
+++ b/ic-agent/src/agent/agent_config.rs
@@ -16,6 +16,8 @@ pub struct AgentConfig {
     pub transport: Option<Arc<dyn Transport>>,
     /// See [`verify_query_signatures`](super::AgentBuilder::with_verify_query_signatures).
     pub verify_query_signatures: bool,
+    /// See [`with_max_concurrent_requests`](super::AgentBuilder::with_max_concurrent_requests).
+    pub max_concurrent_requests: usize,
 }
 
 impl Default for AgentConfig {
@@ -26,6 +28,7 @@ impl Default for AgentConfig {
             ingress_expiry: None,
             transport: None,
             verify_query_signatures: true,
+            max_concurrent_requests: 50,
         }
     }
 }

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -98,4 +98,12 @@ impl AgentBuilder {
         self.config.verify_query_signatures = verify_query_signatures;
         self
     }
+
+    /// Sets the maximum number of requests that the agent will make concurrently. The replica is configured
+    /// to only permit 50 concurrent requests per client. Set this value lower if you have multiple agents,
+    /// to avoid the slowdown of retrying any 429 errors.
+    pub fn with_max_concurrent_requests(mut self, max_concurrent_requests: usize) -> Self {
+        self.config.max_concurrent_requests = max_concurrent_requests;
+        self
+    }
 }

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -1,7 +1,10 @@
 //! A [`Transport`] that connects using a [`hyper`] client.
+use http::StatusCode;
 pub use hyper;
+use tokio::time::sleep;
 
 use std::sync::Arc;
+use std::time::Duration;
 use std::{any, error::Error, future::Future, marker::PhantomData, sync::atomic::AtomicPtr};
 
 use http_body::Body;
@@ -140,13 +143,7 @@ where
         url: String,
         body: Option<Vec<u8>>,
     ) -> Result<Vec<u8>, AgentError> {
-        let http_request = Request::builder()
-            .method(method)
-            .uri(url)
-            .header(CONTENT_TYPE, "application/cbor")
-            .body(body.unwrap_or_default().into())
-            .map_err(|err| AgentError::TransportError(Box::new(err)))?;
-
+        let body = body.unwrap_or_default();
         fn map_error<E: Error + Send + Sync + 'static>(err: E) -> AgentError {
             if any::TypeId::of::<E>() == any::TypeId::of::<AgentError>() {
                 // Store the value in an `Option` so we can `take`
@@ -165,13 +162,24 @@ where
             }
             AgentError::TransportError(Box::new(err))
         }
-        let response = self
-            .service
-            .clone()
-            .call(http_request)
-            .await
-            .map_err(map_error)?;
-
+        let response = loop {
+            let http_request = Request::builder()
+                .method(&method)
+                .uri(&url)
+                .header(CONTENT_TYPE, "application/cbor")
+                .body(body.clone().into())
+                .map_err(|err| AgentError::TransportError(Box::new(err)))?;
+            let response = self
+                .service
+                .clone()
+                .call(http_request)
+                .await
+                .map_err(map_error)?;
+            if response.status() != StatusCode::TOO_MANY_REQUESTS {
+                break response;
+            }
+            sleep(Duration::from_millis(250)).await;
+        };
         let (parts, body) = response.into_parts();
         let body = if let Some(limit) = self.max_response_body_size {
             http_body_to_bytes_with_max_length(body, limit)

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -1,7 +1,6 @@
 //! A [`Transport`] that connects using a [`hyper`] client.
 use http::StatusCode;
 pub use hyper;
-use tokio::time::sleep;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -178,7 +177,7 @@ where
             if response.status() != StatusCode::TOO_MANY_REQUESTS {
                 break response;
             }
-            sleep(Duration::from_millis(250)).await;
+            crate::util::sleep(Duration::from_millis(250)).await;
         };
         let (parts, body) = response.into_parts();
         let body = if let Some(limit) = self.max_response_body_size {

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -1,7 +1,7 @@
 //! A [`Transport`] that connects using a [`reqwest`] client.
 #![cfg(feature = "reqwest")]
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use ic_transport_types::RejectResponse;
 pub use reqwest;
@@ -11,6 +11,7 @@ use reqwest::{
     header::{HeaderMap, CONTENT_TYPE},
     Body, Client, Method, Request, StatusCode,
 };
+use tokio::time::sleep;
 
 use crate::{
     agent::{
@@ -136,7 +137,13 @@ impl ReqwestTransport {
 
         *http_request.body_mut() = body.map(Body::from);
 
-        let request_result = self.request(http_request.try_clone().unwrap()).await?;
+        let request_result = loop {
+            let result = self.request(http_request.try_clone().unwrap()).await?;
+            if result.0 != StatusCode::TOO_MANY_REQUESTS {
+                break result;
+            }
+            sleep(Duration::from_millis(250)).await;
+        };
         let status = request_result.0;
         let headers = request_result.1;
         let body = request_result.2;

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -11,7 +11,6 @@ use reqwest::{
     header::{HeaderMap, CONTENT_TYPE},
     Body, Client, Method, Request, StatusCode,
 };
-use tokio::time::sleep;
 
 use crate::{
     agent::{
@@ -142,7 +141,7 @@ impl ReqwestTransport {
             if result.0 != StatusCode::TOO_MANY_REQUESTS {
                 break result;
             }
-            sleep(Duration::from_millis(250)).await;
+            crate::util::sleep(Duration::from_millis(250)).await;
         };
         let status = request_result.0;
         let headers = request_result.1;

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -9,6 +9,7 @@ pub mod status;
 
 pub use agent_config::AgentConfig;
 pub use agent_error::AgentError;
+use async_lock::Semaphore;
 pub use builder::AgentBuilder;
 use cached::{Cached, TimedCache};
 use ed25519_consensus::{Error as Ed25519Error, Signature, VerificationKey};
@@ -20,7 +21,6 @@ pub use ic_transport_types::{
 pub use nonce::{NonceFactory, NonceGenerator};
 use rangemap::{RangeInclusiveMap, RangeInclusiveSet, StepFns};
 use time::OffsetDateTime;
-use tokio::sync::Semaphore;
 
 #[cfg(test)]
 mod agent_test;
@@ -375,7 +375,7 @@ impl Agent {
     where
         A: serde::de::DeserializeOwned,
     {
-        let _permit = self.concurrent_requests_semaphore.acquire().await.unwrap();
+        let _permit = self.concurrent_requests_semaphore.acquire().await;
         let bytes = self
             .transport
             .query(effective_canister_id, serialized_bytes)
@@ -391,7 +391,7 @@ impl Agent {
     where
         A: serde::de::DeserializeOwned,
     {
-        let _permit = self.concurrent_requests_semaphore.acquire().await.unwrap();
+        let _permit = self.concurrent_requests_semaphore.acquire().await;
         let bytes = self
             .transport
             .read_state(effective_canister_id, serialized_bytes)
@@ -407,7 +407,7 @@ impl Agent {
     where
         A: serde::de::DeserializeOwned,
     {
-        let _permit = self.concurrent_requests_semaphore.acquire().await.unwrap();
+        let _permit = self.concurrent_requests_semaphore.acquire().await;
         let bytes = self
             .transport
             .read_subnet_state(subnet_id, serialized_bytes)
@@ -421,7 +421,7 @@ impl Agent {
         request_id: RequestId,
         serialized_bytes: Vec<u8>,
     ) -> Result<RequestId, AgentError> {
-        let _permit = self.concurrent_requests_semaphore.acquire().await.unwrap();
+        let _permit = self.concurrent_requests_semaphore.acquire().await;
         self.transport
             .call(effective_canister_id, serialized_bytes, request_id)
             .await?;
@@ -721,26 +721,7 @@ impl Agent {
             };
 
             match retry_policy.next_backoff() {
-                #[cfg(not(target_family = "wasm"))]
-                Some(duration) => tokio::time::sleep(duration).await,
-
-                #[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
-                Some(duration) => {
-                    wasm_bindgen_futures::JsFuture::from(js_sys::Promise::new(&mut |rs, rj| {
-                        if let Err(e) = web_sys::window()
-                            .expect("global window unavailable")
-                            .set_timeout_with_callback_and_timeout_and_arguments_0(
-                                &rs,
-                                duration.as_millis() as _,
-                            )
-                        {
-                            use wasm_bindgen::UnwrapThrowExt;
-                            rj.call1(&rj, &e).unwrap_throw();
-                        }
-                    }))
-                    .await
-                    .expect("unable to setTimeout");
-                }
+                Some(duration) => crate::util::sleep(duration).await,
 
                 None => return Err(AgentError::TimeoutWaitingForResponse()),
             }
@@ -776,25 +757,8 @@ impl Agent {
             };
 
             match retry_policy.next_backoff() {
-                #[cfg(not(target_family = "wasm"))]
-                Some(duration) => tokio::time::sleep(duration).await,
-                #[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
-                Some(duration) => {
-                    wasm_bindgen_futures::JsFuture::from(js_sys::Promise::new(&mut |rs, rj| {
-                        if let Err(e) = web_sys::window()
-                            .expect("global window unavailable")
-                            .set_timeout_with_callback_and_timeout_and_arguments_0(
-                                &rs,
-                                duration.as_millis() as _,
-                            )
-                        {
-                            use wasm_bindgen::UnwrapThrowExt;
-                            rj.call1(&rj, &e).unwrap_throw();
-                        }
-                    }))
-                    .await
-                    .expect("unable to setTimeout");
-                }
+                Some(duration) => crate::util::sleep(duration).await,
+
                 None => return Err(AgentError::TimeoutWaitingForResponse()),
             }
         }
@@ -1804,9 +1768,10 @@ impl<'agent> UpdateBuilder<'agent> {
     }
 }
 
-#[cfg(all(test, feature = "reqwest"))]
+#[cfg(all(test, feature = "reqwest", not(target_family = "wasm")))]
 mod offline_tests {
     use super::*;
+    use futures_util::future::pending;
     // Any tests that involve the network should go in agent_test, not here.
 
     #[test]
@@ -1829,5 +1794,49 @@ mod offline_tests {
         }
         // in six requests, there should be no more than two timestamps
         assert!(num_timestamps <= 2, "num_timestamps:{num_timestamps} > 2");
+    }
+
+    #[tokio::test]
+    async fn client_ratelimit() {
+        struct SlowTransport(Arc<Mutex<usize>>);
+        impl Transport for SlowTransport {
+            fn call(&self, _: Principal, _: Vec<u8>, _: RequestId) -> AgentFuture<()> {
+                *self.0.lock().unwrap() += 1;
+                Box::pin(pending())
+            }
+            fn query(&self, _: Principal, _: Vec<u8>) -> AgentFuture<Vec<u8>> {
+                *self.0.lock().unwrap() += 1;
+                Box::pin(pending())
+            }
+            fn read_state(&self, _: Principal, _: Vec<u8>) -> AgentFuture<Vec<u8>> {
+                *self.0.lock().unwrap() += 1;
+                Box::pin(pending())
+            }
+            fn read_subnet_state(&self, _: Principal, _: Vec<u8>) -> AgentFuture<Vec<u8>> {
+                *self.0.lock().unwrap() += 1;
+                Box::pin(pending())
+            }
+            fn status(&self) -> AgentFuture<Vec<u8>> {
+                *self.0.lock().unwrap() += 1;
+                Box::pin(pending())
+            }
+        }
+        let count = Arc::new(Mutex::new(0));
+        let agent = Agent::builder()
+            .with_transport(SlowTransport(count.clone()))
+            .with_max_concurrent_requests(2)
+            .build()
+            .unwrap();
+        for _ in 0..3 {
+            let agent = agent.clone();
+            tokio::spawn(async move {
+                agent
+                    .query(&"ryjl3-tyaaa-aaaaa-aaaba-cai".parse().unwrap(), "greet")
+                    .call()
+                    .await
+            });
+        }
+        crate::util::sleep(Duration::from_millis(250)).await;
+        assert_eq!(*count.lock().unwrap(), 2);
     }
 }

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -116,6 +116,7 @@ compile_error!("Feature `hyper` cannot be used from WASM.");
 pub mod agent;
 pub mod export;
 pub mod identity;
+mod util;
 
 use agent::response_authentication::LookupPath;
 #[doc(inline)]

--- a/ic-agent/src/util.rs
+++ b/ic-agent/src/util.rs
@@ -1,0 +1,21 @@
+use std::time::Duration;
+
+pub async fn sleep(d: Duration) {
+    #[cfg(not(all(target_family = "wasm", feature = "wasm-bindgen")))]
+    tokio::time::sleep(d).await;
+    #[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
+    wasm_bindgen_futures::JsFuture::from(js_sys::Promise::new(&mut |rs, rj| {
+        if let Err(e) = web_sys::window()
+            .expect("global window unavailable")
+            .set_timeout_with_callback_and_timeout_and_arguments_0(&rs, d.as_millis() as _)
+        {
+            use wasm_bindgen::UnwrapThrowExt;
+            rj.call1(&rj, &e).unwrap_throw();
+        }
+    }))
+    .await
+    .expect("unable to setTimeout");
+    #[cfg(all(target_family = "wasm", not(feature = "wasm-bindgen")))]
+    const _: () =
+        { panic!("Using ic-agent from WASM requires enabling the `wasm-bindgen` feature") };
+}

--- a/ic-utils/Cargo.toml
+++ b/ic-utils/Cargo.toml
@@ -28,6 +28,7 @@ strum = "0.24"
 strum_macros = "0.24"
 thiserror = { workspace = true }
 time = { workspace = true }
+tokio = { workspace = true }
 semver = "1.0.7"
 once_cell = "1.10.0"
 


### PR DESCRIPTION
ManagementCanister::install currently does not work for very large modules due to hitting 429 after the first fifty chunks. This PR fixes that in two ways: limiting concurrent requests to 50 via semaphore, and retrying any 429s that slip through.