### PR TITLE
feat: Allow to choose a custom retry policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Added the possibility to set a custom `retry_policy`.
 * Add `read_state_canister_controllers` and `read_state_canister_module_hash` functions.
 
 ## [0.40.0] - 2025-03-17


### PR DESCRIPTION
# Description

Currently, the only retry policy is a default hard-coded one. This PR allows to choose a custom one.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [x] I have made corresponding changes to the documentation.
