### PR TITLE
feat: Add `CanisterInfo`.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-13-large, ubuntu-latest ]
+        os: [ macos-13-large, ubuntu-22.04 ]
         dfx: [ '0.8.4', '0.9.2', '0.10.1', '0.11.1' ]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `wasm_memory_threshold` field to `CanisterSettings`.
 
+* Added `CanisterInfo` to `MgmtMethod`.
+
 ## [0.39.2] - 2024-12-20
 
 * Bumped `ic-certification` to `3.0.0`.

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -94,7 +94,7 @@ pub enum MgmtMethod {
     /// There is no corresponding agent function as only canisters can call it.
     NodeMetricsHistory,
     /// There is no corresponding agent function as only canisters can call it.
-    CanisterInfo
+    CanisterInfo,
 }
 
 impl<'agent> ManagementCanister<'agent> {

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -93,6 +93,8 @@ pub enum MgmtMethod {
     BitcoinGetBlockHeaders,
     /// There is no corresponding agent function as only canisters can call it.
     NodeMetricsHistory,
+    /// There is no corresponding agent function as only canisters can call it.
+    CanisterInfo
 }
 
 impl<'agent> ManagementCanister<'agent> {

--- a/icx/src/main.rs
+++ b/icx/src/main.rs
@@ -326,7 +326,8 @@ pub fn get_effective_canister_id(
             | MgmtMethod::BitcoinGetBlockHeaders
             | MgmtMethod::EcdsaPublicKey
             | MgmtMethod::SignWithEcdsa
-            | MgmtMethod::NodeMetricsHistory => {
+            | MgmtMethod::NodeMetricsHistory
+            | MgmtMethod::CanisterInfo => {
                 bail!("Management canister method {method_name} can only be run from canisters");
             }
         }


### PR DESCRIPTION
# Description

Added `CanisterInfo` to `MgmtMethod`. 

This addresses the issue that `dfx canister call aaaaa-aa canister_info '(record {canister_id=principal"<canister-id>"; num_requested_changes=opt 20;})' --wallet <wallet-id> --ic` failed with `Attempted to call an unsupported management canister method: canister_info`.

