### PR TITLE
fix: decrease the ingress expiry default to 3 min

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Make ingress_expiry required and set the default value to 3 min.
 * Changed `BasicIdentity`'s implmentation from `ring` to `ed25519-consensus`.
 * Added `AgentBuilder::with_max_polling_time` to config the maximum time to wait for a response from the replica.
 * `DelegatedIdentity::new` now checks the delegation chain. The old behavior is available under `new_unchecked`.

--- a/ic-agent/src/agent/agent_config.rs
+++ b/ic-agent/src/agent/agent_config.rs
@@ -31,6 +31,8 @@ pub struct AgentConfig {
     pub max_tcp_error_retries: usize,
     /// See [`with_arc_http_middleware`](super::AgentBuilder::with_arc_http_middleware).
     pub http_service: Option<Arc<dyn HttpService>>,
+    /// See [`with_max_polling_time`](super::AgentBuilder::with_max_polling_time).
+    pub max_polling_time: Duration,
 }
 
 impl Default for AgentConfig {
@@ -38,7 +40,7 @@ impl Default for AgentConfig {
         Self {
             nonce_factory: Arc::new(NonceFactory::random()),
             identity: Arc::new(AnonymousIdentity {}),
-            ingress_expiry: None,
+            ingress_expiry: Some(Duration::from_secs(3 * 60)),
             client: None,
             http_service: None,
             verify_query_signatures: true,
@@ -46,6 +48,7 @@ impl Default for AgentConfig {
             route_provider: None,
             max_response_body_size: None,
             max_tcp_error_retries: 0,
+            max_polling_time: Duration::from_secs(60 * 5),
         }
     }
 }

--- a/ic-agent/src/agent/agent_config.rs
+++ b/ic-agent/src/agent/agent_config.rs
@@ -16,7 +16,7 @@ pub struct AgentConfig {
     /// See [`with_identity`](super::AgentBuilder::with_identity).
     pub identity: Arc<dyn Identity>,
     /// See [`with_ingress_expiry`](super::AgentBuilder::with_ingress_expiry).
-    pub ingress_expiry: Option<Duration>,
+    pub ingress_expiry: Duration,
     /// See [`with_http_client`](super::AgentBuilder::with_http_client).
     pub client: Option<Client>,
     /// See [`with_route_provider`](super::AgentBuilder::with_route_provider).
@@ -40,7 +40,7 @@ impl Default for AgentConfig {
         Self {
             nonce_factory: Arc::new(NonceFactory::random()),
             identity: Arc::new(AnonymousIdentity {}),
-            ingress_expiry: Some(Duration::from_secs(3 * 60)),
+            ingress_expiry: Duration::from_secs(3 * 60),
             client: None,
             http_service: None,
             verify_query_signatures: true,

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -37,7 +37,7 @@ fn make_untimed_agent(url: &str) -> Agent {
     Agent::builder()
         .with_url(url)
         .with_verify_query_signatures(false)
-        .with_ingress_expiry(Some(Duration::from_secs(u32::MAX as _)))
+        .with_ingress_expiry(Duration::from_secs(u32::MAX as _))
         .build()
         .unwrap()
 }
@@ -45,7 +45,7 @@ fn make_untimed_agent(url: &str) -> Agent {
 fn make_certifying_agent(url: &str) -> Agent {
     Agent::builder()
         .with_url(url)
-        .with_ingress_expiry(Some(Duration::from_secs(u32::MAX as _)))
+        .with_ingress_expiry(Duration::from_secs(u32::MAX as _))
         .build()
         .unwrap()
 }

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -98,7 +98,7 @@ impl AgentBuilder {
     /// The timestamp corresponding to this duration may be rounded in order to reduce
     /// cache misses. The current implementation rounds to the nearest minute if the
     /// expiry is more than a minute, but this is not guaranteed.
-    pub fn with_ingress_expiry(mut self, ingress_expiry: Option<std::time::Duration>) -> Self {
+    pub fn with_ingress_expiry(mut self, ingress_expiry: std::time::Duration) -> Self {
         self.config.ingress_expiry = ingress_expiry;
         self
     }

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1191,7 +1191,7 @@ impl Agent {
     }
 }
 
-const DEFAULT_INGRESS_EXPIRY: Duration = Duration::from_secs(240);
+const DEFAULT_INGRESS_EXPIRY: Duration = Duration::from_secs(180);
 
 // Checks if a principal is contained within a list of principal ranges
 // A range is a tuple: (low: Principal, high: Principal), as described here: https://internetcomputer.org/docs/current/references/ic-interface-spec#state-tree-subnet

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -177,7 +177,7 @@ impl Agent {
         Ok(Agent {
             nonce_factory: config.nonce_factory,
             identity: config.identity,
-            ingress_expiry: config.ingress_expiry.unwrap_or(DEFAULT_INGRESS_EXPIRY),
+            ingress_expiry: config.ingress_expiry,
             root_key: Arc::new(RwLock::new(IC_ROOT_KEY.to_vec())),
             client: config.http_service.unwrap_or_else(|| {
                 Arc::new(Retry429Logic {
@@ -1188,8 +1188,6 @@ impl Agent {
         }
     }
 }
-
-const DEFAULT_INGRESS_EXPIRY: Duration = Duration::from_secs(180);
 
 // Checks if a principal is contained within a list of principal ranges
 // A range is a tuple: (low: Principal, high: Principal), as described here: https://internetcomputer.org/docs/current/references/ic-interface-spec#state-tree-subnet


### PR DESCRIPTION
Decrease the ingress expiry default.

Adding a message to be processed takes the order of seconds. We can expiry messages more aggressively.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
