### PR TITLE
fix(ic-agent): use input subnet id to lookup subnet pubkey

### DIFF
--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -1030,7 +1030,7 @@ impl Agent {
                 self.verify_cert_for_subnet(&cert, subnet_id)?;
                 let public_key_path = [
                     "subnet".as_bytes(),
-                    delegation.subnet_id.as_ref(),
+                    subnet_id.as_ref(),
                     "public_key".as_bytes(),
                 ];
                 let pk = lookup_value(&cert.tree, public_key_path)


### PR DESCRIPTION
# Description

Uses the input subnet id to lookup the public key of the subnet in the certificate instead of the subnet id from the delegation.

Closes #678.

# How Has This Been Tested?

Same tests should still pass.

# Checklist:

- [x] The title of this PR complies with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have edited the CHANGELOG accordingly.
- [ ] I have made corresponding changes to the documentation.
