### PR TITLE
fix: AgentBuilder::with_background_dynamic_routing is async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * Updated the serialization of `WasmMemoryPersistence`.
-* `Agent::with_background_dynamic_routing` is no longer `async`.
+* `AgentBuilder::with_background_dynamic_routing` is no longer `async`.
 
 ## [0.39.3] - 2025-01-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * Updated the serialization of `WasmMemoryPersistence`.
+* `Agent::with_background_dynamic_routing` is no longer `async`.
 
 ## [0.39.3] - 2025-01-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 * Updated the serialization of `WasmMemoryPersistence`.
-* `AgentBuilder::with_background_dynamic_routing` is no longer `async`.
+* [BREAKING] `AgentBuilder::with_background_dynamic_routing` is no longer `async`.
 
 ## [0.39.3] - 2025-01-21
 

--- a/ic-agent/src/agent/builder.rs
+++ b/ic-agent/src/agent/builder.rs
@@ -22,7 +22,7 @@ impl AgentBuilder {
     /// and routing traffic via them based on latency. Cannot be set together with `with_route_provider`.
     ///
     /// See [`DynamicRouteProvider`](super::route_provider::DynamicRouteProvider) if more customization is needed such as polling intervals.
-    pub async fn with_background_dynamic_routing(mut self) -> Self {
+    pub fn with_background_dynamic_routing(mut self) -> Self {
         assert!(
             self.config.route_provider.is_none(),
             "with_background_dynamic_routing cannot be called with with_route_provider"


### PR DESCRIPTION
# Description

`AgentBuilder` method `with_background_dynamic_routing` is `async` for no reason.

Reported [on the forum](https://forum.dfinity.org/t/boundary-node-roadmap/15562/97)

# How Has This Been Tested?

not tested

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
