### PR TITLE
refactor(ic-agent)!: remove unused `subnet_id` argument from `verify_for_subnet` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* BREAKING: Remove `subnet_id` parameter from `Agent::verify_for_subnet`.
 * Fix panic in web worker environments in `ic-agent`. 
 * Update `ic-management-canister-types` to 0.5.0
 

--- a/ic-agent/src/agent/agent_test.rs
+++ b/ic-agent/src/agent/agent_test.rs
@@ -597,7 +597,7 @@ async fn too_many_delegations() {
         .expect("read state failed");
     let new_cert = self_delegate_cert(subnet_id.as_slice(), &cert, 1);
     assert!(matches!(
-        agent.verify_for_subnet(&new_cert, subnet_id).unwrap_err(),
+        agent.verify_for_subnet(&new_cert).unwrap_err(),
         AgentError::CertificateHasTooManyDelegations
     ));
 }


### PR DESCRIPTION
# Description

The `subnet_id` argument was not used in the certificate checks.

# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
