### PR TITLE
Fix ic-agent for web worker environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Fix panic in web worker environments in `ic-agent`. 
+
 ## [0.40.1] - 2025-05-15
 
 * Add `read_state_canister_controllers` and `read_state_canister_module_hash` functions.


### PR DESCRIPTION
# Description

When ic-agent is used inside a rust web worker environment, the sleep function panics as the window object is not available. This PR fixes the sleep function so it uses the appropriate `self` object instead (more here: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers#web_workers_api) 

# How Has This Been Tested?

Its a bit difficult to test this e2e as I encountered this panic when my worker was rate limited. I can create a minimal web worker which specifically uses sleep written like this if you feel its necessary.

# Checklist:

- [ ] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
