### PR TITLE
feat: error overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* BREAKING: `AgentError` is now an opaque error type which reveals only the general category of error that occurred.
+* `AgentError` now contains information about the ongoing operation the error occurred in the context of. This allows you to see
+  if a call successfully went through even if there was for example an error Candid-decoding the response.
+
 ## [0.40.0] - 2025-03-17
 
 * BREAKING: Added data about the rejected call to CertifiedReject/UncertifiedReject.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,6 +1139,7 @@ dependencies = [
  "ic-transport-types 0.40.0",
  "ic-verify-bls-signature",
  "ic_principal",
+ "itertools 0.14.0",
  "js-sys",
  "k256",
  "leb128",
@@ -1528,6 +1529,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,7 +1575,7 @@ dependencies = [
  "ascii-canvas",
  "bit-set",
  "ena",
- "itertools",
+ "itertools 0.11.0",
  "lalrpop-util",
  "petgraph",
  "pico-args",
@@ -2209,6 +2219,7 @@ version = "0.0.0"
 dependencies = [
  "candid",
  "ed25519-consensus",
+ "hex",
  "ic-agent",
  "ic-certification 3.0.2",
  "ic-identity-hsm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,9 +1611,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
@@ -3003,9 +3003,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3021,9 +3021,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ dependencies = [
  "ic-certification 3.0.2",
  "ic-transport-types 0.40.0",
  "ic-verify-bls-signature",
+ "ic_principal",
  "js-sys",
  "k256",
  "leb128",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ ic-utils = { path = "ic-utils", version = "0.40.0" }
 ic-transport-types = { path = "ic-transport-types", version = "0.40.0" }
 
 ic-certification = "3"
+ic_principal = "0.1"
 candid = "0.10.10"
 candid_parser = "0.1.4"
 clap = "4.5.21"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -25,7 +25,6 @@ async-trait = "0.1"
 async-watch = "0.3"
 backoff = "0.4.0"
 cached = { version = "0.52", features = ["ahash"], default-features = false }
-candid = { workspace = true }
 der = "0.7"
 ecdsa = "0.16"
 ed25519-consensus = { workspace = true }
@@ -35,6 +34,7 @@ hex = { workspace = true }
 http = "1.0.0"
 http-body = "1.0.0"
 ic-certification = { workspace = true }
+ic_principal = { workspace = true }
 ic-transport-types = { workspace = true }
 ic-verify-bls-signature = "0.5"
 k256 = { workspace = true, features = ["pem"] }
@@ -78,6 +78,7 @@ wasm-bindgen-futures = { version = "0.4", optional = true }
 web-sys = { version = "0.3", features = ["Window"], optional = true }
 
 [dev-dependencies]
+candid = { workspace = true }
 serde_json.workspace = true
 tracing-subscriber = "0.3"
 tracing = "0.1"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -33,10 +33,11 @@ futures-util = { workspace = true }
 hex = { workspace = true }
 http = "1.0.0"
 http-body = "1.0.0"
-ic-certification = { workspace = true }
 ic_principal = { workspace = true }
+ic-certification = { workspace = true }
 ic-transport-types = { workspace = true }
 ic-verify-bls-signature = "0.5"
+itertools = "0.14.0"
 k256 = { workspace = true, features = ["pem"] }
 p256 = { workspace = true, features = ["pem"] }
 leb128 = { workspace = true }

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -267,7 +267,7 @@ impl HttpErrorPayload {
         // always try to parse it as a String.
         // When fail, print the raw byte array
         f.write_fmt(format_args!(
-            "Http Error: status {}, content type {:?}, content: {}",
+            "Replica HTTP error: status {}, content type {:?}, content: {}",
             http::StatusCode::from_u16(self.status)
                 .map_or_else(|_| format!("{}", self.status), |code| format!("{code}")),
             self.content_type.clone().unwrap_or_default(),
@@ -295,7 +295,6 @@ impl Display for HttpErrorPayload {
 #[cfg(test)]
 mod tests {
     use super::HttpErrorPayload;
-    use crate::AgentError;
 
     #[test]
     fn content_type_none_valid_utf8() {
@@ -306,8 +305,8 @@ mod tests {
         };
 
         assert_eq!(
-            format!("{}", AgentError::HttpError(payload)),
-            r#"The replica returned an HTTP Error: Http Error: status 420 <unknown status code>, content type "", content: hello"#,
+            format!("{payload}"),
+            r#"Replica HTTP error: status 420 <unknown status code>, content type "", content: hello"#,
         );
     }
 
@@ -320,8 +319,8 @@ mod tests {
         };
 
         assert_eq!(
-            format!("{}", AgentError::HttpError(payload)),
-            r#"The replica returned an HTTP Error: Http Error: status 420 <unknown status code>, content type "", content: (unable to decode content as UTF-8: [195, 40])"#,
+            format!("{payload}"),
+            r#"Replica HTTP rror: status 420 <unknown status code>, content type "", content: (unable to decode content as UTF-8: [195, 40])"#,
         );
     }
 
@@ -334,8 +333,8 @@ mod tests {
         };
 
         assert_eq!(
-            format!("{}", AgentError::HttpError(payload)),
-            r#"The replica returned an HTTP Error: Http Error: status 420 <unknown status code>, content type "text/plain", content: hello"#,
+            format!("{payload}"),
+            r#"Replica HTTP error: status 420 <unknown status code>, content type "text/plain", content: hello"#,
         );
     }
 
@@ -348,8 +347,8 @@ mod tests {
         };
 
         assert_eq!(
-            format!("{}", AgentError::HttpError(payload)),
-            r#"The replica returned an HTTP Error: Http Error: status 420 <unknown status code>, content type "text/plain; charset=utf-8", content: hello"#,
+            format!("{payload}"),
+            r#"Replica HTTP error: status 420 <unknown status code>, content type "text/plain; charset=utf-8", content: hello"#,
         );
     }
 
@@ -362,8 +361,8 @@ mod tests {
         };
 
         assert_eq!(
-            format!("{}", AgentError::HttpError(payload)),
-            r#"The replica returned an HTTP Error: Http Error: status 420 <unknown status code>, content type "text/html", content: world"#,
+            format!("{payload}"),
+            r#"Replica HTTP error: status 420 <unknown status code>, content type "text/html", content: world"#,
         );
     }
 }

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -1,4 +1,4 @@
-//! Errors that can occur when using the replica agent.
+//! Errors that can occur when using the agent.
 
 use ic_certification::Label;
 use ic_transport_types::RejectResponse;

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -85,6 +85,9 @@ impl AgentError {
             },
         }
     }
+    pub(crate) fn add_context(&mut self) {
+        self.inner.operation_info = CURRENT_OPERATION.try_with(|op| (*op.borrow()).clone()).ok();
+    }
     /// If this error is an HTTP error, retrieve the the payload. Equivalent to downcasting [`source()`](Error::source).
     pub fn as_http_error(&self) -> Option<&HttpErrorPayload> {
         self.inner.source.as_ref().and_then(|source| source.downcast_ref())

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -185,14 +185,6 @@ pub(crate) enum ErrorCode {
     #[error("The status response did not contain a root key.  Status: {0}")]
     NoRootKeyInStatus(Status),
 
-    /// The invocation to the wallet call forward method failed with an error.
-    #[error("The invocation to the wallet call forward method failed with the error: {0}")]
-    WalletCallFailed(String),
-
-    /// The wallet operation failed.
-    #[error("The  wallet operation failed: {0}")]
-    WalletError(String),
-
     /// The wallet canister must be upgraded. See [`dfx wallet upgrade`](https://internetcomputer.org/docs/current/references/cli-reference/dfx-wallet)
     #[error("The wallet canister must be upgraded: {0}")]
     WalletUpgradeRequired(String),

--- a/ic-agent/src/agent/agent_error.rs
+++ b/ic-agent/src/agent/agent_error.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use thiserror::Error;
 
-use super::{status::Status, Operation, OperationInfo, CURRENT_OPERATION};
+use super::{status::Status, OperationInfo, CURRENT_OPERATION};
 
 /// An error that can occur when using an `Agent`. Includes partial operation info.
 /// 
@@ -116,8 +116,6 @@ pub(crate) enum ErrorCode {
     CertifiedReject {
         /// The rejection returned by the replica.
         reject: RejectResponse,
-        /// The operation that was rejected. Not always available.
-        operation: Option<Operation>,
     },
 
     /// The subnet may have rejected the message. This rejection cannot be verified as authentic.
@@ -125,8 +123,6 @@ pub(crate) enum ErrorCode {
     UncertifiedReject {
         /// The rejection returned by the boundary node.
         reject: RejectResponse,
-        /// The operation that was rejected. Not always available.
-        operation: Option<Operation>,
     },
 
     /// The status endpoint returned an invalid status.

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -554,7 +554,7 @@ async fn no_cert() {
     .await;
     let agent = make_certifying_agent(&url);
     let result = agent.query(&canister, "getVersion").call().await;
-    assert_eq!(result.unwrap_err().kind(), ErrorKind::Protocol);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::Trust);
     assert_mock(read_mock).await;
 }
 

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -2,10 +2,7 @@ use self::mock::{
     assert_mock, assert_single_mock, assert_single_mock_count, mock, mock_additional,
 };
 use crate::{
-    agent::{Operation, OperationStatus, Status},
-    agent_error::ErrorKind,
-    export::Principal,
-    Agent, AgentError, Certificate,
+    agent::Status, agent_error::ErrorKind, export::Principal, Agent, AgentError, Certificate,
 };
 use candid::{Encode, Nat};
 use futures_util::FutureExt;

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -808,7 +808,7 @@ impl Agent {
             match retry_policy.next_backoff() {
                 Some(duration) => crate::util::sleep(duration).await,
 
-                None => return Err(ErrorCode::TimeoutWaitingForResponse).context(Limit),
+                None => return Err(ErrorCode::TimeoutWaitingForResponse).context(Protocol),
             }
         }
     }

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -2290,19 +2290,31 @@ impl HttpService for Retry429Logic {
     }
 }
 
+/// The status of an [`Operation`].
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum OperationStatus {
+    /// The operation has not been sent to the IC.
     NotSent,
+    /// The operation may or may not have been sent to the IC, and the IC may or may not have received it.
     MaybeReceived,
+    /// The IC has definitely received the request, and any further information is certified.
+    /// This is never returned for query calls.
     Received,
 }
 
+/// Info about an agent operation. Can be obtained from [`AgentError`].
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct OperationInfo {
+    /// The known status of the operation. Only set to [`Received`] if this is *guaranteed* to be true.
     pub status: OperationStatus,
+    /// The operation being attempted.
     pub operation: Operation,
+    /// The expiry timestamp of the operation, in Unix nanoseconds.
     pub expiry: u64,
+    /// The response to the operation, if it has been completed. The result is `Ok` for responses and `Err` for rejects.
+    ///
+    /// This information is reliable if-and-only-if `status` is set to [`Received`].
     pub response: Option<Result<Vec<u8>, RejectResponse>>,
 }
 
@@ -2323,7 +2335,7 @@ pub enum Operation {
         /// The name of the method.
         method: String,
     },
-    /// A read of the state tree, in the context of a canister. This will *not* be returned for request polling.
+    /// A read of the state tree, in the context of a canister. This will *not* be the active operation during request polling.
     ReadState {
         /// The requested paths within the state tree.
         paths: Vec<Vec<Label>>,

--- a/ic-agent/src/agent/route_provider.rs
+++ b/ic-agent/src/agent/route_provider.rs
@@ -86,7 +86,7 @@ impl RouteProvider for RoundRobinRouteProvider {
     /// Generates a url for the given endpoint.
     fn route(&self) -> Result<Url, AgentError> {
         if self.routes.is_empty() {
-            return Err(AgentError::new_tool_error_in_context(
+            return Err(AgentError::new_route_provider_error_without_context(
                 "No routing urls provided".to_string(),
             ));
         }

--- a/ic-agent/src/agent/route_provider.rs
+++ b/ic-agent/src/agent/route_provider.rs
@@ -19,9 +19,9 @@ use std::{
 };
 use url::Url;
 
-use crate::agent::AgentError;
+use crate::agent::agent_error::{AgentError, ErrorKind::*};
 
-use super::HttpService;
+use super::{agent_error::ResultExt, HttpService};
 #[cfg(not(feature = "_internal_dynamic-routing"))]
 pub(crate) mod dynamic_routing;
 #[cfg(feature = "_internal_dynamic-routing")]
@@ -86,7 +86,7 @@ impl RouteProvider for RoundRobinRouteProvider {
     /// Generates a url for the given endpoint.
     fn route(&self) -> Result<Url, AgentError> {
         if self.routes.is_empty() {
-            return Err(AgentError::RouteProviderError(
+            return Err(AgentError::new_tool_error_in_context(
                 "No routing urls provided".to_string(),
             ));
         }
@@ -128,21 +128,23 @@ impl RoundRobinRouteProvider {
         let routes: Result<Vec<Url>, _> = routes
             .into_iter()
             .map(|url| {
-                Url::from_str(url.as_ref()).and_then(|mut url| {
-                    // rewrite *.ic0.app to ic0.app
-                    if let Some(domain) = url.domain() {
-                        if domain.ends_with(IC0_SUB_DOMAIN) {
-                            url.set_host(Some(IC0_DOMAIN))?;
-                        } else if domain.ends_with(ICP0_SUB_DOMAIN) {
-                            url.set_host(Some(ICP0_DOMAIN))?;
-                        } else if domain.ends_with(ICP_API_SUB_DOMAIN) {
-                            url.set_host(Some(ICP_API_DOMAIN))?;
-                        } else if domain.ends_with(LOCALHOST_SUB_DOMAIN) {
-                            url.set_host(Some(LOCALHOST_DOMAIN))?;
+                Url::from_str(url.as_ref())
+                    .and_then(|mut url| {
+                        // rewrite *.ic0.app to ic0.app
+                        if let Some(domain) = url.domain() {
+                            if domain.ends_with(IC0_SUB_DOMAIN) {
+                                url.set_host(Some(IC0_DOMAIN))?;
+                            } else if domain.ends_with(ICP0_SUB_DOMAIN) {
+                                url.set_host(Some(ICP0_DOMAIN))?;
+                            } else if domain.ends_with(ICP_API_SUB_DOMAIN) {
+                                url.set_host(Some(ICP_API_DOMAIN))?;
+                            } else if domain.ends_with(LOCALHOST_SUB_DOMAIN) {
+                                url.set_host(Some(LOCALHOST_DOMAIN))?;
+                            }
                         }
-                    }
-                    Ok(url)
-                })
+                        Ok(url)
+                    })
+                    .context(Input)
             })
             .collect();
         Ok(Self {
@@ -178,20 +180,17 @@ impl DynamicRouteProvider {
         strategy: DynamicRoutingStrategy,
     ) -> Result<Self, AgentError> {
         let seed_nodes: Result<Vec<_>, _> = seed_domains.into_iter().map(Node::new).collect();
+        let seed_nodes = seed_nodes.context(Input)?;
         let boxed = match strategy {
             DynamicRoutingStrategy::ByLatency => Box::new(
-                DynamicRouteProviderBuilder::new(
-                    LatencyRoutingSnapshot::new(),
-                    seed_nodes?,
-                    client,
-                )
-                .build()
-                .await,
+                DynamicRouteProviderBuilder::new(LatencyRoutingSnapshot::new(), seed_nodes, client)
+                    .build()
+                    .await,
             ) as Box<dyn RouteProvider>,
             DynamicRoutingStrategy::RoundRobin => Box::new(
                 DynamicRouteProviderBuilder::new(
                     RoundRobinRoutingSnapshot::new(),
-                    seed_nodes?,
+                    seed_nodes,
                     client,
                 )
                 .build()
@@ -209,22 +208,19 @@ impl DynamicRouteProvider {
         health_check_interval: Duration,
     ) -> Result<Self, AgentError> {
         let seed_nodes: Result<Vec<_>, _> = seed_domains.into_iter().map(Node::new).collect();
+        let seed_nodes = seed_nodes.context(Input)?;
         let boxed = match strategy {
             DynamicRoutingStrategy::ByLatency => Box::new(
-                DynamicRouteProviderBuilder::new(
-                    LatencyRoutingSnapshot::new(),
-                    seed_nodes?,
-                    client,
-                )
-                .with_fetch_period(list_update_interval)
-                .with_check_period(health_check_interval)
-                .build()
-                .await,
+                DynamicRouteProviderBuilder::new(LatencyRoutingSnapshot::new(), seed_nodes, client)
+                    .with_fetch_period(list_update_interval)
+                    .with_check_period(health_check_interval)
+                    .build()
+                    .await,
             ) as Box<dyn RouteProvider>,
             DynamicRoutingStrategy::RoundRobin => Box::new(
                 DynamicRouteProviderBuilder::new(
                     RoundRobinRoutingSnapshot::new(),
-                    seed_nodes?,
+                    seed_nodes,
                     client,
                 )
                 .with_fetch_period(list_update_interval)
@@ -316,10 +312,7 @@ mod tests {
         let provider = RoundRobinRouteProvider::new::<&str>(vec![])
             .expect("failed to create a route provider");
         let result = provider.route().unwrap_err();
-        assert_eq!(
-            result,
-            AgentError::RouteProviderError("No routing urls provided".to_string())
-        );
+        assert!(format!("{result}").contains("No routing urls provided"));
     }
 
     #[test]

--- a/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
@@ -170,7 +170,7 @@ where
     fn route(&self) -> Result<Url, AgentError> {
         let snapshot = self.routing_snapshot.load();
         let node = snapshot.next_node().ok_or_else(|| {
-            AgentError::RouteProviderError("No healthy API nodes found.".to_string())
+            AgentError::new_tool_error_in_context("No healthy API nodes found.".to_string())
         })?;
         Ok(node.to_routing_url())
     }
@@ -179,7 +179,7 @@ where
         let snapshot = self.routing_snapshot.load();
         let nodes = snapshot.next_n_nodes(n);
         if nodes.is_empty() {
-            return Err(AgentError::RouteProviderError(
+            return Err(AgentError::new_tool_error_in_context(
                 "No healthy API nodes found.".to_string(),
             ));
         };
@@ -523,10 +523,7 @@ mod tests {
         for _ in 0..4 {
             tokio::time::sleep(check_interval).await;
             let result = route_provider.route();
-            assert_eq!(
-                result.unwrap_err(),
-                AgentError::RouteProviderError("No healthy API nodes found.".to_string())
-            );
+            assert!(format!("{}", result.unwrap_err()).contains("No healthy API nodes found."));
         }
 
         // Test 2: calls to route() return both seeds, as they become healthy.
@@ -573,10 +570,7 @@ mod tests {
         tokio::time::sleep(2 * check_interval).await;
         for _ in 0..4 {
             let result = route_provider.route();
-            assert_eq!(
-                result.unwrap_err(),
-                AgentError::RouteProviderError("No healthy API nodes found.".to_string())
-            );
+            assert!(format!("{}", result.unwrap_err()).contains("No healthy API nodes found."));
         }
     }
 
@@ -610,10 +604,7 @@ mod tests {
         for _ in 0..4 {
             tokio::time::sleep(check_interval).await;
             let result = route_provider.route();
-            assert_eq!(
-                result.unwrap_err(),
-                AgentError::RouteProviderError("No healthy API nodes found.".to_string())
-            );
+            assert!(format!("{}", result.unwrap_err()).contains("No healthy API nodes found"));
         }
     }
 

--- a/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
@@ -170,7 +170,9 @@ where
     fn route(&self) -> Result<Url, AgentError> {
         let snapshot = self.routing_snapshot.load();
         let node = snapshot.next_node().ok_or_else(|| {
-            AgentError::new_tool_error_in_context("No healthy API nodes found.".to_string())
+            AgentError::new_route_provider_error_without_context(
+                "No healthy API nodes found.".to_string(),
+            )
         })?;
         Ok(node.to_routing_url())
     }
@@ -179,7 +181,7 @@ where
         let snapshot = self.routing_snapshot.load();
         let nodes = snapshot.next_n_nodes(n);
         if nodes.is_empty() {
-            return Err(AgentError::new_tool_error_in_context(
+            return Err(AgentError::new_route_provider_error_without_context(
                 "No healthy API nodes found.".to_string(),
             ));
         };
@@ -298,7 +300,7 @@ mod tests {
             },
             RouteProvider, RoutesStats,
         },
-        Agent, AgentError,
+        Agent,
     };
 
     static TRACING_INIT: Once = Once::new();

--- a/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use arc_swap::ArcSwap;
-use candid::Principal;
 use futures_util::FutureExt;
+use ic_principal::Principal;
 use stop_token::StopSource;
 use thiserror::Error;
 use url::Url;

--- a/ic-agent/src/agent/route_provider/dynamic_routing/nodes_fetch.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/nodes_fetch.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use candid::Principal;
 use futures_util::FutureExt;
+use ic_principal::Principal;
 use std::{fmt::Debug, sync::Arc, time::Duration};
 use stop_token::StopToken;
 use url::Url;

--- a/ic-agent/src/export.rs
+++ b/ic-agent/src/export.rs
@@ -1,4 +1,4 @@
 //! A module to re-export types that are visible through the ic-agent API.
 #[doc(inline)]
-pub use candid::types::principal::{Principal, PrincipalError};
+pub use ic_principal::{Principal, PrincipalError};
 pub use reqwest;

--- a/ic-agent/src/identity/delegated.rs
+++ b/ic-agent/src/identity/delegated.rs
@@ -1,6 +1,6 @@
-use candid::Principal;
 use der::{Decode, SliceReader};
 use ecdsa::signature::Verifier;
+use ic_principal::Principal;
 use k256::Secp256k1;
 use p256::NistP256;
 use pkcs8::{spki::SubjectPublicKeyInfoRef, AssociatedOid, ObjectIdentifier};

--- a/ic-agent/src/lib.rs
+++ b/ic-agent/src/lib.rs
@@ -111,7 +111,7 @@ pub mod agent;
 pub mod export;
 pub mod identity;
 
-use agent::response_authentication::LookupPath;
+use agent::response_authentication::{LookupError, LookupPath};
 #[doc(inline)]
 pub use agent::{agent_error, agent_error::AgentError, Agent, NonceFactory, NonceGenerator};
 #[doc(inline)]
@@ -128,6 +128,6 @@ pub use ic_certification::{hash_tree, Certificate};
 pub fn lookup_value<P: LookupPath, Storage: AsRef<[u8]>>(
     tree: &ic_certification::certificate::Certificate<Storage>,
     path: P,
-) -> Result<&[u8], AgentError> {
+) -> Result<&[u8], LookupError> {
     agent::response_authentication::lookup_value(&tree.tree, path)
 }

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -391,7 +391,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AndThenAsyncCaller")
-            .field("inner", &self.inner)
+            .field("inner", &self.inner as &dyn fmt::Debug)
             .field("and_then", &self.and_then)
             .field("_out", &self._out)
             .field("_out2", &self._out2)
@@ -535,7 +535,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MappedAsyncCaller")
-            .field("inner", &self.inner)
+            .field("inner", &self.inner as &dyn fmt::Debug)
             .field("map", &self.map)
             .field("_out", &self._out)
             .field("_out2", &self._out2)

--- a/ic-utils/src/call.rs
+++ b/ic-utils/src/call.rs
@@ -474,7 +474,7 @@ where
     Out: for<'de> ArgumentDecoder<'de> + Send + 'a,
     Out2: for<'de> ArgumentDecoder<'de> + Send + 'a,
     Err: CanisterError,
-    Inner: AsyncCall<Value = Out> + Send + 'a,
+    Inner: AsyncCall<Value = Out, Error = Err> + Send + 'a,
     R: Future<Output = Result<Out2, Err>> + Send + 'a,
     AndThen: Send + Fn(Out) -> R + 'a,
 {
@@ -496,7 +496,7 @@ where
     Out: for<'de> ArgumentDecoder<'de> + Send + 'a,
     Out2: for<'de> ArgumentDecoder<'de> + Send + 'a,
     Err: CanisterError,
-    Inner: AsyncCall<Value = Out> + Send + 'a,
+    Inner: AsyncCall<Value = Out, Error = Err> + Send + 'a,
     R: Future<Output = Result<Out2, Err>> + Send + 'a,
     AndThen: Send + Fn(Out) -> R + 'a,
 {

--- a/ic-utils/src/error.rs
+++ b/ic-utils/src/error.rs
@@ -1,19 +1,24 @@
-use std::error::Error;
-
 use ic_agent::AgentError;
 use thiserror::Error;
 
+/// A canister error for canisters that don't have any custom error cases.
 #[derive(Debug, Error)]
 pub enum BaseError {
+    /// Agent error.
     #[error("agent error: {0}")]
     Agent(#[from] AgentError),
+    /// Candid error.
     #[error("{0}")]
     Candid(#[from] candid::Error),
 }
 
+/// Trait implemented by canister errors.
 pub trait CanisterError: std::error::Error + Send + Sync + 'static {
+    /// Creates an error from a context-free Candid error.
     fn from_candid(err: candid::Error) -> Self;
+    /// Creates an error from a context-free agent error.
     fn from_agent(err: AgentError) -> Self;
+    /// If this error wraps an agent error, returns it.
     fn as_agent(&self) -> Option<&AgentError>;
 }
 

--- a/ic-utils/src/error.rs
+++ b/ic-utils/src/error.rs
@@ -1,0 +1,28 @@
+use std::error::Error;
+
+use ic_agent::AgentError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum BaseError {
+    #[error("agent error: {0}")]
+    Agent(#[from] AgentError),
+    #[error("{0}")]
+    Candid(#[from] candid::Error),
+}
+
+pub trait CanisterError: std::error::Error + Send + Sync + 'static {
+    fn from_candid(err: candid::Error) -> Self;
+    fn from_agent(err: AgentError) -> Self;
+}
+
+impl<T: Error + From<AgentError> + From<candid::Error> + Send + Sync + 'static> CanisterError
+    for T
+{
+    fn from_agent(err: AgentError) -> Self {
+        Self::from(err)
+    }
+    fn from_candid(err: candid::Error) -> Self {
+        Self::from(err)
+    }
+}

--- a/ic-utils/src/interfaces/http_request.rs
+++ b/ic-utils/src/interfaces/http_request.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     call::{AsyncCall, SyncCall},
+    error::BaseError,
     Canister,
 };
 use candid::{
@@ -409,7 +410,7 @@ impl<'agent> HttpRequestCanister<'agent> {
         >,
         body: impl AsRef<[u8]>,
         certificate_version: Option<&u16>,
-    ) -> impl 'agent + SyncCall<Value = (HttpResponse,)> {
+    ) -> impl 'agent + SyncCall<Value = (HttpResponse,), Error = BaseError> {
         self.http_request_custom(
             method.as_ref(),
             url.as_ref(),
@@ -428,7 +429,7 @@ impl<'agent> HttpRequestCanister<'agent> {
         headers: H,
         body: &[u8],
         certificate_version: Option<&u16>,
-    ) -> impl 'agent + SyncCall<Value = (HttpResponse<T, C>,)>
+    ) -> impl 'agent + SyncCall<Value = (HttpResponse<T, C>,), Error = BaseError>
     where
         H: 'agent + Send + Sync + Clone + ExactSizeIterator<Item = HeaderField<'agent>>,
         T: 'agent + Send + Sync + CandidType + for<'de> Deserialize<'de>,
@@ -453,7 +454,7 @@ impl<'agent> HttpRequestCanister<'agent> {
         url: impl AsRef<str>,
         headers: impl 'agent + Send + Sync + Clone + ExactSizeIterator<Item = HeaderField<'agent>>,
         body: impl AsRef<[u8]>,
-    ) -> impl 'agent + AsyncCall<Value = (HttpResponse,)> {
+    ) -> impl 'agent + AsyncCall<Value = (HttpResponse,), Error = BaseError> {
         self.http_request_update_custom(method.as_ref(), url.as_ref(), headers, body.as_ref())
     }
 
@@ -466,7 +467,7 @@ impl<'agent> HttpRequestCanister<'agent> {
         url: &str,
         headers: H,
         body: &[u8],
-    ) -> impl 'agent + AsyncCall<Value = (HttpResponse<T, C>,)>
+    ) -> impl 'agent + AsyncCall<Value = (HttpResponse<T, C>,), Error = BaseError>
     where
         H: 'agent + Send + Sync + Clone + ExactSizeIterator<Item = HeaderField<'agent>>,
         T: 'agent + Send + Sync + CandidType + for<'de> Deserialize<'de>,
@@ -487,7 +488,7 @@ impl<'agent> HttpRequestCanister<'agent> {
         &'canister self,
         method: impl AsRef<str>,
         token: Token,
-    ) -> impl 'agent + SyncCall<Value = (StreamingCallbackHttpResponse,)> {
+    ) -> impl 'agent + SyncCall<Value = (StreamingCallbackHttpResponse,), Error = BaseError> {
         self.query(method.as_ref()).with_value_arg(token.0).build()
     }
 
@@ -497,7 +498,7 @@ impl<'agent> HttpRequestCanister<'agent> {
         &'canister self,
         method: impl AsRef<str>,
         token: T,
-    ) -> impl 'agent + SyncCall<Value = (StreamingCallbackHttpResponse<T>,)>
+    ) -> impl 'agent + SyncCall<Value = (StreamingCallbackHttpResponse<T>,), Error = BaseError>
     where
         T: 'agent + Send + Sync + CandidType + for<'de> Deserialize<'de>,
     {

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     call::{AsyncCall, SyncCall},
+    error::BaseError,
     Canister,
 };
 use candid::{CandidType, Deserialize, Nat};
@@ -267,7 +268,7 @@ impl<'agent> ManagementCanister<'agent> {
     pub fn canister_status(
         &self,
         canister_id: &Principal,
-    ) -> impl 'agent + AsyncCall<Value = (StatusCallResult,)> {
+    ) -> impl 'agent + AsyncCall<Value = (StatusCallResult,), Error = BaseError> {
         #[derive(CandidType)]
         struct In {
             canister_id: Principal,
@@ -289,7 +290,10 @@ impl<'agent> ManagementCanister<'agent> {
 
     /// This method deposits the cycles included in this call into the specified canister.
     /// Only the controller of the canister can deposit cycles.
-    pub fn deposit_cycles(&self, canister_id: &Principal) -> impl 'agent + AsyncCall<Value = ()> {
+    pub fn deposit_cycles(
+        &self,
+        canister_id: &Principal,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = BaseError> {
         #[derive(CandidType)]
         struct Argument {
             canister_id: Principal,
@@ -304,7 +308,10 @@ impl<'agent> ManagementCanister<'agent> {
     }
 
     /// Deletes a canister.
-    pub fn delete_canister(&self, canister_id: &Principal) -> impl 'agent + AsyncCall<Value = ()> {
+    pub fn delete_canister(
+        &self,
+        canister_id: &Principal,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = BaseError> {
         #[derive(CandidType)]
         struct Argument {
             canister_id: Principal,
@@ -326,7 +333,7 @@ impl<'agent> ManagementCanister<'agent> {
         &self,
         canister_id: &Principal,
         amount: u64,
-    ) -> impl 'agent + AsyncCall<Value = ()> {
+    ) -> impl 'agent + AsyncCall<Value = (), Error = BaseError> {
         #[derive(CandidType)]
         struct Argument {
             canister_id: Principal,
@@ -345,14 +352,17 @@ impl<'agent> ManagementCanister<'agent> {
     /// This method takes no input and returns 32 pseudo-random bytes to the caller.
     /// The return value is unknown to any part of the IC at time of the submission of this call.
     /// A new return value is generated for each call to this method.
-    pub fn raw_rand(&self) -> impl 'agent + AsyncCall<Value = (Vec<u8>,)> {
+    pub fn raw_rand(&self) -> impl 'agent + AsyncCall<Value = (Vec<u8>,), Error = BaseError> {
         self.update(MgmtMethod::RawRand.as_ref())
             .build()
             .map(|result: (Vec<u8>,)| (result.0,))
     }
 
     /// Starts a canister.
-    pub fn start_canister(&self, canister_id: &Principal) -> impl 'agent + AsyncCall<Value = ()> {
+    pub fn start_canister(
+        &self,
+        canister_id: &Principal,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = BaseError> {
         #[derive(CandidType)]
         struct Argument {
             canister_id: Principal,
@@ -367,7 +377,10 @@ impl<'agent> ManagementCanister<'agent> {
     }
 
     /// Stop a canister.
-    pub fn stop_canister(&self, canister_id: &Principal) -> impl 'agent + AsyncCall<Value = ()> {
+    pub fn stop_canister(
+        &self,
+        canister_id: &Principal,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = BaseError> {
         #[derive(CandidType)]
         struct Argument {
             canister_id: Principal,
@@ -388,7 +401,10 @@ impl<'agent> ManagementCanister<'agent> {
     /// Outstanding responses to the canister will not be processed, even if they arrive after code has been installed again.
     /// The canister is now empty. In particular, any incoming or queued calls will be rejected.
     //// A canister after uninstalling retains its cycles balance, controller, status, and allocations.
-    pub fn uninstall_code(&self, canister_id: &Principal) -> impl 'agent + AsyncCall<Value = ()> {
+    pub fn uninstall_code(
+        &self,
+        canister_id: &Principal,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = BaseError> {
         #[derive(CandidType)]
         struct Argument {
             canister_id: Principal,
@@ -424,7 +440,7 @@ impl<'agent> ManagementCanister<'agent> {
         &self,
         canister_id: &Principal,
         chunk: &[u8],
-    ) -> impl 'agent + AsyncCall<Value = (UploadChunkResult,)> {
+    ) -> impl 'agent + AsyncCall<Value = (UploadChunkResult,), Error = BaseError> {
         #[derive(CandidType, Deserialize)]
         struct Argument<'a> {
             canister_id: Principal,
@@ -445,7 +461,7 @@ impl<'agent> ManagementCanister<'agent> {
     pub fn clear_chunk_store(
         &self,
         canister_id: &Principal,
-    ) -> impl 'agent + AsyncCall<Value = ()> {
+    ) -> impl 'agent + AsyncCall<Value = (), Error = BaseError> {
         #[derive(CandidType)]
         struct Argument<'a> {
             canister_id: &'a Principal,
@@ -460,7 +476,7 @@ impl<'agent> ManagementCanister<'agent> {
     pub fn stored_chunks(
         &self,
         canister_id: &Principal,
-    ) -> impl 'agent + AsyncCall<Value = (StoreChunksResult,)> {
+    ) -> impl 'agent + AsyncCall<Value = (StoreChunksResult,), Error = BaseError> {
         #[derive(CandidType)]
         struct Argument<'a> {
             canister_id: &'a Principal,
@@ -497,7 +513,7 @@ impl<'agent> ManagementCanister<'agent> {
     pub fn fetch_canister_logs(
         &self,
         canister_id: &Principal,
-    ) -> impl 'agent + SyncCall<Value = (FetchCanisterLogsResponse,)> {
+    ) -> impl 'agent + SyncCall<Value = (FetchCanisterLogsResponse,), Error = BaseError> {
         #[derive(CandidType)]
         struct In {
             canister_id: Principal,
@@ -519,7 +535,7 @@ impl<'agent> ManagementCanister<'agent> {
         &self,
         canister_id: &Principal,
         replace_snapshot: Option<&[u8]>,
-    ) -> impl 'agent + AsyncCall<Value = (Snapshot,)> {
+    ) -> impl 'agent + AsyncCall<Value = (Snapshot,), Error = BaseError> {
         #[derive(CandidType)]
         struct In<'a> {
             canister_id: Principal,
@@ -541,7 +557,7 @@ impl<'agent> ManagementCanister<'agent> {
         &self,
         canister_id: &Principal,
         snapshot_id: &[u8],
-    ) -> impl 'agent + AsyncCall<Value = ()> {
+    ) -> impl 'agent + AsyncCall<Value = (), Error = BaseError> {
         #[derive(CandidType)]
         struct In<'a> {
             canister_id: Principal,
@@ -562,7 +578,7 @@ impl<'agent> ManagementCanister<'agent> {
     pub fn list_canister_snapshots(
         &self,
         canister_id: &Principal,
-    ) -> impl 'agent + AsyncCall<Value = (Vec<Snapshot>,)> {
+    ) -> impl 'agent + AsyncCall<Value = (Vec<Snapshot>,), Error = BaseError> {
         #[derive(CandidType)]
         struct In {
             canister_id: Principal,
@@ -580,7 +596,7 @@ impl<'agent> ManagementCanister<'agent> {
         &self,
         canister_id: &Principal,
         snapshot_id: &[u8],
-    ) -> impl 'agent + AsyncCall<Value = ()> {
+    ) -> impl 'agent + AsyncCall<Value = (), Error = BaseError> {
         #[derive(CandidType)]
         struct In<'a> {
             canister_id: Principal,

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -10,7 +10,7 @@ use super::attributes::{
 };
 use super::{ChunkHash, LogVisibility, ManagementCanister};
 use crate::call::CallFuture;
-use crate::error::BaseError;
+use crate::error::{impl_canister_error, BaseError};
 use crate::{
     call::AsyncCall, canister::Argument, interfaces::management_canister::MgmtMethod, Canister,
 };
@@ -519,6 +519,8 @@ pub enum CanisterManagementError {
     #[error(transparent)]
     Conversion(#[from] AttributeConversionError),
 }
+
+impl_canister_error!(CanisterManagementError);
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash, CandidType, Copy)]
 /// Wasm main memory retention on upgrades.
@@ -1341,17 +1343,17 @@ type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a>>;
 #[derive(Debug, Error)]
 pub enum AttributeConversionError {
     #[error(transparent)]
-    FreezingThreshold(FreezingThresholdError),
+    FreezingThreshold(#[from] FreezingThresholdError),
     #[error(transparent)]
-    ComputeAllocation(ComputeAllocationError),
+    ComputeAllocation(#[from] ComputeAllocationError),
     #[error(transparent)]
-    MemoryAllocation(MemoryAllocationError),
+    MemoryAllocation(#[from] MemoryAllocationError),
     #[error(transparent)]
-    ReservedCyclesLimit(ReservedCyclesLimitError),
+    ReservedCyclesLimit(#[from] ReservedCyclesLimitError),
     #[error(transparent)]
-    WasmMemoryLimit(WasmMemoryLimitError),
+    WasmMemoryLimit(#[from] WasmMemoryLimitError),
     #[error(transparent)]
-    Principal(PrincipalError),
+    Principal(#[from] PrincipalError),
 }
 
 impl From<Infallible> for AttributeConversionError {

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -4,8 +4,13 @@
 pub use super::attributes::{
     ComputeAllocation, FreezingThreshold, MemoryAllocation, ReservedCyclesLimit, WasmMemoryLimit,
 };
+use super::attributes::{
+    ComputeAllocationError, FreezingThresholdError, MemoryAllocationError,
+    ReservedCyclesLimitError, WasmMemoryLimitError,
+};
 use super::{ChunkHash, LogVisibility, ManagementCanister};
 use crate::call::CallFuture;
+use crate::error::BaseError;
 use crate::{
     call::AsyncCall, canister::Argument, interfaces::management_canister::MgmtMethod, Canister,
 };
@@ -16,8 +21,10 @@ use futures_util::{
     stream::{self, FuturesUnordered},
     FutureExt, Stream, StreamExt, TryStreamExt,
 };
+use ic_agent::export::PrincipalError;
 use ic_agent::{agent::CallResponse, export::Principal, AgentError};
 use sha2::{Digest, Sha256};
+use std::convert::Infallible;
 use std::{
     collections::BTreeSet,
     convert::{From, TryInto},
@@ -25,6 +32,7 @@ use std::{
     pin::Pin,
     str::FromStr,
 };
+use thiserror::Error;
 
 /// The set of possible canister settings. Similar to [`DefiniteCanisterSettings`](super::DefiniteCanisterSettings),
 /// but all the fields are optional.
@@ -96,14 +104,14 @@ pub struct CanisterSettings {
 pub struct CreateCanisterBuilder<'agent, 'canister: 'agent> {
     canister: &'canister Canister<'agent>,
     effective_canister_id: Principal,
-    controllers: Option<Result<Vec<Principal>, AgentError>>,
-    compute_allocation: Option<Result<ComputeAllocation, AgentError>>,
-    memory_allocation: Option<Result<MemoryAllocation, AgentError>>,
-    freezing_threshold: Option<Result<FreezingThreshold, AgentError>>,
-    reserved_cycles_limit: Option<Result<ReservedCyclesLimit, AgentError>>,
-    wasm_memory_limit: Option<Result<WasmMemoryLimit, AgentError>>,
-    wasm_memory_threshold: Option<Result<WasmMemoryLimit, AgentError>>,
-    log_visibility: Option<Result<LogVisibility, AgentError>>,
+    controllers: Option<Result<Vec<Principal>, AttributeConversionError>>,
+    compute_allocation: Option<Result<ComputeAllocation, AttributeConversionError>>,
+    memory_allocation: Option<Result<MemoryAllocation, AttributeConversionError>>,
+    freezing_threshold: Option<Result<FreezingThreshold, AttributeConversionError>>,
+    reserved_cycles_limit: Option<Result<ReservedCyclesLimit, AttributeConversionError>>,
+    wasm_memory_limit: Option<Result<WasmMemoryLimit, AttributeConversionError>>,
+    wasm_memory_threshold: Option<Result<WasmMemoryLimit, AttributeConversionError>>,
+    log_visibility: Option<Result<LogVisibility, AttributeConversionError>>,
     is_provisional_create: bool,
     amount: Option<u128>,
     specified_id: Option<Principal>,
@@ -160,7 +168,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// Pass in an effective canister id for the update call.
     pub fn with_effective_canister_id<C, E>(self, effective_canister_id: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<Principal, Error = E>,
     {
         match effective_canister_id.try_into() {
@@ -176,17 +184,14 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// it will revert the controller to default.
     pub fn with_optional_controller<C, E>(self, controller: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<Principal, Error = E>,
     {
-        let controller_to_add: Option<Result<Principal, _>> = controller.map(|ca| {
-            ca.try_into()
-                .map_err(|e| AgentError::MessageError(format!("{e}")))
-        });
+        let controller_to_add: Option<Result<Principal, _>> = controller.map(|ca| ca.try_into());
         let controllers: Option<Result<Vec<Principal>, _>> =
             match (controller_to_add, self.controllers) {
                 (_, Some(Err(sticky))) => Some(Err(sticky)),
-                (Some(Err(e)), _) => Some(Err(e)),
+                (Some(Err(e)), _) => Some(Err(e.into())),
                 (None, _) => None,
                 (Some(Ok(controller)), Some(Ok(controllers))) => {
                     let mut controllers = controllers;
@@ -204,7 +209,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// Pass in a designated controller for the canister.
     pub fn with_controller<C, E>(self, controller: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<Principal, Error = E>,
     {
         self.with_optional_controller(Some(controller))
@@ -214,14 +219,11 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// it will revert the compute allocation to default.
     pub fn with_optional_compute_allocation<C, E>(self, compute_allocation: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<ComputeAllocation, Error = E>,
     {
         Self {
-            compute_allocation: compute_allocation.map(|ca| {
-                ca.try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            compute_allocation: compute_allocation.map(|ca| ca.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -229,7 +231,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// Pass in a compute allocation value for the canister.
     pub fn with_compute_allocation<C, E>(self, compute_allocation: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<ComputeAllocation, Error = E>,
     {
         self.with_optional_compute_allocation(Some(compute_allocation))
@@ -239,14 +241,11 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// it will revert the memory allocation to default.
     pub fn with_optional_memory_allocation<E, C>(self, memory_allocation: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<MemoryAllocation, Error = E>,
     {
         Self {
-            memory_allocation: memory_allocation.map(|ma| {
-                ma.try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            memory_allocation: memory_allocation.map(|ma| ma.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -254,7 +253,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// Pass in a memory allocation value for the canister.
     pub fn with_memory_allocation<C, E>(self, memory_allocation: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<MemoryAllocation, Error = E>,
     {
         self.with_optional_memory_allocation(Some(memory_allocation))
@@ -264,14 +263,11 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// it will revert the freezing threshold to default.
     pub fn with_optional_freezing_threshold<E, C>(self, freezing_threshold: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<FreezingThreshold, Error = E>,
     {
         Self {
-            freezing_threshold: freezing_threshold.map(|ma| {
-                ma.try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            freezing_threshold: freezing_threshold.map(|ma| ma.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -279,7 +275,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// Pass in a freezing threshold value for the canister.
     pub fn with_freezing_threshold<C, E>(self, freezing_threshold: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<FreezingThreshold, Error = E>,
     {
         self.with_optional_freezing_threshold(Some(freezing_threshold))
@@ -288,7 +284,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// Pass in a reserved cycles limit value for the canister.
     pub fn with_reserved_cycles_limit<C, E>(self, limit: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<ReservedCyclesLimit, Error = E>,
     {
         self.with_optional_reserved_cycles_limit(Some(limit))
@@ -298,15 +294,11 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// it will create the canister with the default limit.
     pub fn with_optional_reserved_cycles_limit<E, C>(self, limit: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<ReservedCyclesLimit, Error = E>,
     {
         Self {
-            reserved_cycles_limit: limit.map(|limit| {
-                limit
-                    .try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            reserved_cycles_limit: limit.map(|limit| limit.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -314,7 +306,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// Pass in a Wasm memory limit value for the canister.
     pub fn with_wasm_memory_limit<C, E>(self, wasm_memory_limit: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<WasmMemoryLimit, Error = E>,
     {
         self.with_optional_wasm_memory_limit(Some(wasm_memory_limit))
@@ -324,15 +316,11 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// it will revert the Wasm memory limit to default.
     pub fn with_optional_wasm_memory_limit<E, C>(self, wasm_memory_limit: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<WasmMemoryLimit, Error = E>,
     {
         Self {
-            wasm_memory_limit: wasm_memory_limit.map(|limit| {
-                limit
-                    .try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            wasm_memory_limit: wasm_memory_limit.map(|limit| limit.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -340,7 +328,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// Pass in a Wasm memory threshold value for the canister.
     pub fn with_wasm_memory_threshold<C, E>(self, wasm_memory_threshold: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<WasmMemoryLimit, Error = E>,
     {
         self.with_optional_wasm_memory_threshold(Some(wasm_memory_threshold))
@@ -350,15 +338,12 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// it will revert the Wasm memory threshold to default.
     pub fn with_optional_wasm_memory_threshold<E, C>(self, wasm_memory_threshold: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<WasmMemoryLimit, Error = E>,
     {
         Self {
-            wasm_memory_threshold: wasm_memory_threshold.map(|limit| {
-                limit
-                    .try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            wasm_memory_threshold: wasm_memory_threshold
+                .map(|limit| limit.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -366,7 +351,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// Pass in a log visibility setting for the canister.
     pub fn with_log_visibility<C, E>(self, log_visibility: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<LogVisibility, Error = E>,
     {
         self.with_optional_log_visibility(Some(log_visibility))
@@ -376,59 +361,61 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     /// it will revert the log visibility to default.
     pub fn with_optional_log_visibility<E, C>(self, log_visibility: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<LogVisibility, Error = E>,
     {
         Self {
-            log_visibility: log_visibility.map(|visibility| {
-                visibility
-                    .try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            log_visibility: log_visibility
+                .map(|visibility| visibility.try_into().map_err(From::from)),
             ..self
         }
     }
 
     /// Create an [`AsyncCall`] implementation that, when called, will create a
     /// canister.
-    pub fn build(self) -> Result<impl 'agent + AsyncCall<Value = (Principal,)>, AgentError> {
+    pub fn build(
+        self,
+    ) -> Result<
+        impl 'agent + AsyncCall<Value = (Principal,), Error = CanisterManagementError>,
+        AttributeConversionError,
+    > {
         let controllers = match self.controllers {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(x),
             None => None,
         };
         let compute_allocation = match self.compute_allocation {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u8::from(x))),
             None => None,
         };
         let memory_allocation = match self.memory_allocation {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u64::from(x))),
             None => None,
         };
         let freezing_threshold = match self.freezing_threshold {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u64::from(x))),
             None => None,
         };
         let reserved_cycles_limit = match self.reserved_cycles_limit {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u128::from(x))),
             None => None,
         };
         let wasm_memory_limit = match self.wasm_memory_limit {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u64::from(x))),
             None => None,
         };
         let wasm_memory_threshold = match self.wasm_memory_threshold {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u64::from(x))),
             None => None,
         };
         let log_visibility = match self.log_visibility {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(x),
             None => None,
         };
@@ -460,12 +447,12 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
                 specified_id: self.specified_id,
             };
             self.canister
-                .update(MgmtMethod::ProvisionalCreateCanisterWithCycles.as_ref())
+                .update_(MgmtMethod::ProvisionalCreateCanisterWithCycles.as_ref())
                 .with_arg(in_arg)
                 .with_effective_canister_id(self.effective_canister_id)
         } else {
             self.canister
-                .update(MgmtMethod::CreateCanister.as_ref())
+                .update_(MgmtMethod::CreateCanister.as_ref())
                 .with_arg(CanisterSettings {
                     controllers,
                     compute_allocation,
@@ -485,12 +472,12 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     }
 
     /// Make a call. This is equivalent to the [`AsyncCall::call`].
-    pub async fn call(self) -> Result<CallResponse<(Principal,)>, AgentError> {
+    pub async fn call(self) -> Result<CallResponse<(Principal,)>, CanisterManagementError> {
         self.build()?.call().await
     }
 
     /// Make a call. This is equivalent to the [`AsyncCall::call_and_wait`].
-    pub async fn call_and_wait(self) -> Result<(Principal,), AgentError> {
+    pub async fn call_and_wait(self) -> Result<(Principal,), CanisterManagementError> {
         self.build()?.call_and_wait().await
     }
 }
@@ -499,23 +486,38 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<'agent, 'canister: 'agent> AsyncCall for CreateCanisterBuilder<'agent, 'canister> {
     type Value = (Principal,);
+    type Error = CanisterManagementError;
 
-    async fn call(self) -> Result<CallResponse<(Principal,)>, AgentError> {
+    async fn call(self) -> Result<CallResponse<(Principal,)>, CanisterManagementError> {
         self.build()?.call().await
     }
 
-    async fn call_and_wait(self) -> Result<(Principal,), AgentError> {
+    async fn call_and_wait(self) -> Result<(Principal,), CanisterManagementError> {
         self.build()?.call_and_wait().await
     }
 }
 
 impl<'agent, 'canister: 'agent> IntoFuture for CreateCanisterBuilder<'agent, 'canister> {
-    type IntoFuture = CallFuture<'agent, (Principal,)>;
-    type Output = Result<(Principal,), AgentError>;
+    type IntoFuture = CallFuture<'agent, (Principal,), CanisterManagementError>;
+    type Output = Result<(Principal,), CanisterManagementError>;
 
     fn into_future(self) -> Self::IntoFuture {
         AsyncCall::call_and_wait(self)
     }
+}
+
+/// An error that can occur when performing an operation that updates canister settings.
+#[derive(Debug, Error)]
+pub enum CanisterManagementError {
+    /// An error occurred when encoding/decoding Candid.
+    #[error("{0}")]
+    Candid(#[from] candid::Error),
+    /// An error occurred in the agent.
+    #[error("{0}")]
+    Agent(#[from] AgentError),
+    /// An error occurred parsing a canister setting.
+    #[error(transparent)]
+    Conversion(#[from] AttributeConversionError),
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash, CandidType, Copy)]
@@ -643,10 +645,12 @@ impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
 
     /// Create an [`AsyncCall`] implementation that, when called, will install the
     /// canister.
-    pub fn build(self) -> Result<impl 'agent + AsyncCall<Value = ()>, AgentError> {
+    pub fn build(
+        self,
+    ) -> Result<impl 'agent + AsyncCall<Value = (), Error = BaseError>, candid::Error> {
         Ok(self
             .canister
-            .update(MgmtMethod::InstallCode.as_ref())
+            .update_(MgmtMethod::InstallCode.as_ref())
             .with_arg(CanisterInstall {
                 mode: self.mode.unwrap_or(InstallMode::Install),
                 canister_id: self.canister_id,
@@ -658,12 +662,12 @@ impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
     }
 
     /// Make a call. This is equivalent to the [`AsyncCall::call`].
-    pub async fn call(self) -> Result<CallResponse<()>, AgentError> {
+    pub async fn call(self) -> Result<CallResponse<()>, BaseError> {
         self.build()?.call().await
     }
 
     /// Make a call. This is equivalent to the [`AsyncCall::call_and_wait`].
-    pub async fn call_and_wait(self) -> Result<(), AgentError> {
+    pub async fn call_and_wait(self) -> Result<(), BaseError> {
         self.build()?.call_and_wait().await
     }
 }
@@ -672,19 +676,20 @@ impl<'agent, 'canister: 'agent> InstallCodeBuilder<'agent, 'canister> {
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<'agent, 'canister: 'agent> AsyncCall for InstallCodeBuilder<'agent, 'canister> {
     type Value = ();
+    type Error = BaseError;
 
-    async fn call(self) -> Result<CallResponse<()>, AgentError> {
+    async fn call(self) -> Result<CallResponse<()>, BaseError> {
         self.build()?.call().await
     }
 
-    async fn call_and_wait(self) -> Result<(), AgentError> {
+    async fn call_and_wait(self) -> Result<(), BaseError> {
         self.build()?.call_and_wait().await
     }
 }
 
 impl<'agent, 'canister: 'agent> IntoFuture for InstallCodeBuilder<'agent, 'canister> {
-    type IntoFuture = CallFuture<'agent, ()>;
-    type Output = Result<(), AgentError>;
+    type IntoFuture = CallFuture<'agent, (), BaseError>;
+    type Output = Result<(), BaseError>;
 
     fn into_future(self) -> Self::IntoFuture {
         AsyncCall::call_and_wait(self)
@@ -761,7 +766,9 @@ impl<'agent: 'canister, 'canister> InstallChunkedCodeBuilder<'agent, 'canister> 
     }
 
     /// Create an [`AsyncCall`] implementation that, when called, will install the canister.
-    pub fn build(self) -> Result<impl 'agent + AsyncCall<Value = ()>, AgentError> {
+    pub fn build(
+        self,
+    ) -> Result<impl 'agent + AsyncCall<Value = (), Error = BaseError>, candid::Error> {
         #[derive(CandidType)]
         struct In {
             mode: InstallMode,
@@ -798,12 +805,12 @@ impl<'agent: 'canister, 'canister> InstallChunkedCodeBuilder<'agent, 'canister> 
     }
 
     /// Make the call. This is equivalent to [`AsyncCall::call`].
-    pub async fn call(self) -> Result<CallResponse<()>, AgentError> {
+    pub async fn call(self) -> Result<CallResponse<()>, BaseError> {
         self.build()?.call().await
     }
 
     /// Make the call. This is equivalent to [`AsyncCall::call_and_wait`].
-    pub async fn call_and_wait(self) -> Result<(), AgentError> {
+    pub async fn call_and_wait(self) -> Result<(), BaseError> {
         self.build()?.call_and_wait().await
     }
 }
@@ -812,19 +819,20 @@ impl<'agent: 'canister, 'canister> InstallChunkedCodeBuilder<'agent, 'canister> 
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<'agent, 'canister: 'agent> AsyncCall for InstallChunkedCodeBuilder<'agent, 'canister> {
     type Value = ();
+    type Error = BaseError;
 
-    async fn call(self) -> Result<CallResponse<()>, AgentError> {
+    async fn call(self) -> Result<CallResponse<()>, BaseError> {
         self.call().await
     }
 
-    async fn call_and_wait(self) -> Result<(), AgentError> {
+    async fn call_and_wait(self) -> Result<(), BaseError> {
         self.call_and_wait().await
     }
 }
 
 impl<'agent, 'canister: 'agent> IntoFuture for InstallChunkedCodeBuilder<'agent, 'canister> {
-    type IntoFuture = CallFuture<'agent, ()>;
-    type Output = Result<(), AgentError>;
+    type IntoFuture = CallFuture<'agent, (), BaseError>;
+    type Output = Result<(), BaseError>;
 
     fn into_future(self) -> Self::IntoFuture {
         AsyncCall::call_and_wait(self)
@@ -893,7 +901,7 @@ impl<'agent: 'canister, 'canister: 'builder, 'builder> InstallBuilder<'agent, 'c
 
     /// Invoke the installation process. This may result in many calls which may take several seconds;
     /// use [`call_and_wait_with_progress`](Self::call_and_wait_with_progress) if you want progress reporting.
-    pub async fn call_and_wait(self) -> Result<(), AgentError> {
+    pub async fn call_and_wait(self) -> Result<(), BaseError> {
         self.call_and_wait_with_progress()
             .await
             .try_for_each(|_| ready(Ok(())))
@@ -905,7 +913,7 @@ impl<'agent: 'canister, 'canister: 'builder, 'builder> InstallBuilder<'agent, 'c
     /// There are exactly [`size_hint().0`](Stream::size_hint) steps.
     pub async fn call_and_wait_with_progress(
         self,
-    ) -> impl Stream<Item = Result<(), AgentError>> + 'builder {
+    ) -> impl Stream<Item = Result<(), BaseError>> + 'builder {
         let stream_res = /* try { */ async move {
             let arg = self.arg.serialize()?;
             let stream: BoxStream<'_, _> =
@@ -983,8 +991,8 @@ impl<'agent: 'canister, 'canister: 'builder, 'builder> InstallBuilder<'agent, 'c
 impl<'agent: 'canister, 'canister: 'builder, 'builder> IntoFuture
     for InstallBuilder<'agent, 'canister, 'builder>
 {
-    type IntoFuture = CallFuture<'builder, ()>;
-    type Output = Result<(), AgentError>;
+    type IntoFuture = CallFuture<'builder, (), BaseError>;
+    type Output = Result<(), BaseError>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.call_and_wait())
@@ -996,14 +1004,14 @@ impl<'agent: 'canister, 'canister: 'builder, 'builder> IntoFuture
 pub struct UpdateCanisterBuilder<'agent, 'canister: 'agent> {
     canister: &'canister Canister<'agent>,
     canister_id: Principal,
-    controllers: Option<Result<Vec<Principal>, AgentError>>,
-    compute_allocation: Option<Result<ComputeAllocation, AgentError>>,
-    memory_allocation: Option<Result<MemoryAllocation, AgentError>>,
-    freezing_threshold: Option<Result<FreezingThreshold, AgentError>>,
-    reserved_cycles_limit: Option<Result<ReservedCyclesLimit, AgentError>>,
-    wasm_memory_limit: Option<Result<WasmMemoryLimit, AgentError>>,
-    wasm_memory_threshold: Option<Result<WasmMemoryLimit, AgentError>>,
-    log_visibility: Option<Result<LogVisibility, AgentError>>,
+    controllers: Option<Result<Vec<Principal>, AttributeConversionError>>,
+    compute_allocation: Option<Result<ComputeAllocation, AttributeConversionError>>,
+    memory_allocation: Option<Result<MemoryAllocation, AttributeConversionError>>,
+    freezing_threshold: Option<Result<FreezingThreshold, AttributeConversionError>>,
+    reserved_cycles_limit: Option<Result<ReservedCyclesLimit, AttributeConversionError>>,
+    wasm_memory_limit: Option<Result<WasmMemoryLimit, AttributeConversionError>>,
+    wasm_memory_threshold: Option<Result<WasmMemoryLimit, AttributeConversionError>>,
+    log_visibility: Option<Result<LogVisibility, AttributeConversionError>>,
 }
 
 impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
@@ -1027,13 +1035,11 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// it will revert the controller to default.
     pub fn with_optional_controller<C, E>(self, controller: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<Principal, Error = E>,
     {
-        let controller_to_add: Option<Result<Principal, _>> = controller.map(|ca| {
-            ca.try_into()
-                .map_err(|e| AgentError::MessageError(format!("{e}")))
-        });
+        let controller_to_add: Option<Result<Principal, _>> =
+            controller.map(|ca| ca.try_into().map_err(From::from));
         let controllers: Option<Result<Vec<Principal>, _>> =
             match (controller_to_add, self.controllers) {
                 (_, Some(Err(sticky))) => Some(Err(sticky)),
@@ -1056,7 +1062,7 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// Pass in a designated controller for the canister.
     pub fn with_controller<C, E>(self, controller: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<Principal, Error = E>,
     {
         self.with_optional_controller(Some(controller))
@@ -1066,14 +1072,11 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// it will revert the compute allocation to default.
     pub fn with_optional_compute_allocation<C, E>(self, compute_allocation: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<ComputeAllocation, Error = E>,
     {
         Self {
-            compute_allocation: compute_allocation.map(|ca| {
-                ca.try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            compute_allocation: compute_allocation.map(|ca| ca.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -1081,7 +1084,7 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// Pass in a compute allocation value for the canister.
     pub fn with_compute_allocation<C, E>(self, compute_allocation: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<ComputeAllocation, Error = E>,
     {
         self.with_optional_compute_allocation(Some(compute_allocation))
@@ -1091,14 +1094,11 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// it will revert the memory allocation to default.
     pub fn with_optional_memory_allocation<E, C>(self, memory_allocation: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<MemoryAllocation, Error = E>,
     {
         Self {
-            memory_allocation: memory_allocation.map(|ma| {
-                ma.try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            memory_allocation: memory_allocation.map(|ma| ma.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -1106,7 +1106,7 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// Pass in a memory allocation value for the canister.
     pub fn with_memory_allocation<C, E>(self, memory_allocation: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<MemoryAllocation, Error = E>,
     {
         self.with_optional_memory_allocation(Some(memory_allocation))
@@ -1116,14 +1116,11 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// it will revert the freezing threshold to default.
     pub fn with_optional_freezing_threshold<E, C>(self, freezing_threshold: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<FreezingThreshold, Error = E>,
     {
         Self {
-            freezing_threshold: freezing_threshold.map(|ma| {
-                ma.try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            freezing_threshold: freezing_threshold.map(|ma| ma.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -1131,7 +1128,7 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// Pass in a freezing threshold value for the canister.
     pub fn with_freezing_threshold<C, E>(self, freezing_threshold: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<FreezingThreshold, Error = E>,
     {
         self.with_optional_freezing_threshold(Some(freezing_threshold))
@@ -1140,7 +1137,7 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// Pass in a reserved cycles limit value for the canister.
     pub fn with_reserved_cycles_limit<C, E>(self, limit: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<ReservedCyclesLimit, Error = E>,
     {
         self.with_optional_reserved_cycles_limit(Some(limit))
@@ -1150,14 +1147,11 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// If this is [`None`], leaves the reserved cycles limit unchanged.
     pub fn with_optional_reserved_cycles_limit<E, C>(self, limit: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<ReservedCyclesLimit, Error = E>,
     {
         Self {
-            reserved_cycles_limit: limit.map(|ma| {
-                ma.try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            reserved_cycles_limit: limit.map(|ma| ma.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -1165,7 +1159,7 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// Pass in a Wasm memory limit value for the canister.
     pub fn with_wasm_memory_limit<C, E>(self, wasm_memory_limit: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<WasmMemoryLimit, Error = E>,
     {
         self.with_optional_wasm_memory_limit(Some(wasm_memory_limit))
@@ -1175,15 +1169,11 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// leaves the Wasm memory limit unchanged.
     pub fn with_optional_wasm_memory_limit<E, C>(self, wasm_memory_limit: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<WasmMemoryLimit, Error = E>,
     {
         Self {
-            wasm_memory_limit: wasm_memory_limit.map(|limit| {
-                limit
-                    .try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            wasm_memory_limit: wasm_memory_limit.map(|limit| limit.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -1191,7 +1181,7 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// Pass in a Wasm memory threshold value for the canister.
     pub fn with_wasm_memory_threshold<C, E>(self, wasm_memory_threshold: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<WasmMemoryLimit, Error = E>,
     {
         self.with_optional_wasm_memory_threshold(Some(wasm_memory_threshold))
@@ -1201,15 +1191,12 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// leaves the memory threshold unchanged.
     pub fn with_optional_wasm_memory_threshold<E, C>(self, wasm_memory_threshold: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<WasmMemoryLimit, Error = E>,
     {
         Self {
-            wasm_memory_threshold: wasm_memory_threshold.map(|limit| {
-                limit
-                    .try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            wasm_memory_threshold: wasm_memory_threshold
+                .map(|limit| limit.try_into().map_err(From::from)),
             ..self
         }
     }
@@ -1217,7 +1204,7 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// Pass in a log visibility setting for the canister.
     pub fn with_log_visibility<C, E>(self, log_visibility: C) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<LogVisibility, Error = E>,
     {
         self.with_optional_log_visibility(Some(log_visibility))
@@ -1227,22 +1214,23 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     /// leaves the log visibility unchanged.
     pub fn with_optional_log_visibility<E, C>(self, log_visibility: Option<C>) -> Self
     where
-        E: std::fmt::Display,
+        AttributeConversionError: From<E>,
         C: TryInto<LogVisibility, Error = E>,
     {
         Self {
-            log_visibility: log_visibility.map(|limit| {
-                limit
-                    .try_into()
-                    .map_err(|e| AgentError::MessageError(format!("{e}")))
-            }),
+            log_visibility: log_visibility.map(|limit| limit.try_into().map_err(From::from)),
             ..self
         }
     }
 
     /// Create an [`AsyncCall`] implementation that, when called, will update a
     /// canisters settings.
-    pub fn build(self) -> Result<impl 'agent + AsyncCall<Value = ()>, AgentError> {
+    pub fn build(
+        self,
+    ) -> Result<
+        impl 'agent + AsyncCall<Value = (), Error = CanisterManagementError>,
+        AttributeConversionError,
+    > {
         #[derive(CandidType)]
         struct In {
             canister_id: Principal,
@@ -1250,49 +1238,49 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
         }
 
         let controllers = match self.controllers {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(x),
             None => None,
         };
         let compute_allocation = match self.compute_allocation {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u8::from(x))),
             None => None,
         };
         let memory_allocation = match self.memory_allocation {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u64::from(x))),
             None => None,
         };
         let freezing_threshold = match self.freezing_threshold {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u64::from(x))),
             None => None,
         };
         let reserved_cycles_limit = match self.reserved_cycles_limit {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u128::from(x))),
             None => None,
         };
         let wasm_memory_limit = match self.wasm_memory_limit {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u64::from(x))),
             None => None,
         };
         let wasm_memory_threshold = match self.wasm_memory_threshold {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(Nat::from(u64::from(x))),
             None => None,
         };
         let log_visibility = match self.log_visibility {
-            Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
+            Some(Err(x)) => return Err(x),
             Some(Ok(x)) => Some(x),
             None => None,
         };
 
         Ok(self
             .canister
-            .update(MgmtMethod::UpdateSettings.as_ref())
+            .update_(MgmtMethod::UpdateSettings.as_ref())
             .with_arg(In {
                 canister_id: self.canister_id,
                 settings: CanisterSettings {
@@ -1311,12 +1299,12 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
     }
 
     /// Make a call. This is equivalent to the [`AsyncCall::call`].
-    pub async fn call(self) -> Result<CallResponse<()>, AgentError> {
+    pub async fn call(self) -> Result<CallResponse<()>, CanisterManagementError> {
         self.build()?.call().await
     }
 
     /// Make a call. This is equivalent to the [`AsyncCall::call_and_wait`].
-    pub async fn call_and_wait(self) -> Result<(), AgentError> {
+    pub async fn call_and_wait(self) -> Result<(), CanisterManagementError> {
         self.build()?.call_and_wait().await
     }
 }
@@ -1325,18 +1313,19 @@ impl<'agent, 'canister: 'agent> UpdateCanisterBuilder<'agent, 'canister> {
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl<'agent, 'canister: 'agent> AsyncCall for UpdateCanisterBuilder<'agent, 'canister> {
     type Value = ();
-    async fn call(self) -> Result<CallResponse<()>, AgentError> {
+    type Error = CanisterManagementError;
+    async fn call(self) -> Result<CallResponse<()>, CanisterManagementError> {
         self.build()?.call().await
     }
 
-    async fn call_and_wait(self) -> Result<(), AgentError> {
+    async fn call_and_wait(self) -> Result<(), CanisterManagementError> {
         self.build()?.call_and_wait().await
     }
 }
 
 impl<'agent, 'canister: 'agent> IntoFuture for UpdateCanisterBuilder<'agent, 'canister> {
-    type IntoFuture = CallFuture<'agent, ()>;
-    type Output = Result<(), AgentError>;
+    type IntoFuture = CallFuture<'agent, (), CanisterManagementError>;
+    type Output = Result<(), CanisterManagementError>;
     fn into_future(self) -> Self::IntoFuture {
         AsyncCall::call_and_wait(self)
     }
@@ -1346,3 +1335,27 @@ impl<'agent, 'canister: 'agent> IntoFuture for UpdateCanisterBuilder<'agent, 'ca
 type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + 'a>>;
 #[cfg(target_family = "wasm")]
 type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a>>;
+
+/// Union of all the canister settings errors.
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum AttributeConversionError {
+    #[error(transparent)]
+    FreezingThreshold(FreezingThresholdError),
+    #[error(transparent)]
+    ComputeAllocation(ComputeAllocationError),
+    #[error(transparent)]
+    MemoryAllocation(MemoryAllocationError),
+    #[error(transparent)]
+    ReservedCyclesLimit(ReservedCyclesLimitError),
+    #[error(transparent)]
+    WasmMemoryLimit(WasmMemoryLimitError),
+    #[error(transparent)]
+    Principal(PrincipalError),
+}
+
+impl From<Infallible> for AttributeConversionError {
+    fn from(value: Infallible) -> Self {
+        match value {}
+    }
+}

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -11,7 +11,7 @@ use std::{
 use crate::{
     call::{AsyncCall, CallFuture, SyncCall},
     canister::Argument,
-    error::BaseError,
+    error::{impl_canister_error, BaseError},
     interfaces::management_canister::{
         attributes::{ComputeAllocation, FreezingThreshold, MemoryAllocation},
         builders::CanisterSettings,
@@ -1239,6 +1239,8 @@ pub enum WalletError {
     WalletError(String),
 }
 
+impl_canister_error!(WalletError);
+
 /// The reason for [`WalletError::WalletUpgradeRequired`].
 #[derive(Debug, Eq, PartialEq)]
 pub enum UpgradeReason {
@@ -1257,15 +1259,6 @@ impl Display for UpgradeReason {
             Self::MultiController => {
                 f.write_str("the installed wallet does not support multiple controllers")
             }
-        }
-    }
-}
-
-impl From<BaseError> for WalletError {
-    fn from(value: BaseError) -> Self {
-        match value {
-            BaseError::Agent(a) => Self::Agent(a),
-            BaseError::Candid(c) => Self::Candid(c),
         }
     }
 }

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -3,6 +3,7 @@
 //! [cycles wallet]: https://github.com/dfinity/cycles-wallet
 
 use std::{
+    fmt::Display,
     future::{Future, IntoFuture},
     ops::Deref,
 };
@@ -10,6 +11,7 @@ use std::{
 use crate::{
     call::{AsyncCall, CallFuture, SyncCall},
     canister::Argument,
+    error::BaseError,
     interfaces::management_canister::{
         attributes::{ComputeAllocation, FreezingThreshold, MemoryAllocation},
         builders::CanisterSettings,
@@ -18,9 +20,10 @@ use crate::{
 };
 use async_trait::async_trait;
 use candid::{decode_args, utils::ArgumentDecoder, CandidType, Deserialize, Nat};
-use ic_agent::{agent::CallResponse, export::Principal, Agent, AgentError};
+use ic_agent::{agent::CallResponse, agent_error::ErrorKind, export::Principal, Agent, AgentError};
 use once_cell::sync::Lazy;
 use semver::{Version, VersionReq};
+use thiserror::Error;
 
 const REPLICA_ERROR_NO_SUCH_QUERY_METHOD: &str = "has no query method 'wallet_api_version'";
 const IC_REF_ERROR_NO_SUCH_QUERY_METHOD: &str = "query method does not exist";
@@ -82,7 +85,9 @@ where
     }
 
     /// Creates an [`AsyncCall`] implementation that, when called, will forward the specified canister call.
-    pub fn build(self) -> Result<impl 'agent + AsyncCall<Value = Out>, AgentError> {
+    pub fn build(
+        self,
+    ) -> Result<impl 'agent + AsyncCall<Value = Out, Error = WalletError>, WalletError> {
         #[derive(CandidType, Deserialize)]
         struct In<TCycles> {
             canister: Principal,
@@ -103,31 +108,28 @@ where
                 canister: self.destination,
                 method_name: self.method_name,
                 args: self.arg.serialize()?,
-                cycles: u64::try_from(self.amount).map_err(|_| {
-                    AgentError::WalletUpgradeRequired(
-                        "The installed wallet does not support cycle counts >2^64-1".to_string(),
-                    )
-                })?,
+                cycles: u64::try_from(self.amount)
+                    .map_err(|_| WalletError::WalletUpgradeRequired(UpgradeReason::Cycles128))?,
             })
         }
         .build()
+        .map_err(WalletError::from)
         .and_then(|(result,): (Result<CallResult, String>,)| async move {
-            let result = result.map_err(AgentError::WalletCallFailed)?;
-            decode_args::<Out>(result.r#return.as_slice())
-                .map_err(|e| AgentError::CandidError(Box::new(e)))
+            let result = result.map_err(WalletError::WalletCallFailed)?;
+            decode_args::<Out>(result.r#return.as_slice()).map_err(WalletError::Candid)
         }))
     }
 
     /// Calls the forwarded canister call on the wallet canister. Equivalent to `.build().call()`.
-    pub fn call(self) -> impl Future<Output = Result<CallResponse<Out>, AgentError>> + 'agent {
+    pub fn call(self) -> impl Future<Output = Result<CallResponse<Out>, WalletError>> + 'agent {
         let call = self.build();
-        async { call?.call().await }
+        async { Ok(call?.call().await?) }
     }
 
     /// Calls the forwarded canister call on the wallet canister, and waits for the result. Equivalent to `.build().call_and_wait()`.
-    pub fn call_and_wait(self) -> impl Future<Output = Result<Out, AgentError>> + 'agent {
+    pub fn call_and_wait(self) -> impl Future<Output = Result<Out, WalletError>> + 'agent {
         let call = self.build();
-        async { call?.call_and_wait().await }
+        async { Ok(call?.call_and_wait().await?) }
     }
 }
 
@@ -138,12 +140,13 @@ where
     Out: for<'de> ArgumentDecoder<'de> + Send + Sync + 'agent,
 {
     type Value = Out;
+    type Error = WalletError;
 
-    async fn call(self) -> Result<CallResponse<Out>, AgentError> {
+    async fn call(self) -> Result<CallResponse<Out>, WalletError> {
         self.call().await
     }
 
-    async fn call_and_wait(self) -> Result<Out, AgentError> {
+    async fn call_and_wait(self) -> Result<Out, WalletError> {
         self.call_and_wait().await
     }
 }
@@ -152,8 +155,8 @@ impl<'agent: 'canister, 'canister, Out> IntoFuture for CallForwarder<'agent, 'ca
 where
     Out: for<'de> ArgumentDecoder<'de> + Send + Sync + 'agent,
 {
-    type IntoFuture = CallFuture<'agent, Out>;
-    type Output = Result<Out, AgentError>;
+    type IntoFuture = CallFuture<'agent, Out, WalletError>;
+    type Output = Result<Out, WalletError>;
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.call_and_wait())
     }
@@ -433,7 +436,7 @@ impl<'agent> WalletCanister<'agent> {
     pub async fn create(
         agent: &'agent Agent,
         canister_id: Principal,
-    ) -> Result<WalletCanister<'agent>, AgentError> {
+    ) -> Result<WalletCanister<'agent>, WalletError> {
         let canister = Canister::builder()
             .with_agent(agent)
             .with_canister_id(canister_id)
@@ -445,20 +448,21 @@ impl<'agent> WalletCanister<'agent> {
     /// Create a `WalletCanister` interface from an existing canister object. Fails if it cannot learn the wallet's version.
     pub async fn from_canister(
         canister: Canister<'agent>,
-    ) -> Result<WalletCanister<'agent>, AgentError> {
+    ) -> Result<WalletCanister<'agent>, WalletError> {
         static DEFAULT_VERSION: Lazy<Version> = Lazy::new(|| Version::parse("0.1.0").unwrap());
         let version: Result<(String,), _> =
             canister.query("wallet_api_version").build().call().await;
         let version = match version {
-            Err(AgentError::UncertifiedReject {
-                reject: replica_error,
-                ..
-            }) if replica_error
-                .reject_message
-                .contains(REPLICA_ERROR_NO_SUCH_QUERY_METHOD)
-                || replica_error
-                    .reject_message
-                    .contains(IC_REF_ERROR_NO_SUCH_QUERY_METHOD) =>
+            Err(BaseError::Agent(err))
+                if err.kind() == ErrorKind::Reject
+                    && err.operation_info().is_some_and(|op| {
+                        matches!(&op.response, Some(Err(replica_error)) if replica_error
+                            .reject_message
+                            .contains(REPLICA_ERROR_NO_SUCH_QUERY_METHOD)
+                        || replica_error
+                            .reject_message
+                            .contains(IC_REF_ERROR_NO_SUCH_QUERY_METHOD))
+                    }) =>
             {
                 DEFAULT_VERSION.clone()
             }
@@ -477,8 +481,10 @@ impl<'agent> WalletCanister<'agent> {
 
 impl<'agent> WalletCanister<'agent> {
     /// Re-fetch the API version string of the wallet.
-    pub fn fetch_wallet_api_version(&self) -> impl 'agent + SyncCall<Value = (Option<String>,)> {
-        self.query("wallet_api_version").build()
+    pub fn fetch_wallet_api_version(
+        &self,
+    ) -> impl 'agent + SyncCall<Value = (Option<String>,), Error = WalletError> {
+        self.query_("wallet_api_version").build()
     }
 
     /// Get the (cached) API version of the wallet.
@@ -487,57 +493,82 @@ impl<'agent> WalletCanister<'agent> {
     }
 
     /// Get the friendly name of the wallet (if one exists).
-    pub fn name(&self) -> impl 'agent + SyncCall<Value = (Option<String>,)> {
-        self.query("name").build()
+    pub fn name(&self) -> impl 'agent + SyncCall<Value = (Option<String>,), Error = WalletError> {
+        self.query_("name").build()
     }
 
     /// Set the friendly name of the wallet.
-    pub fn set_name(&self, name: String) -> impl 'agent + AsyncCall<Value = ()> {
-        self.update("set_name").with_arg(name).build()
+    pub fn set_name(
+        &self,
+        name: String,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = WalletError> {
+        self.update_("set_name").with_arg(name).build()
     }
 
     /// Get the current controller's principal ID.
-    pub fn get_controllers(&self) -> impl 'agent + SyncCall<Value = (Vec<Principal>,)> {
-        self.query("get_controllers").build()
+    pub fn get_controllers(
+        &self,
+    ) -> impl 'agent + SyncCall<Value = (Vec<Principal>,), Error = WalletError> {
+        self.query_("get_controllers").build()
     }
 
     /// Transfer controller to another principal ID.
-    pub fn add_controller(&self, principal: Principal) -> impl 'agent + AsyncCall<Value = ()> {
-        self.update("add_controller").with_arg(principal).build()
+    pub fn add_controller(
+        &self,
+        principal: Principal,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = WalletError> {
+        self.update_("add_controller").with_arg(principal).build()
     }
 
     /// Remove a user as a wallet controller.
-    pub fn remove_controller(&self, principal: Principal) -> impl 'agent + AsyncCall<Value = ()> {
-        self.update("remove_controller").with_arg(principal).build()
+    pub fn remove_controller(
+        &self,
+        principal: Principal,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = WalletError> {
+        self.update_("remove_controller")
+            .with_arg(principal)
+            .build()
     }
 
     /// Get the list of custodians.
-    pub fn get_custodians(&self) -> impl 'agent + SyncCall<Value = (Vec<Principal>,)> {
-        self.query("get_custodians").build()
+    pub fn get_custodians(
+        &self,
+    ) -> impl 'agent + SyncCall<Value = (Vec<Principal>,), Error = WalletError> {
+        self.query_("get_custodians").build()
     }
 
     /// Authorize a new custodian.
-    pub fn authorize(&self, custodian: Principal) -> impl 'agent + AsyncCall<Value = ()> {
-        self.update("authorize").with_arg(custodian).build()
+    pub fn authorize(
+        &self,
+        custodian: Principal,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = WalletError> {
+        self.update_("authorize").with_arg(custodian).build()
     }
 
     /// Deauthorize a custodian.
-    pub fn deauthorize(&self, custodian: Principal) -> impl 'agent + AsyncCall<Value = ()> {
-        self.update("deauthorize").with_arg(custodian).build()
+    pub fn deauthorize(
+        &self,
+        custodian: Principal,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = WalletError> {
+        self.update_("deauthorize").with_arg(custodian).build()
     }
 
     /// Get the balance with the 64-bit API.
-    pub fn wallet_balance64(&self) -> impl 'agent + SyncCall<Value = (BalanceResult<u64>,)> {
-        self.query("wallet_balance").build()
+    pub fn wallet_balance64(
+        &self,
+    ) -> impl 'agent + SyncCall<Value = (BalanceResult<u64>,), Error = WalletError> {
+        self.query_("wallet_balance").build()
     }
 
     /// Get the balance with the 128-bit API.
-    pub fn wallet_balance128(&self) -> impl 'agent + SyncCall<Value = (BalanceResult,)> {
-        self.query("wallet_balance128").build()
+    pub fn wallet_balance128(
+        &self,
+    ) -> impl 'agent + SyncCall<Value = (BalanceResult,), Error = WalletError> {
+        self.query_("wallet_balance128").build()
     }
 
     /// Get the balance.
-    pub async fn wallet_balance(&self) -> Result<BalanceResult, AgentError> {
+    pub async fn wallet_balance(&self) -> Result<BalanceResult, WalletError> {
         if self.version_supports_u128_cycles() {
             self.wallet_balance128().call().await.map(|(r,)| r)
         } else {
@@ -555,14 +586,14 @@ impl<'agent> WalletCanister<'agent> {
         &self,
         destination: Principal,
         amount: u64,
-    ) -> impl 'agent + AsyncCall<Value = (Result<(), String>,)> {
+    ) -> impl 'agent + AsyncCall<Value = (Result<(), String>,), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             canister: Principal,
             amount: u64,
         }
 
-        self.update("wallet_send")
+        self.update_("wallet_send")
             .with_arg(In {
                 canister: destination,
                 amount,
@@ -575,14 +606,14 @@ impl<'agent> WalletCanister<'agent> {
         &'canister self,
         destination: Principal,
         amount: u128,
-    ) -> impl 'agent + AsyncCall<Value = (Result<(), String>,)> {
+    ) -> impl 'agent + AsyncCall<Value = (Result<(), String>,), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             canister: Principal,
             amount: u128,
         }
 
-        self.update("wallet_send128")
+        self.update_("wallet_send128")
             .with_arg(In {
                 canister: destination,
                 amount,
@@ -595,32 +626,32 @@ impl<'agent> WalletCanister<'agent> {
         &self,
         destination: Principal,
         amount: u128,
-    ) -> Result<(), AgentError> {
+    ) -> Result<(), WalletError> {
         if self.version_supports_u128_cycles() {
             self.wallet_send128(destination, amount)
                 .call_and_wait()
                 .await?
         } else {
-            let amount = u64::try_from(amount).map_err(|_| {
-                AgentError::WalletUpgradeRequired(
-                    "The installed wallet does not support cycle counts >2^64-1.".to_string(),
-                )
-            })?;
+            let amount = u64::try_from(amount)
+                .map_err(|_| WalletError::WalletUpgradeRequired(UpgradeReason::Cycles128))?;
             self.wallet_send64(destination, amount)
                 .call_and_wait()
                 .await?
         }
         .0
-        .map_err(AgentError::WalletError)
+        .map_err(WalletError::WalletError)
     }
 
     /// A function for sending cycles to, so that a memo can be passed along with them.
-    pub fn wallet_receive(&self, memo: Option<String>) -> impl 'agent + AsyncCall<Value = ((),)> {
+    pub fn wallet_receive(
+        &self,
+        memo: Option<String>,
+    ) -> impl 'agent + AsyncCall<Value = ((),), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             memo: Option<String>,
         }
-        self.update("wallet_receive")
+        self.update_("wallet_receive")
             .with_arg(memo.map(|memo| In { memo: Some(memo) }))
             .build()
     }
@@ -633,7 +664,7 @@ impl<'agent> WalletCanister<'agent> {
         compute_allocation: Option<ComputeAllocation>,
         memory_allocation: Option<MemoryAllocation>,
         freezing_threshold: Option<FreezingThreshold>,
-    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,)> {
+    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             cycles: u64,
@@ -647,7 +678,7 @@ impl<'agent> WalletCanister<'agent> {
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
         };
 
-        self.update("wallet_create_canister")
+        self.update_("wallet_create_canister")
             .with_arg(In { cycles, settings })
             .build()
             .map(|result: (Result<CreateResult, String>,)| (result.0,))
@@ -661,7 +692,7 @@ impl<'agent> WalletCanister<'agent> {
         compute_allocation: Option<ComputeAllocation>,
         memory_allocation: Option<MemoryAllocation>,
         freezing_threshold: Option<FreezingThreshold>,
-    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,)> {
+    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             cycles: u64,
@@ -679,7 +710,7 @@ impl<'agent> WalletCanister<'agent> {
             log_visibility: None,
         };
 
-        self.update("wallet_create_canister")
+        self.update_("wallet_create_canister")
             .with_arg(In { cycles, settings })
             .build()
             .map(|result: (Result<CreateResult, String>,)| (result.0,))
@@ -693,7 +724,7 @@ impl<'agent> WalletCanister<'agent> {
         compute_allocation: Option<ComputeAllocation>,
         memory_allocation: Option<MemoryAllocation>,
         freezing_threshold: Option<FreezingThreshold>,
-    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,)> {
+    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             cycles: u128,
@@ -711,7 +742,7 @@ impl<'agent> WalletCanister<'agent> {
             log_visibility: None,
         };
 
-        self.update("wallet_create_canister128")
+        self.update_("wallet_create_canister128")
             .with_arg(In { cycles, settings })
             .build()
             .map(|result: (Result<CreateResult, String>,)| (result.0,))
@@ -733,7 +764,7 @@ impl<'agent> WalletCanister<'agent> {
         compute_allocation: Option<ComputeAllocation>,
         memory_allocation: Option<MemoryAllocation>,
         freezing_threshold: Option<FreezingThreshold>,
-    ) -> Result<CreateResult, AgentError> {
+    ) -> Result<CreateResult, WalletError> {
         if self.version_supports_u128_cycles() {
             self.wallet_create_canister128(
                 cycles,
@@ -745,11 +776,8 @@ impl<'agent> WalletCanister<'agent> {
             .call_and_wait()
             .await?
         } else {
-            let cycles = u64::try_from(cycles).map_err(|_| {
-                AgentError::WalletUpgradeRequired(
-                    "The installed wallet does not support cycle counts >2^64-1.".to_string(),
-                )
-            })?;
+            let cycles = u64::try_from(cycles)
+                .map_err(|_| WalletError::WalletUpgradeRequired(UpgradeReason::Cycles128))?;
             if self.version_supports_multiple_controllers() {
                 self.wallet_create_canister64_v2(
                     cycles,
@@ -767,8 +795,8 @@ impl<'agent> WalletCanister<'agent> {
                         let first: Principal = *first.unwrap();
                         Ok(Some(first))
                     }
-                    Some(_) => Err(AgentError::WalletUpgradeRequired(
-                        "The installed wallet does not support multiple controllers.".to_string(),
+                    Some(_) => Err(WalletError::WalletUpgradeRequired(
+                        UpgradeReason::MultiController,
                     )),
                     None => Ok(None),
                 }?;
@@ -784,7 +812,7 @@ impl<'agent> WalletCanister<'agent> {
             }
         }
         .0
-        .map_err(AgentError::WalletError)
+        .map_err(WalletError::WalletError)
     }
 
     /// Create a wallet canister with the single-controller 64-bit API.
@@ -795,7 +823,7 @@ impl<'agent> WalletCanister<'agent> {
         compute_allocation: Option<ComputeAllocation>,
         memory_allocation: Option<MemoryAllocation>,
         freezing_threshold: Option<FreezingThreshold>,
-    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,)> {
+    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             cycles: u64,
@@ -809,7 +837,7 @@ impl<'agent> WalletCanister<'agent> {
             freezing_threshold: freezing_threshold.map(u64::from).map(Nat::from),
         };
 
-        self.update("wallet_create_wallet")
+        self.update_("wallet_create_wallet")
             .with_arg(In { cycles, settings })
             .build()
             .map(|result: (Result<CreateResult, String>,)| (result.0,))
@@ -823,7 +851,7 @@ impl<'agent> WalletCanister<'agent> {
         compute_allocation: Option<ComputeAllocation>,
         memory_allocation: Option<MemoryAllocation>,
         freezing_threshold: Option<FreezingThreshold>,
-    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,)> {
+    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             cycles: u64,
@@ -841,7 +869,7 @@ impl<'agent> WalletCanister<'agent> {
             log_visibility: None,
         };
 
-        self.update("wallet_create_wallet")
+        self.update_("wallet_create_wallet")
             .with_arg(In { cycles, settings })
             .build()
             .map(|result: (Result<CreateResult, String>,)| (result.0,))
@@ -855,7 +883,7 @@ impl<'agent> WalletCanister<'agent> {
         compute_allocation: Option<ComputeAllocation>,
         memory_allocation: Option<MemoryAllocation>,
         freezing_threshold: Option<FreezingThreshold>,
-    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,)> {
+    ) -> impl 'agent + AsyncCall<Value = (Result<CreateResult, String>,), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             cycles: u128,
@@ -873,7 +901,7 @@ impl<'agent> WalletCanister<'agent> {
             log_visibility: None,
         };
 
-        self.update("wallet_create_wallet128")
+        self.update_("wallet_create_wallet128")
             .with_arg(In { cycles, settings })
             .build()
             .map(|result: (Result<CreateResult, String>,)| (result.0,))
@@ -887,7 +915,7 @@ impl<'agent> WalletCanister<'agent> {
         compute_allocation: Option<ComputeAllocation>,
         memory_allocation: Option<MemoryAllocation>,
         freezing_threshold: Option<FreezingThreshold>,
-    ) -> Result<CreateResult, AgentError> {
+    ) -> Result<CreateResult, WalletError> {
         if self.version_supports_u128_cycles() {
             self.wallet_create_wallet128(
                 cycles,
@@ -899,11 +927,8 @@ impl<'agent> WalletCanister<'agent> {
             .call_and_wait()
             .await?
         } else {
-            let cycles = u64::try_from(cycles).map_err(|_| {
-                AgentError::WalletUpgradeRequired(
-                    "The installed wallet does not support cycle counts >2^64-1.".to_string(),
-                )
-            })?;
+            let cycles = u64::try_from(cycles)
+                .map_err(|_| WalletError::WalletUpgradeRequired(UpgradeReason::Cycles128))?;
             if self.version_supports_multiple_controllers() {
                 self.wallet_create_wallet64_v2(
                     cycles,
@@ -917,8 +942,8 @@ impl<'agent> WalletCanister<'agent> {
             } else {
                 let controller: Option<Principal> = match &controllers {
                     Some(c) if c.len() == 1 => Ok(Some(c[0])),
-                    Some(_) => Err(AgentError::WalletUpgradeRequired(
-                        "The installed wallet does not support multiple controllers.".to_string(),
+                    Some(_) => Err(WalletError::WalletUpgradeRequired(
+                        UpgradeReason::MultiController,
                     )),
                     None => Ok(None),
                 }?;
@@ -934,7 +959,7 @@ impl<'agent> WalletCanister<'agent> {
             }
         }
         .0
-        .map_err(AgentError::WalletError)
+        .map_err(WalletError::WalletError)
     }
 
     /// Store the wallet WASM inside the wallet canister.
@@ -942,30 +967,38 @@ impl<'agent> WalletCanister<'agent> {
     pub fn wallet_store_wallet_wasm(
         &self,
         wasm_module: Vec<u8>,
-    ) -> impl 'agent + AsyncCall<Value = ()> {
+    ) -> impl 'agent + AsyncCall<Value = (), Error = WalletError> {
         #[derive(CandidType, Deserialize)]
         struct In {
             #[serde(with = "serde_bytes")]
             wasm_module: Vec<u8>,
         }
-        self.update("wallet_store_wallet_wasm")
+        self.update_("wallet_store_wallet_wasm")
             .with_arg(In { wasm_module })
             .build()
     }
 
     /// Add a principal to the address book.
-    pub fn add_address(&self, address: AddressEntry) -> impl 'agent + AsyncCall<Value = ()> {
-        self.update("add_address").with_arg(address).build()
+    pub fn add_address(
+        &self,
+        address: AddressEntry,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = WalletError> {
+        self.update_("add_address").with_arg(address).build()
     }
 
     /// List the entries in the address book.
-    pub fn list_addresses(&self) -> impl 'agent + SyncCall<Value = (Vec<AddressEntry>,)> {
-        self.query("list_addresses").build()
+    pub fn list_addresses(
+        &self,
+    ) -> impl 'agent + SyncCall<Value = (Vec<AddressEntry>,), Error = WalletError> {
+        self.query_("list_addresses").build()
     }
 
     /// Remove a principal from the address book.
-    pub fn remove_address(&self, principal: Principal) -> impl 'agent + AsyncCall<Value = ()> {
-        self.update("remove_address").with_arg(principal).build()
+    pub fn remove_address(
+        &self,
+        principal: Principal,
+    ) -> impl 'agent + AsyncCall<Value = (), Error = WalletError> {
+        self.update_("remove_address").with_arg(principal).build()
     }
 
     /// Get a list of all transaction events this wallet remembers, using the 64-bit API. Fails if any events are 128-bit.
@@ -973,7 +1006,7 @@ impl<'agent> WalletCanister<'agent> {
         &self,
         from: Option<u32>,
         to: Option<u32>,
-    ) -> impl 'agent + SyncCall<Value = (Vec<Event<u64>>,)> {
+    ) -> impl 'agent + SyncCall<Value = (Vec<Event<u64>>,), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             from: Option<u32>,
@@ -986,7 +1019,7 @@ impl<'agent> WalletCanister<'agent> {
             Some(In { from, to })
         };
 
-        self.query("get_events").with_arg(arg).build()
+        self.query_("get_events").with_arg(arg).build()
     }
 
     /// Get a list of all transaction events this wallet remembers, using the 128-bit API.
@@ -994,7 +1027,7 @@ impl<'agent> WalletCanister<'agent> {
         &self,
         from: Option<u32>,
         to: Option<u32>,
-    ) -> impl 'agent + SyncCall<Value = (Vec<Event>,)> {
+    ) -> impl 'agent + SyncCall<Value = (Vec<Event>,), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             from: Option<u32>,
@@ -1005,7 +1038,7 @@ impl<'agent> WalletCanister<'agent> {
         } else {
             Some(In { from, to })
         };
-        self.query("get_events128").with_arg(arg).build()
+        self.query_("get_events128").with_arg(arg).build()
     }
 
     /// Get a list of all transaction events this wallet remembers.
@@ -1013,7 +1046,7 @@ impl<'agent> WalletCanister<'agent> {
         &self,
         from: Option<u32>,
         to: Option<u32>,
-    ) -> Result<Vec<Event>, AgentError> {
+    ) -> Result<Vec<Event>, WalletError> {
         if self.version_supports_u128_cycles() {
             self.get_events128(from, to)
                 .call()
@@ -1101,13 +1134,13 @@ impl<'agent> WalletCanister<'agent> {
         &self,
         from: Option<u32>,
         to: Option<u32>,
-    ) -> impl 'agent + SyncCall<Value = (Vec<ManagedCanisterInfo>, u32)> {
+    ) -> impl 'agent + SyncCall<Value = (Vec<ManagedCanisterInfo>, u32), Error = WalletError> {
         #[derive(CandidType)]
         struct In {
             from: Option<u32>,
             to: Option<u32>,
         }
-        self.query("list_managed_canisters")
+        self.query_("list_managed_canisters")
             .with_arg((In { from, to },))
             .build()
     }
@@ -1118,14 +1151,15 @@ impl<'agent> WalletCanister<'agent> {
         canister: Principal,
         from: Option<u32>,
         to: Option<u32>,
-    ) -> impl 'agent + SyncCall<Value = (Option<Vec<ManagedCanisterEvent<u64>>>,)> {
+    ) -> impl 'agent + SyncCall<Value = (Option<Vec<ManagedCanisterEvent<u64>>>,), Error = WalletError>
+    {
         #[derive(CandidType)]
         struct In {
             canister: Principal,
             from: Option<u32>,
             to: Option<u32>,
         }
-        self.query("get_managed_canister_events")
+        self.query_("get_managed_canister_events")
             .with_arg((In { canister, from, to },))
             .build()
     }
@@ -1136,14 +1170,15 @@ impl<'agent> WalletCanister<'agent> {
         canister: Principal,
         from: Option<u32>,
         to: Option<u32>,
-    ) -> impl 'agent + SyncCall<Value = (Option<Vec<ManagedCanisterEvent>>,)> {
+    ) -> impl 'agent + SyncCall<Value = (Option<Vec<ManagedCanisterEvent>>,), Error = WalletError>
+    {
         #[derive(CandidType)]
         struct In {
             canister: Principal,
             from: Option<u32>,
             to: Option<u32>,
         }
-        self.query("get_managed_canister_events128")
+        self.query_("get_managed_canister_events128")
             .with_arg((In { canister, from, to },))
             .build()
     }
@@ -1154,7 +1189,7 @@ impl<'agent> WalletCanister<'agent> {
         canister: Principal,
         from: Option<u32>,
         to: Option<u32>,
-    ) -> Result<Option<Vec<ManagedCanisterEvent>>, AgentError> {
+    ) -> Result<Option<Vec<ManagedCanisterEvent>>, WalletError> {
         if self.version_supports_u128_cycles() {
             self.get_managed_canister_events128(canister, from, to)
                 .call()
@@ -1181,5 +1216,56 @@ impl<'agent> WalletCanister<'agent> {
     pub fn version_supports_u128_cycles(&self) -> bool {
         static U128_CYCLES: Lazy<VersionReq> = Lazy::new(|| VersionReq::parse(">=0.3.0").unwrap());
         U128_CYCLES.matches(&self.version)
+    }
+}
+
+/// An error that can occur when interfacing with a wallet canister.
+#[derive(Error, Debug)]
+pub enum WalletError {
+    /// An error occurred encoding/decoding Candid.
+    #[error("{0}")]
+    Candid(#[from] candid::Error),
+    /// An error occurred in the agent.
+    #[error("{0}")]
+    Agent(#[from] AgentError),
+    /// The wallet canister must be upgraded.
+    #[error("The wallet canister must be upgraded: {0}")]
+    WalletUpgradeRequired(UpgradeReason),
+    /// The `call_forward` call failed.
+    #[error("The invocation to the wallet call forward method failed with the error: {0}")]
+    WalletCallFailed(String),
+    /// The wallet returned an error.
+    #[error("The wallet operation failed: {0}")]
+    WalletError(String),
+}
+
+/// The reason for [`WalletError::WalletUpgradeRequired`].
+#[derive(Debug, Eq, PartialEq)]
+pub enum UpgradeReason {
+    /// The wallet does not support a 128-bit cycle count.
+    Cycles128,
+    /// The wallet does not support multiple controllers.
+    MultiController,
+}
+
+impl Display for UpgradeReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Cycles128 => {
+                f.write_str("the installed wallet does not support cycle counts >2^64-1")
+            }
+            Self::MultiController => {
+                f.write_str("the installed wallet does not support multiple controllers")
+            }
+        }
+    }
+}
+
+impl From<BaseError> for WalletError {
+    fn from(value: BaseError) -> Self {
+        match value {
+            BaseError::Agent(a) => Self::Agent(a),
+            BaseError::Candid(c) => Self::Candid(c),
+        }
     }
 }

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -123,13 +123,13 @@ where
     /// Calls the forwarded canister call on the wallet canister. Equivalent to `.build().call()`.
     pub fn call(self) -> impl Future<Output = Result<CallResponse<Out>, WalletError>> + 'agent {
         let call = self.build();
-        async { Ok(call?.call().await?) }
+        async { call?.call().await }
     }
 
     /// Calls the forwarded canister call on the wallet canister, and waits for the result. Equivalent to `.build().call_and_wait()`.
     pub fn call_and_wait(self) -> impl Future<Output = Result<Out, WalletError>> + 'agent {
         let call = self.build();
-        async { Ok(call?.call_and_wait().await?) }
+        async { call?.call_and_wait().await }
     }
 }
 

--- a/ic-utils/src/lib.rs
+++ b/ic-utils/src/lib.rs
@@ -15,7 +15,7 @@
 pub mod call;
 /// A higher-level canister type for managing various aspects of a canister.
 pub mod canister;
-mod error;
+pub mod error;
 /// A few known canister types for use with [`Canister`].
 pub mod interfaces;
 

--- a/ic-utils/src/lib.rs
+++ b/ic-utils/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod call;
 /// A higher-level canister type for managing various aspects of a canister.
 pub mod canister;
+/// An error interface for canister errors.
 pub mod error;
 /// A few known canister types for use with [`Canister`].
 pub mod interfaces;

--- a/ic-utils/src/lib.rs
+++ b/ic-utils/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod call;
 /// A higher-level canister type for managing various aspects of a canister.
 pub mod canister;
+mod error;
 /// A few known canister types for use with [`Canister`].
 pub mod interfaces;
 

--- a/ref-tests/Cargo.toml
+++ b/ref-tests/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 candid = { workspace = true }
 ed25519-consensus = { workspace = true }
+hex.workspace = true
 ic-agent = { path = "../ic-agent" }
 ic-identity-hsm = { path = "../ic-identity-hsm" }
 ic-utils = { path = "../ic-utils", features = ["raw"] }

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -6,13 +6,14 @@ use candid::CandidType;
 use ic_agent::{
     agent::{agent_error::HttpErrorPayload, Envelope, EnvelopeContent, RejectCode, RejectResponse},
     export::Principal,
-    AgentError, Identity,
+    Identity,
 };
 use ic_certification::Label;
 use ic_utils::{
     call::{AsyncCall, SyncCall},
     interfaces::{
         management_canister::builders::{CanisterSettings, InstallMode},
+        wallet::WalletError,
         WalletCanister,
     },
     Argument, Canister,
@@ -25,6 +26,7 @@ use ref_tests::{
 use serde::Serialize;
 use std::{
     borrow::Cow,
+    error::Error,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -53,10 +55,13 @@ fn basic_expiry() {
             .call_and_wait()
             .await;
 
-        match result.unwrap_err() {
-            AgentError::HttpError(HttpErrorPayload { status, .. }) => assert_eq!(status, 400),
-            x => panic!("Was expecting an error, got {:?}", x),
-        }
+        let err = result.unwrap_err();
+        let payload = err
+            .source()
+            .unwrap()
+            .downcast_ref::<HttpErrorPayload>()
+            .unwrap();
+        assert_eq!(payload.status, 400);
 
         let result = agent
             .update(&canister_id, "update")
@@ -184,21 +189,23 @@ fn canister_reject_call() {
             WalletCanister::create(&agent, create_wallet_canister(&agent, None).await?).await?;
 
         let result = alice.wallet_send(*bob.canister_id(), 1_000_000).await;
-
+        let WalletError::Agent(err) = result.unwrap_err() else {
+            panic!("not an agent error")
+        };
         assert!(
             matches!(
-                &result,
-                Err(AgentError::CertifiedReject { reject: RejectResponse {
+                &err.operation_info().unwrap().response,
+                Some(Err(RejectResponse {
                     reject_code: RejectCode::CanisterError,
                     reject_message,
                     error_code: Some(error_code),
                     ..
-                }, .. }) if reject_message.contains(&format!(
+                })) if reject_message.contains(&format!(
                     "Canister {}: Canister has no update method 'wallet_send'",
                     alice.canister_id()
                 )) && error_code == "IC0536"
             ),
-            "wrong error: {result:?}"
+            "wrong error: {err:?}"
         );
 
         Ok(())
@@ -556,7 +563,7 @@ mod sign_send {
             signed_query_inspect, signed_request_status_inspect, signed_update_inspect,
             ReplyResponse, RequestStatusResponse,
         },
-        AgentError,
+        agent_error::InspectionError,
     };
     use ref_tests::{universal_canister::payload, with_universal_canister};
     use std::{thread, time};
@@ -664,7 +671,7 @@ mod sign_send {
             );
 
             assert!(matches!(result,
-                    Err(AgentError::CallDataMismatch{field, value_arg, value_cbor})
+                    Err(InspectionError::CallDataMismatch{field, value_arg, value_cbor})
                     if field == *"method_name" && value_arg == *"non_query" && value_cbor == *"query"));
 
             Ok(())


### PR DESCRIPTION
Reworks `AgentError` into an opaque error type. Tracks ongoing call info and reports it as part of the error.