### PR TITLE
chore: Release v0.44.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.44.1] - 2025-09-15
+
 * Added `read_state_subnet_canister_ranges` which can query the canister id ranges for a given subnet.
 
 ## [0.44.0] - 2025-08-25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "arc-swap",
  "async-channel",
@@ -1210,7 +1210,7 @@ dependencies = [
  "http-body-util",
  "ic-certification 3.0.2",
  "ic-ed25519",
- "ic-transport-types 0.44.0",
+ "ic-transport-types 0.44.1",
  "ic-verify-bls-signature",
  "js-sys",
  "k256",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "candid",
  "hex",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "async-trait",
  "candid",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "anyhow",
  "candid",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.44.0"
+version = "0.44.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
@@ -25,9 +25,9 @@ license = "Apache-2.0"
 needless_lifetimes = "allow"
 
 [workspace.dependencies]
-ic-agent = { path = "ic-agent", version = "0.44.0", default-features = false }
-ic-utils = { path = "ic-utils", version = "0.44.0" }
-ic-transport-types = { path = "ic-transport-types", version = "0.44.0" }
+ic-agent = { path = "ic-agent", version = "0.44.1", default-features = false }
+ic-utils = { path = "ic-utils", version = "0.44.1" }
+ic-transport-types = { path = "ic-transport-types", version = "0.44.1" }
 
 ic-certification = "3"
 candid = "0.10.10"


### PR DESCRIPTION
# Description

Release 0.44.1 with changes about adding `read_state_subnet_canister_ranges`.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
