### PR TITLE
feat: Add BitcoinGetBlockHeaders to MgmtMethod

### DIFF
--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -89,6 +89,8 @@ pub enum MgmtMethod {
     BitcoinSendTransaction,
     /// There is no corresponding agent function as only canisters can call it. Use [`BitcoinCanister`](super::BitcoinCanister) instead.
     BitcoinGetCurrentFeePercentiles,
+    /// There is no corresponding agent function as only canisters can call it. Use [`BitcoinCanister`](super::BitcoinCanister) instead.
+    BitcoinGetBlockHeaders,
     /// There is no corresponding agent function as only canisters can call it.
     NodeMetricsHistory,
 }

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -323,6 +323,7 @@ pub fn get_effective_canister_id(
             | MgmtMethod::BitcoinGetUtxos
             | MgmtMethod::BitcoinSendTransaction
             | MgmtMethod::BitcoinGetCurrentFeePercentiles
+            | MgmtMethod::BitcoinGetBlockHeaders
             | MgmtMethod::EcdsaPublicKey
             | MgmtMethod::SignWithEcdsa
             | MgmtMethod::NodeMetricsHistory => {


### PR DESCRIPTION
Since this cannot be called by canisters outside the bitcoin canister interface, this does not include an implementation.