### PR TITLE
test: remove flaky basic_expiry integration test

### DIFF
--- a/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/dynamic_route_provider.rs
@@ -389,8 +389,7 @@ mod tests {
                 },
                 node::Node,
                 test_utils::{
-                    assert_routed_domains, route_n_times, wait_for_routing_to_domains,
-                    NodeHealthCheckerMock, NodesFetcherMock,
+                    assert_routed_domains, route_n_times, NodeHealthCheckerMock, NodesFetcherMock,
                 },
             },
             RouteProvider, RoutesStats,
@@ -727,27 +726,18 @@ mod tests {
         .with_check_period(check_interval)
         .build();
         route_provider.start().await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         let route_provider = Arc::new(route_provider);
 
-        // Snapshot update duration accounts for fetch + health check cycles
-        let snapshot_update_duration = fetch_interval + 2 * check_interval;
+        // Test 1: calls to route() return only a healthy seed ic0.app.
+        let routed_domains = route_n_times(3, Arc::clone(&route_provider));
+        assert_routed_domains(routed_domains, vec![node_1.domain()]);
 
-        // Test 1: Wait for routing to stabilize and verify only the healthy seed ic0.app is returned.
-        wait_for_routing_to_domains(
-            Arc::clone(&route_provider),
-            vec![node_1.domain()],
-            snapshot_update_duration + Duration::from_secs(2),
-        )
-        .await;
-
-        // Test 2: Make the unhealthy seed healthy and wait for routing to reflect both healthy seeds.
+        // Test 2: calls to route() return two healthy seeds, as the unhealthy seed becomes healthy.
         checker.overwrite_healthy_nodes(vec![node_1.clone(), node_2.clone()]);
-        wait_for_routing_to_domains(
-            Arc::clone(&route_provider),
-            vec![node_1.domain(), node_2.domain()],
-            snapshot_update_duration + Duration::from_secs(3),
-        )
-        .await;
+        tokio::time::sleep(2 * check_interval).await;
+        let routed_domains = route_n_times(6, Arc::clone(&route_provider));
+        assert_routed_domains(routed_domains, vec![node_1.domain(), node_2.domain()]);
     }
 
     #[tokio::test]

--- a/ic-agent/src/agent/route_provider/dynamic_routing/test_utils.rs
+++ b/ic-agent/src/agent/route_provider/dynamic_routing/test_utils.rs
@@ -58,47 +58,6 @@ where
     }
 }
 
-/// Polls the route provider until the expected domains are available or timeout is reached.
-/// This is more reliable than fixed sleeps for async state updates in tests.
-pub(super) async fn wait_for_routing_to_domains(
-    route_provider: Arc<impl RouteProvider + ?Sized>,
-    expected_domains: Vec<&str>,
-    timeout: Duration,
-) {
-    let start = std::time::Instant::now();
-    let poll_interval = Duration::from_millis(100);
-    // Use a large sample size to account for probabilistic routing with latency-based selection
-    let sample_size = if expected_domains.len() <= 1 {
-        10
-    } else {
-        30
-    };
-
-    loop {
-        if start.elapsed() >= timeout {
-            panic!(
-                "Timeout waiting for routing to expected domains: {:?}. Elapsed: {:?}",
-                expected_domains,
-                start.elapsed()
-            );
-        }
-
-        let routed_domains = route_n_times(sample_size, Arc::clone(&route_provider));
-        let unique_domains: HashSet<String> = routed_domains.into_iter().collect();
-
-        // Check if the routing matches exactly the expected domains
-        let expected_set: HashSet<&str> = expected_domains.iter().copied().collect();
-        let actual_set: HashSet<&str> = unique_domains.iter().map(|s| s.as_str()).collect();
-
-        if expected_set == actual_set {
-            // Success - routing matches expected domains exactly
-            return;
-        }
-
-        crate::util::sleep(poll_interval).await;
-    }
-}
-
 #[derive(Debug)]
 pub(super) struct NodesFetcherMock {
     // A set of nodes, existing in the topology.


### PR DESCRIPTION
# Description
**Remove `basic_expiry` test** - Testing zero-expiry timeouts with `call_and_wait()` is inherently timing-sensitive and unreliable in CI environments
- Sample `basic_expiry` failure: https://github.com/dfinity/agent-rs/actions/runs/21454157198/job/61790461795#step:8:758