### PR TITLE
fix: break infinite loop on non-network error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Fix `HttpService call` retry behavior such that only network errors are retried.
+
 ## [0.44.1] - 2025-09-15
 
 * Added `read_state_subnet_canister_ranges` which can query the canister id ranges for a given subnet.
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.44.0] - 2025-08-25
 
 * BREAKING: Bump `ic-management-canister-types` to v0.4.0.
-  * The `CanisterSettings` types contains a new field `environment_variables`. 
+  * The `CanisterSettings` types contains a new field `environment_variables`.
 
 ## [0.43.0] - 2025-08-25
 

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -2111,6 +2111,10 @@ where
                         }
                         retry_count += 1;
                     }
+                    // All other errors return immediately.
+                    else {
+                        return Err(AgentError::TransportError(TransportError::Reqwest(err)));
+                    }
                 }
 
                 Ok(resp) => {


### PR DESCRIPTION
# Description

In some tests, we observed that `agent-rs` infinitely retries certain requests. This small change fixes this behavior by only retrying network issues and returning immediately for other errors.

# How Has This Been Tested?

We have a small poc with which we discovered the issue and verified that it works afterwards.

# Checklist:

- [X] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] I have edited the CHANGELOG accordingly.
- [O] I have made corresponding changes to the documentation.
