### PR TITLE
chore: bump ic-certification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.39.0]
 
+* Bumped `ic-certification` to `3.0.0`.
 * The lower-level update call functions now return the certificate in addition to the parsed response data.
 * Make ingress_expiry required and set the default value to 3 min.
 * Changed `BasicIdentity`'s implementation from `ring` to `ed25519-consensus`.
@@ -33,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Url` now implements `RouteProvider`.
 * Add canister snapshot methods to `ManagementCanister`.
 * Add `AllowedViewers` to `LogVisibility` enum.
-* Remove the cargo feature, `experimental_sync_call`, and enable synchronous update calls by default. 
+* Remove the cargo feature, `experimental_sync_call`, and enable synchronous update calls by default.
 
 ## [0.37.1] - 2024-07-25
 
@@ -75,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `ReqwestTransport` and `HyperTransport` structures storing the trait object `route_provider: Box<dyn RouteProvider>` have been modified to allow for shared ownership via `Arc<dyn RouteProvider>`.
 * Added `wasm_memory_limit` to canister creation and canister setting update options.
 * Bumped Reqwest version from `0.11.7` to `0.12.4`
- 
+
 ## [0.34.0] - 2024-03-18
 
 * Changed `AgentError::ReplicaError` to `CertifiedReject` or `UncertifiedReject`. `CertifiedReject`s went through consensus, and `UncertifiedReject`s did not. If your code uses `ReplicaError`:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ dependencies = [
  "hex",
  "http",
  "http-body",
- "ic-certification",
+ "ic-certification 3.0.2",
  "ic-transport-types 0.39.1",
  "ic-verify-bls-signature",
  "js-sys",
@@ -1184,6 +1184,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-certification"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eae40f26fcac9c141cad54d9aa5f423efffde78ac371057c53d275ebbcad443"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.8",
+]
+
+[[package]]
 name = "ic-identity-hsm"
 version = "0.39.1"
 dependencies = [
@@ -1203,7 +1215,7 @@ checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
 dependencies = [
  "candid",
  "hex",
- "ic-certification",
+ "ic-certification 2.6.0",
  "leb128",
  "serde",
  "serde_bytes",
@@ -1218,7 +1230,7 @@ version = "0.39.1"
 dependencies = [
  "candid",
  "hex",
- "ic-certification",
+ "ic-certification 3.0.2",
  "leb128",
  "serde",
  "serde_bytes",
@@ -1440,7 +1452,7 @@ dependencies = [
  "base64 0.22.1",
  "clap",
  "hex",
- "ic-certification",
+ "ic-certification 3.0.2",
  "leb128",
  "reqwest",
  "serde",
@@ -1994,7 +2006,7 @@ dependencies = [
  "base64 0.13.1",
  "candid",
  "hex",
- "ic-certification",
+ "ic-certification 2.6.0",
  "ic-transport-types 0.37.1",
  "reqwest",
  "schemars",
@@ -2197,7 +2209,7 @@ dependencies = [
  "candid",
  "ed25519-consensus",
  "ic-agent",
- "ic-certification",
+ "ic-certification 3.0.2",
  "ic-identity-hsm",
  "ic-utils",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ ic-agent = { path = "ic-agent", version = "0.39.1", default-features = false }
 ic-utils = { path = "ic-utils", version = "0.39.1" }
 ic-transport-types = { path = "ic-transport-types", version = "0.39.1" }
 
-ic-certification = "2.6.0"
+ic-certification = "3"
 candid = "0.10.10"
 candid_parser = "0.1.4"
 clap = "4.5.21"


### PR DESCRIPTION
# Description

The latest ic-certification version is 3. This repo currently uses 2.6. For compatibility with libraries that have already updated to version 3, we bump the version.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
