### PR TITLE
fix: CHANGELOG.md unreleased notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Updated the serialization of `WasmMemoryPersistence`.
 * [BREAKING] `AgentBuilder::with_background_dynamic_routing` is no longer `async`.
+* Extended `RouteProvider` trait with `fn routes_stats()`, returning the number of total and healthy routes.
 
 ## [0.39.3] - 2025-01-21
 
 * Added `wasm_memory_threshold` field to `CanisterSettings`.
 
 * Added `CanisterInfo` to `MgmtMethod`.
-
-* Extended `RouteProvider` trait with `fn routes_stats()`, returning the number of total and healthy routes.
 
 ## [0.39.2] - 2024-12-20
 


### PR DESCRIPTION
Fixes # (issue)
The CHANGELOG was mistakenly updated in the wrong section. The notes should have been added under 'Unreleased' instead of modifying the previous release.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
