### PR TITLE
chore: Update MSRV to 1.78

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/dfinity/agent-rs"
 # MSRV
 # Avoid updating this field unless we use new Rust features
 # Sync rust-version in rust-toolchain.toml
-rust-version = "1.75.0"
+rust-version = "1.78.0"
 license = "Apache-2.0"
 
 [workspace.dependencies]

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -98,14 +98,15 @@ mod management_canister {
                     .call_and_wait()
                     .await;
 
-                assert!(matches!(result,
+                assert!(
+                    matches!(result,
                     Err(AgentError::UncertifiedReject(RejectResponse {
                     reject_code: RejectCode::DestinationInvalid,
                     ref reject_message,
                     error_code: Some(ref error_code)
                 })) if reject_message == "Canister 75hes-oqbaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-q not found" &&
-                        error_code == "IC0301") ||
-                        matches!(result, Err(HttpError(content)) if content.status == 400 && content.content == b"Canister 75hes-oqbaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-q does not belong to any subnet.")
+                        error_code == "IC0301")
+                        || matches!(result, Err(HttpError(content)) if content.status == 400 && content.content == b"Canister 75hes-oqbaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-q does not belong to any subnet.")
                 );
 
                 Ok(())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # MSRV
 # Avoid updating this field unless we use new Rust features
 # Sync rust-version in workspace Cargo.toml
-channel = "1.75.0"
+channel = "1.78.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
rust-analyzer no longer supports 1.77 and below.