### PR TITLE
chore: Release 0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
 ## [0.42.0] - 2025-08-04
 
 * Use [ic-management-canister-types](https://crates.io/crates/ic-management-canister-types/0.3.2) in [ic-utils](./ic-utils/README.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.42.0] - 2025-08-04
 
 * Use [ic-management-canister-types](https://crates.io/crates/ic-management-canister-types/0.3.2) in [ic-utils](./ic-utils/README.md).
   - This change introduces some breaking changes in `ic-utils` due to the type-inconsistency. For example, the `StatusCallResult` defined in `ic-utils` is not consistent to  the `CanisterStatusResult` defined in `ic-management-canister-types`.
   - The legacy types defined in `ic-utils` are marked as deprecated with messages.
   - Some APIs are updated to use the types defined in `ic-management-canister-types`, e.g. `upload_canister_snapshot_metadata`, `upload_canister_snapshot_data`.
 
-## [0.41.1] - 2025-07-10
+## [0.41.0] - 2025-07-10
 
 * Add canister snapshot download and upload methods to `ManagementCanister`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The legacy types defined in `ic-utils` are marked as deprecated with messages.
   - Some APIs are updated to use the types defined in `ic-management-canister-types`, e.g. `upload_canister_snapshot_metadata`, `upload_canister_snapshot_data`.
 
+* Bump MSRV from `1.78.0` to `1.85.0`.
+
 ## [0.41.0] - 2025-07-10
 
 * Add canister snapshot download and upload methods to `ManagementCanister`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,7 @@ dependencies = [
  "async-trait",
  "async-watch",
  "backoff",
+ "base64ct",
  "cached",
  "candid",
  "der",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,6 @@ dependencies = [
  "async-trait",
  "async-watch",
  "backoff",
- "base64ct",
  "cached",
  "candid",
  "der",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -1208,7 +1208,7 @@ dependencies = [
  "http-body",
  "ic-certification 3.0.2",
  "ic-ed25519",
- "ic-transport-types 0.41.0",
+ "ic-transport-types 0.42.0",
  "ic-verify-bls-signature",
  "js-sys",
  "k256",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "candid",
  "hex",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.41.0"
+version = "0.42.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
@@ -25,9 +25,9 @@ license = "Apache-2.0"
 needless_lifetimes = "allow"
 
 [workspace.dependencies]
-ic-agent = { path = "ic-agent", version = "0.41.0", default-features = false }
-ic-utils = { path = "ic-utils", version = "0.41.0" }
-ic-transport-types = { path = "ic-transport-types", version = "0.41.0" }
+ic-agent = { path = "ic-agent", version = "0.42.0", default-features = false }
+ic-utils = { path = "ic-utils", version = "0.42.0" }
+ic-transport-types = { path = "ic-transport-types", version = "0.42.0" }
 
 ic-certification = "3"
 candid = "0.10.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ ic-utils = { path = "ic-utils", version = "0.42.0" }
 ic-transport-types = { path = "ic-transport-types", version = "0.42.0" }
 
 ic-certification = "3"
+base64ct = "1.6.0"
 candid = "0.10.10"
 candid_parser = "0.1.4"
 clap = "4.5.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/dfinity/agent-rs"
 # MSRV
 # Avoid updating this field unless we use new Rust features
 # Sync rust-version in rust-toolchain.toml
-rust-version = "1.78.0"
+rust-version = "1.85.0"
 license = "Apache-2.0"
 
 [workspace.lints.clippy]
@@ -30,7 +30,6 @@ ic-utils = { path = "ic-utils", version = "0.42.0" }
 ic-transport-types = { path = "ic-transport-types", version = "0.42.0" }
 
 ic-certification = "3"
-base64ct = "1.6.0"
 candid = "0.10.10"
 candid_parser = "0.1.4"
 clap = "4.5.21"

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -61,6 +61,7 @@ time = { workspace = true }
 tower-service = "0.3"
 tracing = { version = "0.1", optional = true }
 url = "2.1.0"
+base64ct = { workspace = true }
 
 [dependencies.reqwest]
 workspace = true

--- a/ic-agent/Cargo.toml
+++ b/ic-agent/Cargo.toml
@@ -61,7 +61,6 @@ time = { workspace = true }
 tower-service = "0.3"
 tracing = { version = "0.1", optional = true }
 url = "2.1.0"
-base64ct = { workspace = true }
 
 [dependencies.reqwest]
 workspace = true

--- a/ic-agent/src/agent/response_authentication.rs
+++ b/ic-agent/src/agent/response_authentication.rs
@@ -289,7 +289,10 @@ pub trait LookupPath {
 
 impl<'b, const N: usize> LookupPath for [&'b [u8]; N] {
     type Item = &'b [u8];
-    type Iter<'a> = std::slice::Iter<'a, &'b [u8]> where Self: 'a;
+    type Iter<'a>
+        = std::slice::Iter<'a, &'b [u8]>
+    where
+        Self: 'a;
     fn iter(&self) -> Self::Iter<'_> {
         self.as_slice().iter()
     }
@@ -299,7 +302,10 @@ impl<'b, const N: usize> LookupPath for [&'b [u8]; N] {
 }
 impl<'b, 'c> LookupPath for &'c [&'b [u8]] {
     type Item = &'b [u8];
-    type Iter<'a> = std::slice::Iter<'a, &'b [u8]> where Self: 'a;
+    type Iter<'a>
+        = std::slice::Iter<'a, &'b [u8]>
+    where
+        Self: 'a;
     fn iter(&self) -> Self::Iter<'_> {
         <[_]>::iter(self)
     }
@@ -309,7 +315,10 @@ impl<'b, 'c> LookupPath for &'c [&'b [u8]] {
 }
 impl<'b> LookupPath for Vec<&'b [u8]> {
     type Item = &'b [u8];
-    type Iter<'a> = std::slice::Iter<'a, &'b [u8]> where Self: 'a;
+    type Iter<'a>
+        = std::slice::Iter<'a, &'b [u8]>
+    where
+        Self: 'a;
     fn iter(&self) -> Self::Iter<'_> {
         <[_]>::iter(self.as_slice())
     }
@@ -320,7 +329,10 @@ impl<'b> LookupPath for Vec<&'b [u8]> {
 
 impl<const N: usize> LookupPath for [Vec<u8>; N] {
     type Item = Vec<u8>;
-    type Iter<'a> = std::slice::Iter<'a, Vec<u8>> where Self: 'a;
+    type Iter<'a>
+        = std::slice::Iter<'a, Vec<u8>>
+    where
+        Self: 'a;
     fn iter(&self) -> Self::Iter<'_> {
         self.as_slice().iter()
     }
@@ -330,7 +342,10 @@ impl<const N: usize> LookupPath for [Vec<u8>; N] {
 }
 impl<'c> LookupPath for &'c [Vec<u8>] {
     type Item = Vec<u8>;
-    type Iter<'a> = std::slice::Iter<'a, Vec<u8>> where Self: 'a;
+    type Iter<'a>
+        = std::slice::Iter<'a, Vec<u8>>
+    where
+        Self: 'a;
     fn iter(&self) -> Self::Iter<'_> {
         <[_]>::iter(self)
     }
@@ -340,7 +355,10 @@ impl<'c> LookupPath for &'c [Vec<u8>] {
 }
 impl LookupPath for Vec<Vec<u8>> {
     type Item = Vec<u8>;
-    type Iter<'a> = std::slice::Iter<'a, Vec<u8>> where Self: 'a;
+    type Iter<'a>
+        = std::slice::Iter<'a, Vec<u8>>
+    where
+        Self: 'a;
     fn iter(&self) -> Self::Iter<'_> {
         <[_]>::iter(self.as_slice())
     }
@@ -351,7 +369,10 @@ impl LookupPath for Vec<Vec<u8>> {
 
 impl<Storage: AsRef<[u8]> + Into<Vec<u8>>, const N: usize> LookupPath for [Label<Storage>; N] {
     type Item = Label<Storage>;
-    type Iter<'a> = std::slice::Iter<'a, Label<Storage>> where Self: 'a;
+    type Iter<'a>
+        = std::slice::Iter<'a, Label<Storage>>
+    where
+        Self: 'a;
     fn iter(&self) -> Self::Iter<'_> {
         self.as_slice().iter()
     }
@@ -361,7 +382,10 @@ impl<Storage: AsRef<[u8]> + Into<Vec<u8>>, const N: usize> LookupPath for [Label
 }
 impl<'c, Storage: AsRef<[u8]> + Into<Vec<u8>>> LookupPath for &'c [Label<Storage>] {
     type Item = Label<Storage>;
-    type Iter<'a> = std::slice::Iter<'a, Label<Storage>> where Self: 'a;
+    type Iter<'a>
+        = std::slice::Iter<'a, Label<Storage>>
+    where
+        Self: 'a;
     fn iter(&self) -> Self::Iter<'_> {
         <[_]>::iter(self)
     }
@@ -373,7 +397,10 @@ impl<'c, Storage: AsRef<[u8]> + Into<Vec<u8>>> LookupPath for &'c [Label<Storage
 }
 impl LookupPath for Vec<Label<Vec<u8>>> {
     type Item = Label<Vec<u8>>;
-    type Iter<'a> = std::slice::Iter<'a, Label<Vec<u8>>> where Self: 'a;
+    type Iter<'a>
+        = std::slice::Iter<'a, Label<Vec<u8>>>
+    where
+        Self: 'a;
     fn iter(&self) -> Self::Iter<'_> {
         <[_]>::iter(self.as_slice())
     }

--- a/ic-agent/src/agent/route_provider/dynamic_routing/mod.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/mod.rs
@@ -22,6 +22,7 @@
 //! The `DynamicRouteProvider` can be used standalone or injected into the agent to enable dynamic routing. There are several ways to instantiate it:
 //! 1. **Via high-Level Agent API**: Initializes the agent with built-in dynamic routing. This method is user-friendly but provides limited customization options.
 //! 2. **Via [`DynamicRouteProviderBuilder`](dynamic_route_provider::DynamicRouteProviderBuilder)**: Creates a customized `DynamicRouteProvider` with a specific routing strategy and parameters.
+//!
 //! This instance can be used standalone or integrated into the agent via [`AgentBuilder::with_route_provider()`](super::super::AgentBuilder::with_route_provider).
 //! ## Example: High-Level Agent API
 //! ```rust
@@ -130,12 +131,14 @@
 //! - **Nodes Fetcher**: Custom implementation of the [`Fetch`](nodes_fetch::Fetch) trait for node discovery.
 //! - **Health Checker**: Custom implementation of the [`HealthCheck`](health_check::HealthCheck) trait for health monitoring.
 //! - **Routing Strategy**: Custom implementation of the [`RoutingSnapshot`](snapshot::routing_snapshot::RoutingSnapshot) trait for routing logic.
+//!
 //! Two built-in strategies are available: [`LatencyRoutingSnapshot`](snapshot::latency_based_routing::LatencyRoutingSnapshot) and [`RoundRobinRoutingSnapshot`](snapshot::round_robin_routing::RoundRobinRoutingSnapshot).
 //!
 //! # Error Handling
 //! Errors during node fetching or health checking are encapsulated in the [`DynamicRouteProviderError`](dynamic_route_provider::DynamicRouteProviderError) enum:
 //! - `NodesFetchError`: Occurs when fetching the topology fails.
 //! - `HealthCheckError`: Occurs when node health checks fail.
+//!
 //! These errors are not propagated to the caller. Instead, they are logged internally using the `tracing` crate. To capture these errors, configure a `tracing` subscriber in your application.
 //! If no healthy nodes are available, the [`route()`](super::RouteProvider::route()) method returns an [`AgentError::RouteProviderError`](super::super::agent_error::AgentError::RouteProviderError).
 //! # Testing

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # MSRV
 # Avoid updating this field unless we use new Rust features
 # Sync rust-version in workspace Cargo.toml
-channel = "1.78.0"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
# Description

- Release `0.42.0` with changes about using ic-management-canister-types in ic-utils.
- Bump MSRV from `1.78.0` to `1.85.0` as the feature `edition2024` is required during running `cargo publish`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
