### PR TITLE
chore: extend `RouteProvider` trait with routes_stats()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `CanisterInfo` to `MgmtMethod`.
 
+* Extended `RouteProvider` trait with `fn routes_stats()`, returning the number of total and healthy routes as a tuple.
+
 ## [0.39.2] - 2024-12-20
 
 * Bumped `ic-certification` to `3.0.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `CanisterInfo` to `MgmtMethod`.
 
-* Extended `RouteProvider` trait with `fn routes_stats()`, returning the number of total and healthy routes as a tuple.
+* Extended `RouteProvider` trait with `fn routes_stats()`, returning the number of total and healthy routes.
 
 ## [0.39.2] - 2024-12-20
 

--- a/ic-agent/src/agent/route_provider.rs
+++ b/ic-agent/src/agent/route_provider.rs
@@ -49,6 +49,7 @@ pub struct RoutesStats {
 }
 
 impl RoutesStats {
+    /// Creates an new instance of [`RoutesStats`].
     pub fn new(total: usize, healthy: Option<usize>) -> Self {
         Self { total, healthy }
     }

--- a/ic-agent/src/agent/route_provider.rs
+++ b/ic-agent/src/agent/route_provider.rs
@@ -55,11 +55,11 @@ pub trait RouteProvider: std::fmt::Debug + Send + Sync {
     /// Returns the total number of routes and healthy routes as a tuple.
     ///
     /// - First element is the total number of routes available (both healthy and unhealthy)
-    /// - Second element is the number of currently healthy routes
+    /// - Second element is the number of currently healthy routes, or None if health status information is unavailable
     ///
     /// A healthy route is one that is available and ready to receive traffic.
     /// The specific criteria for what constitutes a "healthy" route is implementation dependent.
-    fn routes_stats(&self) -> (usize, usize);
+    fn routes_stats(&self) -> (usize, Option<usize>);
 }
 
 /// A simple implementation of the [`RouteProvider`] which produces an even distribution of the urls from the input ones.
@@ -104,8 +104,8 @@ impl RouteProvider for RoundRobinRouteProvider {
         Ok(urls)
     }
 
-    fn routes_stats(&self) -> (usize, usize) {
-        (self.routes.len(), self.routes.len())
+    fn routes_stats(&self) -> (usize, Option<usize>) {
+        (self.routes.len(), None)
     }
 }
 
@@ -146,8 +146,8 @@ impl RouteProvider for Url {
     fn n_ordered_routes(&self, _: usize) -> Result<Vec<Url>, AgentError> {
         Ok(vec![self.route()?])
     }
-    fn routes_stats(&self) -> (usize, usize) {
-        (1, 1)
+    fn routes_stats(&self) -> (usize, Option<usize>) {
+        (1, None)
     }
 }
 
@@ -231,7 +231,7 @@ impl RouteProvider for DynamicRouteProvider {
     fn n_ordered_routes(&self, n: usize) -> Result<Vec<Url>, AgentError> {
         self.inner.n_ordered_routes(n)
     }
-    fn routes_stats(&self) -> (usize, usize) {
+    fn routes_stats(&self) -> (usize, Option<usize>) {
         self.inner.routes_stats()
     }
 }
@@ -289,8 +289,8 @@ impl<R: RouteProvider> RouteProvider for UrlUntilReady<R> {
             self.url.route()
         }
     }
-    fn routes_stats(&self) -> (usize, usize) {
-        (1, 1)
+    fn routes_stats(&self) -> (usize, Option<usize>) {
+        (1, None)
     }
 }
 

--- a/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
@@ -23,7 +23,7 @@ use crate::{
                 snapshot::routing_snapshot::RoutingSnapshot,
                 type_aliases::AtomicSwap,
             },
-            RouteProvider,
+            RouteProvider, RoutesStats,
         },
         HttpService,
     },
@@ -187,9 +187,9 @@ where
         Ok(urls)
     }
 
-    fn routes_stats(&self) -> (usize, Option<usize>) {
+    fn routes_stats(&self) -> RoutesStats {
         let snapshot = self.routing_snapshot.load();
-        snapshot.nodes_stats()
+        snapshot.routes_stats()
     }
 }
 
@@ -296,7 +296,7 @@ mod tests {
                     assert_routed_domains, route_n_times, NodeHealthCheckerMock, NodesFetcherMock,
                 },
             },
-            RouteProvider,
+            RouteProvider, RoutesStats,
         },
         Agent, AgentError,
     };
@@ -422,7 +422,7 @@ mod tests {
         tokio::time::sleep(snapshot_update_duration).await;
         let routed_domains = route_n_times(6, Arc::clone(&route_provider));
         assert_routed_domains(routed_domains, vec![node_1.domain()], 6);
-        assert_eq!(route_provider.routes_stats(), (1, Some(1)));
+        assert_eq!(route_provider.routes_stats(), RoutesStats::new(1, Some(1)));
 
         // Test 2: multiple route() calls return 3 different domains with equal fairness (repetition).
         // Two healthy nodes are added to the topology.
@@ -437,7 +437,7 @@ mod tests {
             vec![node_1.domain(), node_2.domain(), node_3.domain()],
             2,
         );
-        assert_eq!(route_provider.routes_stats(), (3, Some(3)));
+        assert_eq!(route_provider.routes_stats(), RoutesStats::new(3, Some(3)));
 
         // Test 3:  multiple route() calls return 2 different domains with equal fairness (repetition).
         // One node is set to unhealthy.
@@ -445,7 +445,7 @@ mod tests {
         tokio::time::sleep(snapshot_update_duration).await;
         let routed_domains = route_n_times(6, Arc::clone(&route_provider));
         assert_routed_domains(routed_domains, vec![node_1.domain(), node_3.domain()], 3);
-        assert_eq!(route_provider.routes_stats(), (3, Some(2)));
+        assert_eq!(route_provider.routes_stats(), RoutesStats::new(3, Some(2)));
 
         // Test 4: multiple route() calls return 3 different domains with equal fairness (repetition).
         // Unhealthy node is set back to healthy.
@@ -457,7 +457,7 @@ mod tests {
             vec![node_1.domain(), node_2.domain(), node_3.domain()],
             2,
         );
-        assert_eq!(route_provider.routes_stats(), (3, Some(3)));
+        assert_eq!(route_provider.routes_stats(), RoutesStats::new(3, Some(3)));
 
         // Test 5: multiple route() calls return 3 different domains with equal fairness (repetition).
         // One healthy node is added, but another one goes unhealthy.
@@ -476,7 +476,7 @@ mod tests {
             vec![node_2.domain(), node_3.domain(), node_4.domain()],
             2,
         );
-        assert_eq!(route_provider.routes_stats(), (4, Some(3)));
+        assert_eq!(route_provider.routes_stats(), RoutesStats::new(4, Some(3)));
 
         // Test 6: multiple route() calls return a single domain=api1.com.
         // One node is set to unhealthy and one is removed from the topology.
@@ -485,7 +485,7 @@ mod tests {
         tokio::time::sleep(snapshot_update_duration).await;
         let routed_domains = route_n_times(3, Arc::clone(&route_provider));
         assert_routed_domains(routed_domains, vec![node_2.domain()], 3);
-        assert_eq!(route_provider.routes_stats(), (3, Some(1)));
+        assert_eq!(route_provider.routes_stats(), RoutesStats::new(3, Some(1)));
     }
 
     #[tokio::test]

--- a/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
@@ -186,6 +186,11 @@ where
         let urls = nodes.iter().map(|n| n.to_routing_url()).collect();
         Ok(urls)
     }
+
+    fn routes_stats(&self) -> (usize, usize) {
+        let snapshot = self.routing_snapshot.load();
+        snapshot.nodes_stats()
+    }
 }
 
 impl<S> DynamicRouteProvider<S>
@@ -417,6 +422,7 @@ mod tests {
         tokio::time::sleep(snapshot_update_duration).await;
         let routed_domains = route_n_times(6, Arc::clone(&route_provider));
         assert_routed_domains(routed_domains, vec![node_1.domain()], 6);
+        assert_eq!(route_provider.routes_stats(), (1, 1));
 
         // Test 2: multiple route() calls return 3 different domains with equal fairness (repetition).
         // Two healthy nodes are added to the topology.
@@ -431,6 +437,7 @@ mod tests {
             vec![node_1.domain(), node_2.domain(), node_3.domain()],
             2,
         );
+        assert_eq!(route_provider.routes_stats(), (3, 3));
 
         // Test 3:  multiple route() calls return 2 different domains with equal fairness (repetition).
         // One node is set to unhealthy.
@@ -438,6 +445,7 @@ mod tests {
         tokio::time::sleep(snapshot_update_duration).await;
         let routed_domains = route_n_times(6, Arc::clone(&route_provider));
         assert_routed_domains(routed_domains, vec![node_1.domain(), node_3.domain()], 3);
+        assert_eq!(route_provider.routes_stats(), (3, 2));
 
         // Test 4: multiple route() calls return 3 different domains with equal fairness (repetition).
         // Unhealthy node is set back to healthy.
@@ -449,6 +457,7 @@ mod tests {
             vec![node_1.domain(), node_2.domain(), node_3.domain()],
             2,
         );
+        assert_eq!(route_provider.routes_stats(), (3, 3));
 
         // Test 5: multiple route() calls return 3 different domains with equal fairness (repetition).
         // One healthy node is added, but another one goes unhealthy.
@@ -467,6 +476,7 @@ mod tests {
             vec![node_2.domain(), node_3.domain(), node_4.domain()],
             2,
         );
+        assert_eq!(route_provider.routes_stats(), (4, 3));
 
         // Test 6: multiple route() calls return a single domain=api1.com.
         // One node is set to unhealthy and one is removed from the topology.
@@ -475,6 +485,7 @@ mod tests {
         tokio::time::sleep(snapshot_update_duration).await;
         let routed_domains = route_n_times(3, Arc::clone(&route_provider));
         assert_routed_domains(routed_domains, vec![node_2.domain()], 3);
+        assert_eq!(route_provider.routes_stats(), (3, 1));
     }
 
     #[tokio::test]

--- a/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
@@ -187,7 +187,7 @@ where
         Ok(urls)
     }
 
-    fn routes_stats(&self) -> (usize, usize) {
+    fn routes_stats(&self) -> (usize, Option<usize>) {
         let snapshot = self.routing_snapshot.load();
         snapshot.nodes_stats()
     }
@@ -422,7 +422,7 @@ mod tests {
         tokio::time::sleep(snapshot_update_duration).await;
         let routed_domains = route_n_times(6, Arc::clone(&route_provider));
         assert_routed_domains(routed_domains, vec![node_1.domain()], 6);
-        assert_eq!(route_provider.routes_stats(), (1, 1));
+        assert_eq!(route_provider.routes_stats(), (1, Some(1)));
 
         // Test 2: multiple route() calls return 3 different domains with equal fairness (repetition).
         // Two healthy nodes are added to the topology.
@@ -437,7 +437,7 @@ mod tests {
             vec![node_1.domain(), node_2.domain(), node_3.domain()],
             2,
         );
-        assert_eq!(route_provider.routes_stats(), (3, 3));
+        assert_eq!(route_provider.routes_stats(), (3, Some(3)));
 
         // Test 3:  multiple route() calls return 2 different domains with equal fairness (repetition).
         // One node is set to unhealthy.
@@ -445,7 +445,7 @@ mod tests {
         tokio::time::sleep(snapshot_update_duration).await;
         let routed_domains = route_n_times(6, Arc::clone(&route_provider));
         assert_routed_domains(routed_domains, vec![node_1.domain(), node_3.domain()], 3);
-        assert_eq!(route_provider.routes_stats(), (3, 2));
+        assert_eq!(route_provider.routes_stats(), (3, Some(2)));
 
         // Test 4: multiple route() calls return 3 different domains with equal fairness (repetition).
         // Unhealthy node is set back to healthy.
@@ -457,7 +457,7 @@ mod tests {
             vec![node_1.domain(), node_2.domain(), node_3.domain()],
             2,
         );
-        assert_eq!(route_provider.routes_stats(), (3, 3));
+        assert_eq!(route_provider.routes_stats(), (3, Some(3)));
 
         // Test 5: multiple route() calls return 3 different domains with equal fairness (repetition).
         // One healthy node is added, but another one goes unhealthy.
@@ -476,7 +476,7 @@ mod tests {
             vec![node_2.domain(), node_3.domain(), node_4.domain()],
             2,
         );
-        assert_eq!(route_provider.routes_stats(), (4, 3));
+        assert_eq!(route_provider.routes_stats(), (4, Some(3)));
 
         // Test 6: multiple route() calls return a single domain=api1.com.
         // One node is set to unhealthy and one is removed from the topology.
@@ -485,7 +485,7 @@ mod tests {
         tokio::time::sleep(snapshot_update_duration).await;
         let routed_domains = route_n_times(3, Arc::clone(&route_provider));
         assert_routed_domains(routed_domains, vec![node_2.domain()], 3);
-        assert_eq!(route_provider.routes_stats(), (3, 1));
+        assert_eq!(route_provider.routes_stats(), (3, Some(1)));
     }
 
     #[tokio::test]

--- a/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/latency_based_routing.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/latency_based_routing.rs
@@ -323,8 +323,8 @@ impl RoutingSnapshot for LatencyRoutingSnapshot {
         true
     }
 
-    fn nodes_stats(&self) -> (usize, usize) {
-        (self.existing_nodes.len(), self.healthy_nodes.len())
+    fn nodes_stats(&self) -> (usize, Option<usize>) {
+        (self.existing_nodes.len(), Some(self.healthy_nodes.len()))
     }
 }
 
@@ -356,7 +356,7 @@ mod tests {
         assert!(!snapshot.has_nodes());
         assert!(snapshot.next_node().is_none());
         assert!(snapshot.next_n_nodes(1).is_empty());
-        assert_eq!(snapshot.nodes_stats(), (0, 0));
+        assert_eq!(snapshot.nodes_stats(), (0, Some(0)));
     }
 
     #[test]
@@ -372,7 +372,7 @@ mod tests {
         assert!(snapshot.nodes_with_metrics.is_empty());
         assert!(!snapshot.has_nodes());
         assert!(snapshot.next_node().is_none());
-        assert_eq!(snapshot.nodes_stats(), (0, 0));
+        assert_eq!(snapshot.nodes_stats(), (0, Some(0)));
     }
 
     #[test]
@@ -384,7 +384,7 @@ mod tests {
         let node = Node::new("api1.com").unwrap();
         let health = HealthCheckStatus::new(Some(Duration::from_secs(1)));
         snapshot.existing_nodes.insert(node.clone());
-        assert_eq!(snapshot.nodes_stats(), (1, 0));
+        assert_eq!(snapshot.nodes_stats(), (1, Some(0)));
         // Check first update
         let is_updated = snapshot.update_node(&node, health);
         assert!(is_updated);
@@ -392,7 +392,7 @@ mod tests {
         let node_with_metrics = snapshot.nodes_with_metrics.first().unwrap();
         assert_eq!(node_with_metrics.score, (2.0 / 1.0) / 2.0);
         assert_eq!(snapshot.next_node().unwrap(), node);
-        assert_eq!(snapshot.nodes_stats(), (1, 1));
+        assert_eq!(snapshot.nodes_stats(), (1, Some(1)));
         // Check second update
         let health = HealthCheckStatus::new(Some(Duration::from_secs(2)));
         let is_updated = snapshot.update_node(&node, health);
@@ -415,7 +415,7 @@ mod tests {
         assert_eq!(snapshot.nodes_with_metrics.len(), 1);
         assert_eq!(snapshot.existing_nodes.len(), 1);
         assert!(snapshot.next_node().is_none());
-        assert_eq!(snapshot.nodes_stats(), (1, 0));
+        assert_eq!(snapshot.nodes_stats(), (1, Some(0)));
     }
 
     #[test]

--- a/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/round_robin_routing.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/round_robin_routing.rs
@@ -6,8 +6,11 @@ use std::{
     },
 };
 
-use crate::agent::route_provider::dynamic_routing::{
-    health_check::HealthCheckStatus, node::Node, snapshot::routing_snapshot::RoutingSnapshot,
+use crate::agent::route_provider::{
+    dynamic_routing::{
+        health_check::HealthCheckStatus, node::Node, snapshot::routing_snapshot::RoutingSnapshot,
+    },
+    RoutesStats,
 };
 
 /// Routing snapshot, which samples nodes in a round-robin fashion.
@@ -107,8 +110,8 @@ impl RoutingSnapshot for RoundRobinRoutingSnapshot {
         }
     }
 
-    fn nodes_stats(&self) -> (usize, Option<usize>) {
-        (self.existing_nodes.len(), Some(self.healthy_nodes.len()))
+    fn routes_stats(&self) -> RoutesStats {
+        RoutesStats::new(self.existing_nodes.len(), Some(self.healthy_nodes.len()))
     }
 }
 

--- a/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/round_robin_routing.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/round_robin_routing.rs
@@ -107,8 +107,8 @@ impl RoutingSnapshot for RoundRobinRoutingSnapshot {
         }
     }
 
-    fn nodes_stats(&self) -> (usize, usize) {
-        (self.existing_nodes.len(), self.healthy_nodes.len())
+    fn nodes_stats(&self) -> (usize, Option<usize>) {
+        (self.existing_nodes.len(), Some(self.healthy_nodes.len()))
     }
 }
 

--- a/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/round_robin_routing.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/round_robin_routing.rs
@@ -106,6 +106,10 @@ impl RoutingSnapshot for RoundRobinRoutingSnapshot {
             self.healthy_nodes.remove(node)
         }
     }
+
+    fn nodes_stats(&self) -> (usize, usize) {
+        (self.existing_nodes.len(), self.healthy_nodes.len())
+    }
 }
 
 #[cfg(test)]

--- a/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/routing_snapshot.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/routing_snapshot.rs
@@ -1,6 +1,9 @@
 use std::fmt::Debug;
 
-use crate::agent::route_provider::dynamic_routing::{health_check::HealthCheckStatus, node::Node};
+use crate::agent::route_provider::{
+    dynamic_routing::{health_check::HealthCheckStatus, node::Node},
+    RoutesStats,
+};
 
 /// A trait for interacting with the snapshot of nodes (routing table).
 pub trait RoutingSnapshot: Send + Sync + Clone + Debug {
@@ -15,11 +18,6 @@ pub trait RoutingSnapshot: Send + Sync + Clone + Debug {
     fn sync_nodes(&mut self, nodes: &[Node]) -> bool;
     /// Updates the health status of a specific node, returning `true` if the node was found and updated.
     fn update_node(&mut self, node: &Node, health: HealthCheckStatus) -> bool;
-    /// Returns the total number of nodes and healthy nodes as a tuple.
-    ///
-    /// - First element is the total number of nodes available (both healthy and unhealthy)
-    /// - Second element is the number of currently healthy nodes, or None if health status information is unavailable
-    ///
-    /// The specific criteria for what constitutes a "healthy" node is implementation dependent.
-    fn nodes_stats(&self) -> (usize, Option<usize>);
+    /// Returns statistics about the routes (nodes).
+    fn routes_stats(&self) -> RoutesStats;
 }

--- a/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/routing_snapshot.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/routing_snapshot.rs
@@ -15,6 +15,11 @@ pub trait RoutingSnapshot: Send + Sync + Clone + Debug {
     fn sync_nodes(&mut self, nodes: &[Node]) -> bool;
     /// Updates the health status of a specific node, returning `true` if the node was found and updated.
     fn update_node(&mut self, node: &Node, health: HealthCheckStatus) -> bool;
-    /// Returns the total number of nodes and healthy nodes as a tuple with first and second element, respectively.
-    fn nodes_stats(&self) -> (usize, usize);
+    /// Returns the total number of nodes and healthy nodes as a tuple.
+    ///
+    /// - First element is the total number of nodes available (both healthy and unhealthy)
+    /// - Second element is the number of currently healthy nodes, or None if health status information is unavailable
+    ///
+    /// The specific criteria for what constitutes a "healthy" node is implementation dependent.
+    fn nodes_stats(&self) -> (usize, Option<usize>);
 }

--- a/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/routing_snapshot.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/snapshot/routing_snapshot.rs
@@ -15,4 +15,6 @@ pub trait RoutingSnapshot: Send + Sync + Clone + Debug {
     fn sync_nodes(&mut self, nodes: &[Node]) -> bool;
     /// Updates the health status of a specific node, returning `true` if the node was found and updated.
     fn update_node(&mut self, node: &Node, health: HealthCheckStatus) -> bool;
+    /// Returns the total number of nodes and healthy nodes as a tuple with first and second element, respectively.
+    fn nodes_stats(&self) -> (usize, usize);
 }


### PR DESCRIPTION
# Description

`RouteProvider` trait is extended with a method to get useful metrics about the total number of routes and healthy number of routes.

```
/// Returns statistics about the total number of existing routes and the number of healthy routes.
fn routes_stats(&self) -> RoutesStats;
```

# How Has This Been Tested?

Unit tests were extended accordingly.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
