### PR TITLE
feat: provide from_pem_wo_parameter() to rebuild sepc256k1 identity from  .pem without parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Url` now implements `RouteProvider`.
 * Add canister snapshot methods to `ManagementCanister`.
 * Add `AllowedViewers` to `LogVisibility` enum.
+* Add `from_pem_wo_parameter` for `Secp256k1Identity`.
 
 ## [0.37.1] - 2024-07-25
 


### PR DESCRIPTION
# Description

 "dfx identity export xxx" normally export .pem file without parameter,  looks like 
```
"-----BEGIN EC PRIVATE KEY-----
MHQCAQEEIAgy7nZEcVHkQ4Z1Kdqby8SwyAiyKDQmtbEHTIM+WNeBoAcGBSuBBAAK
oUQDQgAEgO87rJ1ozzdMvJyZQ+GABDqUxGLvgnAnTlcInV3NuhuPv4O3VGzMGzeB
N3d26cRxD99TPtm8uo2OuzKhSiq6EQ==
-----END EC PRIVATE KEY-----
"
```
 but currently agent-rs does not have a method to rebuild identity from it,  this PR provides  *from_pem_wo_parameter()* to achieve this purpose. 

# How Has This Been Tested?
test_secp256k1_public_key_wo_params() is defined for test.


# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
