### PR TITLE
feat: add `log_visibility` to canister settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed the SyncCall and AsyncCall traits to use an associated type for their output instead of a generic parameter.
 * Call builders now generally implement `IntoFuture`, allowing `.call_and_wait().await` to be shortened to `.await`.
 
+* Added `log_visibility` to canister creation and canister setting update options.
+
 ## [0.35.0] - 2024-05-10
 
 * Added a limit to the concurrent requests an agent will make at once. This should make server-side ratelimiting much rarer to encounter, even when sending a high volume of requests (for example, a large `ic_utils::ManagementCanister::install` call).

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -144,6 +144,18 @@ pub struct QueryStats {
     pub response_payload_bytes_total: Nat,
 }
 
+/// Log visibility for a canister.
+#[derive(Default, Clone, Copy, CandidType, Deserialize, Debug, PartialEq, Eq)]
+pub enum LogVisibility {
+    #[default]
+    #[serde(rename = "controllers")]
+    /// Canister logs are visible to controllers only.
+    Controllers,
+    #[serde(rename = "public")]
+    /// Canister logs are visible to everyone.
+    Public,
+}
+
 /// The concrete settings of a canister.
 #[derive(Clone, Debug, Deserialize, CandidType)]
 pub struct DefiniteCanisterSettings {
@@ -159,6 +171,8 @@ pub struct DefiniteCanisterSettings {
     pub reserved_cycles_limit: Option<Nat>,
     /// A soft limit on the Wasm memory usage of the canister in bytes (up to 256TiB).
     pub wasm_memory_limit: Option<Nat>,
+    /// The canister log visibility. Defines which principals are allowed to fetch logs.
+    pub log_visibility: LogVisibility,
 }
 
 impl std::fmt::Display for StatusCallResult {

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -673,6 +673,7 @@ impl<'agent> WalletCanister<'agent> {
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
             reserved_cycles_limit: None,
             wasm_memory_limit: None,
+            log_visibility: None,
         };
 
         self.update("wallet_create_canister")
@@ -703,6 +704,7 @@ impl<'agent> WalletCanister<'agent> {
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
             reserved_cycles_limit: None,
             wasm_memory_limit: None,
+            log_visibility: None,
         };
 
         self.update("wallet_create_canister128")
@@ -717,9 +719,9 @@ impl<'agent> WalletCanister<'agent> {
     /// as the wallet does not support the setting.  If you need to create a canister
     /// with a `reserved_cycles_limit` set, use the management canister.
     ///
-    /// This method does not have a `wasm_memory_limit` parameter,
+    /// This method does not have a `wasm_memory_limit` or `log_visibility` parameter,
     /// as the wallet does not support the setting.  If you need to create a canister
-    /// with a `wasm_memory_limit` set, use the management canister.
+    /// with a `wasm_memory_limit` or `log_visibility` set, use the management canister.
     pub async fn wallet_create_canister(
         &self,
         cycles: u128,
@@ -831,6 +833,7 @@ impl<'agent> WalletCanister<'agent> {
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
             reserved_cycles_limit: None,
             wasm_memory_limit: None,
+            log_visibility: None,
         };
 
         self.update("wallet_create_wallet")
@@ -861,6 +864,7 @@ impl<'agent> WalletCanister<'agent> {
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
             reserved_cycles_limit: None,
             wasm_memory_limit: None,
+            log_visibility: None,
         };
 
         self.update("wallet_create_wallet128")

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -724,6 +724,7 @@ mod management_canister {
                     freezing_threshold: None,
                     reserved_cycles_limit: None,
                     wasm_memory_limit: None,
+                    log_visibility: None,
                 },
             };
 
@@ -1006,7 +1007,10 @@ mod extras {
     };
     use ic_utils::{
         call::AsyncCall,
-        interfaces::{management_canister::builders::ComputeAllocation, ManagementCanister},
+        interfaces::{
+            management_canister::{builders::ComputeAllocation, LogVisibility},
+            ManagementCanister,
+        },
     };
     use ref_tests::get_effective_canister_id;
     use ref_tests::with_agent;
@@ -1308,6 +1312,66 @@ mod extras {
                 result.0.settings.wasm_memory_limit,
                 Some(Nat::from(3_000_000_000_u64))
             );
+
+            Ok(())
+        })
+    }
+
+    #[ignore]
+    #[test]
+    fn create_with_log_visibility() {
+        with_agent(|agent| async move {
+            let ic00 = ManagementCanister::create(&agent);
+
+            let (canister_id,) = ic00
+                .create_canister()
+                .as_provisional_create_with_amount(None)
+                .with_effective_canister_id(get_effective_canister_id())
+                .with_log_visibility(LogVisibility::Public)
+                .call_and_wait()
+                .await
+                .unwrap();
+
+            let result = ic00.canister_status(&canister_id).call_and_wait().await?;
+            assert_eq!(result.0.settings.log_visibility, LogVisibility::Public);
+
+            Ok(())
+        })
+    }
+
+    #[ignore]
+    #[test]
+    fn update_log_visibility() {
+        with_agent(|agent| async move {
+            let ic00 = ManagementCanister::create(&agent);
+
+            let (canister_id,) = ic00
+                .create_canister()
+                .as_provisional_create_with_amount(Some(20_000_000_000_000_u128))
+                .with_effective_canister_id(get_effective_canister_id())
+                .with_log_visibility(LogVisibility::Controllers)
+                .call_and_wait()
+                .await?;
+
+            let result = ic00.canister_status(&canister_id).call_and_wait().await?;
+            assert_eq!(result.0.settings.log_visibility, LogVisibility::Controllers);
+
+            ic00.update_settings(&canister_id)
+                .with_log_visibility(LogVisibility::Public)
+                .call_and_wait()
+                .await?;
+
+            let result = ic00.canister_status(&canister_id).call_and_wait().await?;
+            assert_eq!(result.0.settings.log_visibility, LogVisibility::Public);
+
+            let no_change: Option<LogVisibility> = None;
+            ic00.update_settings(&canister_id)
+                .with_optional_log_visibility(no_change)
+                .call_and_wait()
+                .await?;
+
+            let result = ic00.canister_status(&canister_id).call_and_wait().await?;
+            assert_eq!(result.0.settings.log_visibility, LogVisibility::Public);
 
             Ok(())
         })

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -425,6 +425,7 @@ fn wallet_create_wallet() {
                 freezing_threshold: None,
                 reserved_cycles_limit: None,
                 wasm_memory_limit: None,
+                log_visibility: None,
             },
         };
         let args = Argument::from_candid((create_args,));


### PR DESCRIPTION
# Description

Adds support for the new `log_visibility` setting in canister settings, both when creating a canister and when updating the settings.

Part of [SDK-1543](https://dfinity.atlassian.net/browse/SDK-1543)

# How Has This Been Tested?

Added tests.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.


[SDK-1543]: https://dfinity.atlassian.net/browse/SDK-1543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ