### PR TITLE
feat: introduce http request retries on tcp failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Introduced transparent http request retry logic for network-related failures. `ReqwestTransport::with_max_tcp_errors_retries()`, `HyperTransport::with_max_tcp_errors_retries()`.
 
 ## [0.35.0] - 2024-05-10
 

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -13,16 +13,68 @@ use candid::{Encode, Nat};
 use futures_util::FutureExt;
 use ic_certification::{Delegation, Label};
 use ic_transport_types::{NodeSignature, QueryResponse, RejectCode, RejectResponse, ReplyResponse};
+use reqwest::Client;
 use std::{collections::BTreeMap, time::Duration};
+use std::{collections::VecDeque, sync::Arc};
 #[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
 use wasm_bindgen_test::wasm_bindgen_test;
 
+use crate::agent::http_transport::route_provider::{RoundRobinRouteProvider, RouteProvider};
 #[cfg(all(target_family = "wasm", feature = "wasm-bindgen"))]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 fn make_agent(url: &str) -> Agent {
     Agent::builder()
         .with_transport(ReqwestTransport::create(url).unwrap())
+        .with_verify_query_signatures(false)
+        .build()
+        .unwrap()
+}
+
+fn make_agent_with_route_provider(
+    route_provider: Arc<dyn RouteProvider>,
+    tcp_retries: usize,
+) -> Agent {
+    let client = Client::builder()
+        .use_rustls_tls()
+        .build()
+        .expect("Could not create HTTP client.");
+    Agent::builder()
+        .with_transport(
+            ReqwestTransport::create_with_client_route(route_provider, client)
+                .unwrap()
+                .with_max_tcp_errors_retries(tcp_retries),
+        )
+        .with_verify_query_signatures(false)
+        .build()
+        .unwrap()
+}
+
+fn make_agent_with_hyper_transport_route_provider(
+    route_provider: Arc<dyn RouteProvider>,
+    tcp_retries: usize,
+) -> Agent {
+    use super::http_transport::HyperTransport;
+    use http_body_util::Full;
+    use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
+    use hyper_util::{
+        client::legacy::{connect::HttpConnector, Client as LegacyClient},
+        rt::TokioExecutor,
+    };
+
+    let connector = HttpsConnectorBuilder::new()
+        .with_webpki_roots()
+        .https_or_http()
+        .enable_http1()
+        .enable_http2()
+        .build();
+    let client: LegacyClient<HttpsConnector<HttpConnector>, Full<VecDeque<u8>>> =
+        LegacyClient::builder(TokioExecutor::new()).build(connector);
+    let transport = HyperTransport::create_with_service_route(route_provider, client)
+        .unwrap()
+        .with_max_tcp_errors_retries(tcp_retries);
+    Agent::builder()
+        .with_transport(transport)
         .with_verify_query_signatures(false)
         .build()
         .unwrap()
@@ -294,6 +346,72 @@ async fn status_okay() -> Result<(), AgentError> {
 
     assert!(result.is_ok());
 
+    Ok(())
+}
+
+#[cfg_attr(not(target_family = "wasm"), tokio::test)]
+async fn reqwest_client_status_okay_when_request_retried() -> Result<(), AgentError> {
+    let map = BTreeMap::new();
+    let response = serde_cbor::Value::Map(map);
+    let (read_mock, url) = mock(
+        "GET",
+        "/api/v2/status",
+        200,
+        serde_cbor::to_vec(&response)?,
+        Some("application/cbor"),
+    )
+    .await;
+    // Without retry request should fail.
+    let non_working_url = "http://127.0.0.1:4444";
+    let tcp_retries = 0;
+    let route_provider = RoundRobinRouteProvider::new(vec![non_working_url, &url]).unwrap();
+    let agent = make_agent_with_route_provider(Arc::new(route_provider), tcp_retries);
+    let result = agent.status().await;
+    assert!(result.is_err());
+
+    // With retry request should succeed.
+    let tcp_retries = 1;
+    let route_provider = RoundRobinRouteProvider::new(vec![non_working_url, &url]).unwrap();
+    let agent = make_agent_with_route_provider(Arc::new(route_provider), tcp_retries);
+    let result = agent.status().await;
+
+    assert_mock(read_mock).await;
+
+    assert!(result.is_ok());
+    Ok(())
+}
+
+#[cfg_attr(not(target_family = "wasm"), tokio::test)]
+async fn hyper_client_status_okay_when_request_retried() -> Result<(), AgentError> {
+    let map = BTreeMap::new();
+    let response = serde_cbor::Value::Map(map);
+    let (read_mock, url) = mock(
+        "GET",
+        "/api/v2/status",
+        200,
+        serde_cbor::to_vec(&response)?,
+        Some("application/cbor"),
+    )
+    .await;
+    // Without retry request should fail.
+    let non_working_url = "http://127.0.0.1:4444";
+    let tcp_retries = 0;
+    let route_provider = RoundRobinRouteProvider::new(vec![non_working_url, &url]).unwrap();
+    let agent =
+        make_agent_with_hyper_transport_route_provider(Arc::new(route_provider), tcp_retries);
+    let result = agent.status().await;
+    assert!(result.is_err());
+
+    // With retry request should succeed.
+    let tcp_retries = 1;
+    let route_provider = RoundRobinRouteProvider::new(vec![non_working_url, &url]).unwrap();
+    let agent =
+        make_agent_with_hyper_transport_route_provider(Arc::new(route_provider), tcp_retries);
+    let result = agent.status().await;
+
+    assert_mock(read_mock).await;
+
+    assert!(result.is_ok());
     Ok(())
 }
 

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -207,8 +207,10 @@ where
                         match self.service.clone().call(http_request).await {
                             Ok(response) => break response,
                             Err(err) => {
-                                let err_msg = err.to_string();
-                                if err_msg.contains("client error (Connect)") {
+                                if (&err as &dyn Error)
+                                    .downcast_ref::<hyper_util::client::legacy::Error>()
+                                    .is_some_and(|e| e.is_connect())
+                                {
                                     if retry_count >= self.max_tcp_error_retries {
                                         return Err(map_error(err));
                                     }

--- a/ic-agent/src/agent/http_transport/hyper_transport.rs
+++ b/ic-agent/src/agent/http_transport/hyper_transport.rs
@@ -174,7 +174,7 @@ where
         }
 
         let create_request_with_generated_url = || -> Result<Request<_>, AgentError> {
-            let url = self.route_provider.route()?.join(&endpoint)?;
+            let url = self.route_provider.route()?.join(endpoint)?;
             println!("{url}");
             let http_request = Request::builder()
                 .method(&method)
@@ -305,8 +305,8 @@ where
 
     fn status(&self) -> AgentFuture<Vec<u8>> {
         Box::pin(async move {
-            let endpoint = &format!("status");
-            self.request(Method::GET, endpoint, None).await
+            let endpoint = "status".to_string();
+            self.request(Method::GET, &endpoint, None).await
         })
     }
 }

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -113,6 +113,7 @@ impl ReqwestTransport {
             match self.client.execute(http_request).await {
                 Ok(response) => break response,
                 Err(err) => {
+                    // Network-related errors can be retried.
                     if err.is_connect() {
                         if retry_count >= self.max_tcp_error_retries {
                             return Err(AgentError::TransportError(Box::new(err)));

--- a/ic-agent/src/agent/http_transport/reqwest_transport.rs
+++ b/ic-agent/src/agent/http_transport/reqwest_transport.rs
@@ -28,6 +28,7 @@ pub struct ReqwestTransport {
     route_provider: Arc<dyn RouteProvider>,
     client: Client,
     max_response_body_size: Option<usize>,
+    max_tcp_error_retries: usize,
 }
 
 #[doc(hidden)]
@@ -68,6 +69,7 @@ impl ReqwestTransport {
             route_provider,
             client,
             max_response_body_size: None,
+            max_tcp_error_retries: 0,
         })
     }
 
@@ -79,15 +81,49 @@ impl ReqwestTransport {
         }
     }
 
+    /// Sets a max number of retries for tcp connection errors.
+    pub fn with_max_tcp_errors_retries(self, retries: usize) -> Self {
+        ReqwestTransport {
+            max_tcp_error_retries: retries,
+            ..self
+        }
+    }
+
     async fn request(
         &self,
-        http_request: Request,
+        method: Method,
+        endpoint: &str,
+        body: Option<Vec<u8>>,
     ) -> Result<(StatusCode, HeaderMap, Vec<u8>), AgentError> {
-        let response = self
-            .client
-            .execute(http_request)
-            .await
-            .map_err(|x| AgentError::TransportError(Box::new(x)))?;
+        let mut retry_count = 0;
+
+        let response = loop {
+            // RouteProvider generates urls dynamically. Some of these urls can be potentially unhealthy.
+            // TCP related errors (host unreachable, connection refused, connection timed out, connection reset) can be safely retried with a newly generated url.
+            let url = self.route_provider.route()?.join(endpoint)?;
+
+            let mut http_request = Request::new(method.clone(), url);
+
+            http_request
+                .headers_mut()
+                .insert(CONTENT_TYPE, "application/cbor".parse().unwrap());
+
+            *http_request.body_mut() = body.as_ref().cloned().map(Body::from);
+
+            match self.client.execute(http_request).await {
+                Ok(response) => break response,
+                Err(err) => {
+                    if err.is_connect() {
+                        if retry_count >= self.max_tcp_error_retries {
+                            return Err(AgentError::TransportError(Box::new(err)));
+                        }
+                        retry_count += 1;
+                        continue;
+                    }
+                    return Err(AgentError::TransportError(Box::new(err)));
+                }
+            }
+        };
 
         let http_status = response.status();
         let response_headers = response.headers().clone();
@@ -128,16 +164,10 @@ impl ReqwestTransport {
         endpoint: &str,
         body: Option<Vec<u8>>,
     ) -> Result<Vec<u8>, AgentError> {
-        let url = self.route_provider.route()?.join(endpoint)?;
-        let mut http_request = Request::new(method, url);
-        http_request
-            .headers_mut()
-            .insert(CONTENT_TYPE, "application/cbor".parse().unwrap());
-
-        *http_request.body_mut() = body.map(Body::from);
-
         let request_result = loop {
-            let result = self.request(http_request.try_clone().unwrap()).await?;
+            let result = self
+                .request(method.clone(), endpoint, body.as_ref().cloned())
+                .await?;
             if result.0 != StatusCode::TOO_MANY_REQUESTS {
                 break result;
             }


### PR DESCRIPTION
# Description

[RouteProvider](https://github.com/dfinity/agent-rs/blob/d3db617c3698e7ee1a4a3074c495ff063b91bab1/ic-agent/src/agent/http_transport/route_provider.rs#L17) which is used to dynamically retrieve routing URLs for HTTP calls, can potentially return unhealthy URLs. This will be especially acute once API Boundary Node decentralization feature is released, as node providers will be the ones responsible for API nodes maintenance.

If an HTTP request fails on a URL with a network-related error (e.g., host unreachable, connection timeout, connection refused), then this request can be safely retried by using an alternative routing URL, generated by the `RouteProvider`. This retrying policy aims at improving user experience.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
