### PR TITLE
feat: add environment variables to canister settings

### DIFF
--- a/.github/workflows/ic-ref.yml
+++ b/.github/workflows/ic-ref.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dfx
         uses: dfinity/setup-dfx@main
         with:
-          dfx-version: "0.24.3"
+          dfx-version: "0.28.0"
 
       - name: Cargo cache
         uses: actions/cache@v4

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -179,8 +179,8 @@ pub enum LogVisibility {
 /// A generic environment variable struct defining a key-value pair, meant to be used for defining a canister environment
 #[derive(Debug, Clone, CandidType, Deserialize, PartialEq)]
 pub struct EnvironmentVariable {
-    /// Variable key/name
-    pub key: String,
+    /// Variable name
+    pub name: String,
 
     /// Variable value
     pub value: String,

--- a/ic-utils/src/interfaces/management_canister.rs
+++ b/ic-utils/src/interfaces/management_canister.rs
@@ -176,6 +176,16 @@ pub enum LogVisibility {
     AllowedViewers(Vec<Principal>),
 }
 
+/// A generic environment variable struct defining a key-value pair, meant to be used for defining a canister environment
+#[derive(Debug, Clone, CandidType, Deserialize, PartialEq)]
+pub struct EnvironmentVariable {
+    /// Variable key/name
+    pub key: String,
+
+    /// Variable value
+    pub value: String,
+}
+
 /// The concrete settings of a canister.
 #[derive(Clone, Debug, Deserialize, CandidType)]
 pub struct DefiniteCanisterSettings {
@@ -197,6 +207,8 @@ pub struct DefiniteCanisterSettings {
     pub wasm_memory_threshold: Option<Nat>,
     /// The canister log visibility. Defines which principals are allowed to fetch logs.
     pub log_visibility: LogVisibility,
+    /// A set of dynamically-configurable environment variables for a canister
+    pub environment_variables: Vec<EnvironmentVariable>,
 }
 
 impl std::fmt::Display for StatusCallResult {
@@ -686,7 +698,7 @@ impl<'agent> ManagementCanister<'agent> {
     }
 
     /// Creates a canister snapshot, optionally replacing an existing snapshot.
-    ///  
+    ///
     /// <div class="warning">Canisters should be stopped before running this method!</div>
     pub fn take_canister_snapshot(
         &self,

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -6,6 +6,7 @@ pub use super::attributes::{
 };
 use super::{ChunkHash, LogVisibility, ManagementCanister};
 use crate::call::CallFuture;
+use crate::interfaces::management_canister::EnvironmentVariable;
 use crate::{
     call::AsyncCall, canister::Argument, interfaces::management_canister::MgmtMethod, Canister,
 };
@@ -25,13 +26,6 @@ use std::{
     pin::Pin,
     str::FromStr,
 };
-
-/// A generic variable struct defining a key-value pair, meant to be used for defining a canister environment
-#[derive(Debug, Clone, CandidType, Deserialize)]
-pub struct EnvironmentVariable {
-    key: String,
-    value: String,
-}
 
 /// The set of possible canister settings. Similar to [`DefiniteCanisterSettings`](super::DefiniteCanisterSettings),
 /// but all the fields are optional.

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -677,7 +677,7 @@ impl<'agent> WalletCanister<'agent> {
             wasm_memory_limit: None,
             wasm_memory_threshold: None,
             log_visibility: None,
-            environment: None,
+            environment_variables: None,
         };
 
         self.update("wallet_create_canister")
@@ -710,7 +710,7 @@ impl<'agent> WalletCanister<'agent> {
             wasm_memory_limit: None,
             wasm_memory_threshold: None,
             log_visibility: None,
-            environment: None,
+            environment_variables: None,
         };
 
         self.update("wallet_create_canister128")
@@ -841,7 +841,7 @@ impl<'agent> WalletCanister<'agent> {
             wasm_memory_limit: None,
             wasm_memory_threshold: None,
             log_visibility: None,
-            environment: None,
+            environment_variables: None,
         };
 
         self.update("wallet_create_wallet")
@@ -874,7 +874,7 @@ impl<'agent> WalletCanister<'agent> {
             wasm_memory_limit: None,
             wasm_memory_threshold: None,
             log_visibility: None,
-            environment: None,
+            environment_variables: None,
         };
 
         self.update("wallet_create_wallet128")

--- a/ic-utils/src/interfaces/wallet.rs
+++ b/ic-utils/src/interfaces/wallet.rs
@@ -677,6 +677,7 @@ impl<'agent> WalletCanister<'agent> {
             wasm_memory_limit: None,
             wasm_memory_threshold: None,
             log_visibility: None,
+            environment: None,
         };
 
         self.update("wallet_create_canister")
@@ -709,6 +710,7 @@ impl<'agent> WalletCanister<'agent> {
             wasm_memory_limit: None,
             wasm_memory_threshold: None,
             log_visibility: None,
+            environment: None,
         };
 
         self.update("wallet_create_canister128")
@@ -839,6 +841,7 @@ impl<'agent> WalletCanister<'agent> {
             wasm_memory_limit: None,
             wasm_memory_threshold: None,
             log_visibility: None,
+            environment: None,
         };
 
         self.update("wallet_create_wallet")
@@ -871,6 +874,7 @@ impl<'agent> WalletCanister<'agent> {
             wasm_memory_limit: None,
             wasm_memory_threshold: None,
             log_visibility: None,
+            environment: None,
         };
 
         self.update("wallet_create_wallet128")

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -740,7 +740,7 @@ mod management_canister {
                     wasm_memory_limit: None,
                     wasm_memory_threshold: None,
                     log_visibility: None,
-                    environment: None,
+                    environment_variables: None,
                 },
             };
 

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -740,6 +740,7 @@ mod management_canister {
                     wasm_memory_limit: None,
                     wasm_memory_threshold: None,
                     log_visibility: None,
+                    environment: None,
                 },
             };
 

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -1428,7 +1428,7 @@ mod extras {
                 .as_provisional_create_with_amount(None)
                 .with_effective_canister_id(get_effective_canister_id().await)
                 .with_environment_variables(vec![EnvironmentVariable {
-                    key: "key-1".to_string(),
+                    name: "name-1".to_string(),
                     value: "value-1".to_string(),
                 }])
                 .call_and_wait()
@@ -1441,7 +1441,7 @@ mod extras {
             assert_eq!(
                 result.0.settings.environment_variables,
                 vec![EnvironmentVariable {
-                    key: "key-1".to_string(),
+                    name: "name-1".to_string(),
                     value: "value-1".to_string(),
                 }],
             );
@@ -1462,7 +1462,7 @@ mod extras {
                 .as_provisional_create_with_amount(Some(20_000_000_000_000_u128))
                 .with_effective_canister_id(get_effective_canister_id().await)
                 .with_environment_variables(vec![EnvironmentVariable {
-                    key: "key-1".to_string(),
+                    name: "name-1".to_string(),
                     value: "value-1".to_string(),
                 }])
                 .call_and_wait()
@@ -1474,7 +1474,7 @@ mod extras {
             assert_eq!(
                 result.0.settings.environment_variables,
                 vec![EnvironmentVariable {
-                    key: "key-1".to_string(),
+                    name: "name-1".to_string(),
                     value: "value-1".to_string(),
                 }],
             );
@@ -1483,11 +1483,11 @@ mod extras {
             ic00.update_settings(&canister_id)
                 .with_environment_variables(vec![
                     EnvironmentVariable {
-                        key: "key-1".to_string(),
+                        name: "name-1".to_string(),
                         value: "value-1".to_string(),
                     },
                     EnvironmentVariable {
-                        key: "key-2".to_string(),
+                        name: "name-2".to_string(),
                         value: "value-2".to_string(),
                     },
                 ])
@@ -1501,11 +1501,11 @@ mod extras {
                 result.0.settings.environment_variables,
                 vec![
                     EnvironmentVariable {
-                        key: "key-1".to_string(),
+                        name: "name-1".to_string(),
                         value: "value-1".to_string(),
                     },
                     EnvironmentVariable {
-                        key: "key-2".to_string(),
+                        name: "name-2".to_string(),
                         value: "value-2".to_string(),
                     }
                 ],
@@ -1525,11 +1525,11 @@ mod extras {
                 result.0.settings.environment_variables,
                 vec![
                     EnvironmentVariable {
-                        key: "key-1".to_string(),
+                        name: "name-1".to_string(),
                         value: "value-1".to_string(),
                     },
                     EnvironmentVariable {
-                        key: "key-2".to_string(),
+                        name: "name-2".to_string(),
                         value: "value-2".to_string(),
                     }
                 ],

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -443,6 +443,7 @@ fn wallet_create_wallet() {
                 wasm_memory_limit: None,
                 wasm_memory_threshold: None,
                 log_visibility: None,
+                environment: None,
             },
         };
         let args = Argument::from_candid((create_args,));

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -443,7 +443,7 @@ fn wallet_create_wallet() {
                 wasm_memory_limit: None,
                 wasm_memory_threshold: None,
                 log_visibility: None,
-                environment: None,
+                environment_variables: None,
             },
         };
         let args = Argument::from_candid((create_args,));


### PR DESCRIPTION
See https://dfinity.atlassian.net/browse/SDK-2151.

This change is required to add support for canister environment variables in the 
new `icp-cli` tool.