### PR TITLE
ci: remove the unnecessary purge step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,15 +48,6 @@ jobs:
         run: |
           CARGO_TARGET_DIR=target/wasm wasm-pack test --chrome --headless ic-agent --features wasm-bindgen
 
-      - name: Purge for OSX
-        if: matrix.os == 'macos-latest'
-        run: |
-          # There is a bug with BSD tar on macOS where the first 8MB of the file are
-          # sometimes all NUL bytes. See https://github.com/actions/cache/issues/403
-          # and https://github.com/rust-lang/cargo/issues/8603 for some more
-          # information. An alternative solution here is to install GNU tar, but
-          # flushing the disk cache seems to work, too.
-          sudo /usr/sbin/purge
   aggregate:
     name: test:required
     runs-on: ubuntu-latest


### PR DESCRIPTION
The issue has been fixed. The workaround (purge) is not required anymore.

https://github.com/rust-lang/cargo/issues/8603#issuecomment-2099872854