### PR TITLE
chore: release v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.44.0] - 2025-08-25
+
 * BREAKING: Bump `ic-management-canister-types` to v0.4.0.
   * The `CanisterSettings` types contains a new field `environment_variables`. 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -1210,7 +1210,7 @@ dependencies = [
  "http-body-util",
  "ic-certification 3.0.2",
  "ic-ed25519",
- "ic-transport-types 0.43.0",
+ "ic-transport-types 0.44.0",
  "ic-verify-bls-signature",
  "js-sys",
  "k256",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "candid",
  "hex",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.43.0"
+version = "0.44.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
@@ -25,9 +25,9 @@ license = "Apache-2.0"
 needless_lifetimes = "allow"
 
 [workspace.dependencies]
-ic-agent = { path = "ic-agent", version = "0.43.0", default-features = false }
-ic-utils = { path = "ic-utils", version = "0.43.0" }
-ic-transport-types = { path = "ic-transport-types", version = "0.43.0" }
+ic-agent = { path = "ic-agent", version = "0.44.0", default-features = false }
+ic-utils = { path = "ic-utils", version = "0.44.0" }
+ic-transport-types = { path = "ic-transport-types", version = "0.44.0" }
 
 ic-certification = "3"
 candid = "0.10.10"


### PR DESCRIPTION
This release will enable downstream projects like icp-cli to utilize the new IC environment variables feature.