### PR TITLE
fix: AgentBuilder::with_background_dynamic_routing

### DIFF
--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -22,7 +22,7 @@ impl AgentBuilder {
     /// and routing traffic via them based on latency. Cannot be set together with `with_route_provider`.
     ///
     /// See [`DynamicRouteProvider`](super::route_provider::DynamicRouteProvider) if more customization is needed such as polling intervals.
-    pub async fn with_background_dynamic_routing(mut self) -> Self {
+    pub fn with_background_dynamic_routing(mut self) -> Self {
         assert!(
             self.config.route_provider.is_none(),
             "with_background_dynamic_routing cannot be called with with_route_provider"


### PR DESCRIPTION
# Description

Remove redundant `async` from the `with_background_dynamic_routing` function.
