### PR TITLE
feat: Enable http2 for reqwest transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Enable http2 for reqwest transport.
 * Add canister snapshot methods to `ManagementCanister`.
 
 ## [0.37.1] - 2024-07-25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,6 +1994,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -53,7 +53,7 @@ optional = true
 [dependencies.reqwest]
 workspace = true
 default-features = false
-features = ["blocking", "json", "rustls-tls-webpki-roots", "stream"]
+features = ["blocking", "http2", "json", "rustls-tls-webpki-roots", "stream"]
 optional = true
 
 [dependencies.pem]


### PR DESCRIPTION
# Description

This PR enables the HTTP2 feature the reqwest transport by enabling the `http2` feature flag for for the reqwest dependency.

# How Has This Been Tested?

Tested in a system test against production boundary nodes.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
