### PR TITLE
feat: add support for fetching root keys automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Removed the Bitcoin query methods from `ManagementCanister`. Users should use `BitcoinCanister` for that.
 * Added `BitcoinCanister` to `ic-utils`.
+* Added support for automatically fetching the root key in `ic-agent`
+* `Agent::verify` and `Agent::verify_for_subnet` are now `async`.
 
 ## [0.36.0] - 2024-06-04
 

--- a/ic-agent/src/agent/agent_config.rs
+++ b/ic-agent/src/agent/agent_config.rs
@@ -18,6 +18,8 @@ pub struct AgentConfig {
     pub verify_query_signatures: bool,
     /// See [`with_max_concurrent_requests`](super::AgentBuilder::with_max_concurrent_requests).
     pub max_concurrent_requests: usize,
+    /// See [`with_auto_fetch_root_key`](super::AgentBuilder::with_auto_fetch_root_key).
+    pub auto_fetch_root_key: bool,
 }
 
 impl Default for AgentConfig {
@@ -29,6 +31,7 @@ impl Default for AgentConfig {
             transport: None,
             verify_query_signatures: true,
             max_concurrent_requests: 50,
+            auto_fetch_root_key: false,
         }
     }
 }

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -659,7 +659,7 @@ async fn too_many_delegations() {
         .expect("read state failed");
     let new_cert = self_delegate_cert(subnet_id, &cert, 1);
     assert!(matches!(
-        agent.verify(&new_cert, canister_id).unwrap_err(),
+        agent.verify(&new_cert, canister_id).await.unwrap_err(),
         AgentError::CertificateHasTooManyDelegations
     ));
 }

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -106,4 +106,18 @@ impl AgentBuilder {
         self.config.max_concurrent_requests = max_concurrent_requests;
         self
     }
+
+    /// By default, the agent is configured to talk to the main Internet Computer, and verifies
+    /// responses using a hard-coded public key.
+    ///
+    /// This flag will instruct the agent to ask the endpoint for its public key automatically on
+    /// first request and use that instead. This is required when talking to a local test instance,
+    /// for example.
+    ///
+    /// *Only use this when you are  _not_ talking to the main Internet Computer, otherwise
+    /// you are prone to man-in-the-middle attacks! Do not enable this flag by default.*
+    pub fn with_auto_fetch_root_key(mut self, auto_fetch_root_key: bool) -> Self {
+        self.config.auto_fetch_root_key = auto_fetch_root_key;
+        self
+    }
 }

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -102,6 +102,7 @@ pub async fn create_agent(identity: impl Identity + 'static) -> Result<Agent, St
     Agent::builder()
         .with_transport(ReqwestTransport::create(format!("http://127.0.0.1:{}", port)).unwrap())
         .with_identity(identity)
+        .with_auto_fetch_root_key(true)
         .build()
         .map_err(|e| format!("{:?}", e))
 }
@@ -126,10 +127,6 @@ where
         let agent = create_agent(agent_identity)
             .await
             .expect("Could not create an agent.");
-        agent
-            .fetch_root_key()
-            .await
-            .expect("could not fetch root key");
         match f(agent).await {
             Ok(_) => {}
             Err(e) => panic!("{:?}", e),

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -148,7 +148,6 @@ mod management_canister {
             let other_agent_identity = create_basic_identity()?;
             let other_agent_principal = other_agent_identity.sender()?;
             let other_agent = create_agent(other_agent_identity).await?;
-            other_agent.fetch_root_key().await?;
             let other_ic00 = ManagementCanister::create(&other_agent);
 
             // Reinstall with another agent should fail.
@@ -265,19 +264,16 @@ mod management_canister {
             let other_agent_identity = create_basic_identity()?;
             let other_agent_principal = other_agent_identity.sender()?;
             let other_agent = create_agent(other_agent_identity).await?;
-            other_agent.fetch_root_key().await?;
             let other_ic00 = ManagementCanister::create(&other_agent);
 
             let secp256k1_identity = create_secp256k1_identity()?;
             let secp256k1_principal = secp256k1_identity.sender()?;
             let secp256k1_agent = create_agent(secp256k1_identity).await?;
-            secp256k1_agent.fetch_root_key().await?;
             let secp256k1_ic00 = ManagementCanister::create(&secp256k1_agent);
 
             let prime256v1_identity = create_prime256v1_identity()?;
             let prime256v1_principal = prime256v1_identity.sender()?;
             let prime256v1_agent = create_agent(prime256v1_identity).await?;
-            prime256v1_agent.fetch_root_key().await?;
             let prime256v1_ic00 = ManagementCanister::create(&prime256v1_agent);
 
             let ic00 = ManagementCanister::create(&agent);
@@ -625,7 +621,6 @@ mod management_canister {
             // Create another agent with different identity.
             let other_agent_identity = create_basic_identity()?;
             let other_agent = create_agent(other_agent_identity).await?;
-            other_agent.fetch_root_key().await?;
             let other_ic00 = ManagementCanister::create(&other_agent);
 
             // Start as a wrong controller should fail.


### PR DESCRIPTION
# Description

This change introduces a way to fetch root keys automatically on demand. This makes the construction of the agent a bit more ergonomic for local nodes.
Minor breakage to the API had to be introduced unfortunately. I also recommend deprecating the `fetch_root_keys` method.

# How Has This Been Tested?

I ran `cargo test`. Further, this version will also be used by the Yral fronend for testing our changes locally (https://github.com/go-bazzinga/hot-or-not-web-leptos-ssr/blob/rupansh/testcontainers/src/state/canisters.rs#L30)

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
