### PR TITLE
fix: Verify canister ranges for all subnets

### DIFF
--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1239,6 +1239,9 @@ impl Agent {
             .await?;
 
         let (subnet_id, subnet) = lookup_subnet(&cert, &self.root_key.read().unwrap())?;
+        if !subnet.canister_ranges.contains(canister) {
+            return Err(AgentError::CertificateNotAuthorized());
+        }
         let subnet = Arc::new(subnet);
         self.subnet_key_cache
             .lock()


### PR DESCRIPTION
Fixes SDK-2319