### PR TITLE
feat: Support identity sender info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* `ic-agent`: Added `InfoAwareIdentity` and `Identity::sender_info` for setting canister-certified sender info.
+
 ## [0.47.0] - 2026-03-23
 
 * `ic-agent`: `DynamicRouteProviderBuilder::new()` and `::from_components()` now accept a `k_top_nodes: Option<usize>` parameter. Pass `Some(k)` to limit routing to the `k` nodes with the highest latency score; pass `None` to retain the existing behaviour of routing across all healthy nodes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.40.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e7706e55836e8104c98149ec0796d20d5213fef972ac01b544657d410f1883"
+checksum = "4a775244756a5d97ff19b08071a946a4b4896904e35deb036bf215e80f2e703d"
 dependencies = [
  "candid",
  "hex",
@@ -2502,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c0fe19b920be1485cdd3d58a70abfa768c2608f8349864d950791fe1a5c193"
+checksum = "e30621a12b204880522340df8327930d1b7fdefd784c9fc6093b311440fa0506"
 dependencies = [
  "backoff",
  "base64 0.13.1",
@@ -2513,12 +2513,11 @@ dependencies = [
  "hex",
  "ic-certification",
  "ic-management-canister-types 0.5.0",
- "ic-transport-types 0.40.1",
+ "ic-transport-types 0.45.0",
  "reqwest 0.12.28",
  "schemars",
  "semver",
  "serde",
- "serde_bytes",
  "serde_cbor",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ p256 = "0.13.2"
 pem = "3"
 pkcs11 = "0.5.0"
 pkcs8 = "0.10.2"
-pocket-ic = "12.0.0"
+pocket-ic = "13.0.0"
 rand = "0.10.1"
 rangemap = "1.7"
 reqwest = { version = "0.13.2", default-features = false }

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -557,6 +557,7 @@ impl Agent {
             arg,
             ingress_expiry: ingress_expiry_datetime.unwrap_or_else(|| self.get_expiry_date()),
             nonce: use_nonce.then(|| self.nonce_factory.generate()).flatten(),
+            sender_info: self.identity.sender_info(),
         })
     }
 
@@ -700,6 +701,7 @@ impl Agent {
             nonce,
             sender: self.identity.sender().map_err(AgentError::SigningError)?,
             ingress_expiry: ingress_expiry_datetime.unwrap_or_else(|| self.get_expiry_date()),
+            sender_info: self.identity.sender_info(),
         })
     }
 
@@ -1480,6 +1482,7 @@ pub fn signed_query_inspect(
             method_name: method_name_cbor,
             arg: arg_cbor,
             nonce: _nonce,
+            sender_info: _,
         } => {
             if ingress_expiry != *ingress_expiry_cbor {
                 return Err(AgentError::CallDataMismatch {
@@ -1555,6 +1558,7 @@ pub fn signed_update_inspect(
             canister_id: canister_id_cbor,
             method_name: method_name_cbor,
             arg: arg_cbor,
+            sender_info: _,
         } => {
             if ingress_expiry != *ingress_expiry_cbor {
                 return Err(AgentError::CallDataMismatch {
@@ -1847,6 +1851,7 @@ impl<'agent> QueryBuilder<'agent> {
             method_name,
             arg,
             nonce,
+            sender_info,
         } = content
         else {
             unreachable!()
@@ -1860,6 +1865,7 @@ impl<'agent> QueryBuilder<'agent> {
             effective_canister_id,
             signed_query,
             nonce,
+            sender_info,
         })
     }
 
@@ -2035,6 +2041,7 @@ impl<'agent> UpdateBuilder<'agent> {
             canister_id,
             method_name,
             arg,
+            sender_info,
         } = content
         else {
             unreachable!()
@@ -2049,6 +2056,7 @@ impl<'agent> UpdateBuilder<'agent> {
             effective_canister_id,
             signed_update,
             request_id,
+            sender_info,
         })
     }
 

--- a/ic-agent/src/identity/delegated.rs
+++ b/ic-agent/src/identity/delegated.rs
@@ -19,7 +19,8 @@ use crate::{
 use super::{error::DelegationError, Delegation, Identity, SignedDelegation};
 
 // OID for canister signatures per IC interface spec §Canister signatures: 1.3.6.1.4.1.56387.1.2
-const CANISTER_SIG_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.6.1.4.1.56387.1.2");
+pub(crate) const CANISTER_SIG_OID: ObjectIdentifier =
+    ObjectIdentifier::new_unwrap("1.3.6.1.4.1.56387.1.2");
 
 /// CBOR body of a canister signature per the IC interface spec.
 ///
@@ -149,6 +150,9 @@ impl Identity for DelegatedIdentity {
         chain.extend(self.chain.iter().cloned());
         chain
     }
+    fn sender_info(&self) -> Option<ic_transport_types::SenderInfo> {
+        self.to.sender_info()
+    }
 }
 
 /// Verify one link in the delegation chain: that `delegation` was signed by the key `from_key`.
@@ -225,7 +229,9 @@ fn verify_delegation_link(
 ///
 /// Format per the IC interface spec:
 ///   `| canister_id_length (1 byte) | canister_id_bytes | seed_bytes |`
-fn parse_canister_sig_pubkey(raw: &[u8]) -> Result<(Principal, Vec<u8>), DelegationError> {
+pub(crate) fn parse_canister_sig_pubkey(
+    raw: &[u8],
+) -> Result<(Principal, Vec<u8>), DelegationError> {
     if raw.is_empty() {
         return Err(DelegationError::Parse);
     }
@@ -322,7 +328,7 @@ fn resolve_cert_key(
 /// 1. The certificate must be valid.
 /// 2. `lookup_path(["canister", canister_id, "certified_data"], cert.tree) == reconstruct(sig.tree)`.
 /// 3. `lookup_path(["sig", sha256(seed), sha256(payload)], sig.tree) == Found("")`.
-fn verify_canister_sig(
+pub(crate) fn verify_canister_sig(
     payload: &[u8],
     sig_bytes: &[u8],
     signing_canister_id: Principal,

--- a/ic-agent/src/identity/info_aware.rs
+++ b/ic-agent/src/identity/info_aware.rs
@@ -1,0 +1,132 @@
+use candid::Principal;
+use pkcs8::{
+    der::{Decode, SliceReader},
+    spki::SubjectPublicKeyInfoRef,
+};
+
+use ic_transport_types::SenderInfo;
+
+use crate::{
+    agent::{EnvelopeContent, IC_ROOT_KEY},
+    Signature,
+};
+
+use super::{
+    delegated::{parse_canister_sig_pubkey, verify_canister_sig, CANISTER_SIG_OID},
+    error::DelegationError,
+    Delegation, Identity, SignedDelegation,
+};
+
+// Domain separator per IC interface spec §Identity attributes: \x0E (14) + "ic-sender-info"
+const SENDER_INFO_DOMAIN_SEP: &[u8; 15] = b"\x0Eic-sender-info";
+
+/// An identity wrapper that attaches canister-certified sender information to every request.
+///
+/// The inner identity's public key must be a canister signature key (OID 1.3.6.1.4.1.56387.1.2).
+/// `sig` must be a canister signature over `\x0Eic-sender-info || info` using that same key.
+pub struct InfoAwareIdentity<I: Identity> {
+    inner: I,
+    info: Vec<u8>,
+    signer: Principal,
+    sig: Vec<u8>,
+}
+
+impl<I: Identity> InfoAwareIdentity<I> {
+    /// Wraps `inner` and attaches `info`/`sig` as certified sender information.
+    ///
+    /// Verifies the canister signature against the IC mainnet root key.
+    /// `inner` must have a canister signature public key.
+    pub fn new(inner: I, info: Vec<u8>, sig: Vec<u8>) -> Result<Self, DelegationError> {
+        Self::new_impl(inner, info, sig, IC_ROOT_KEY)
+    }
+
+    /// Like [`new`](Self::new), but verifies against a custom root key (e.g. local replica or testnet).
+    pub fn new_with_root_key(
+        inner: I,
+        info: Vec<u8>,
+        sig: Vec<u8>,
+        root_key: &[u8],
+    ) -> Result<Self, DelegationError> {
+        Self::new_impl(inner, info, sig, root_key)
+    }
+
+    /// Like [`new`](Self::new), but skips cryptographic verification of the canister signature.
+    ///
+    /// The replica will still reject an invalid signature. The signer principal is still parsed
+    /// from the inner identity's public key.
+    pub fn new_unchecked(inner: I, info: Vec<u8>, sig: Vec<u8>) -> Result<Self, DelegationError> {
+        let (signer, _seed) = parse_canister_pubkey(&inner)?;
+        Ok(Self {
+            inner,
+            info,
+            signer,
+            sig,
+        })
+    }
+
+    fn new_impl(
+        inner: I,
+        info: Vec<u8>,
+        sig: Vec<u8>,
+        root_key: &[u8],
+    ) -> Result<Self, DelegationError> {
+        let (signer, seed) = parse_canister_pubkey(&inner)?;
+        let mut payload = Vec::with_capacity(SENDER_INFO_DOMAIN_SEP.len() + info.len());
+        payload.extend_from_slice(SENDER_INFO_DOMAIN_SEP);
+        payload.extend_from_slice(&info);
+        verify_canister_sig(&payload, &sig, signer, &seed, root_key)?;
+        Ok(Self {
+            inner,
+            info,
+            signer,
+            sig,
+        })
+    }
+}
+
+/// Parse the inner identity's public key as a canister sig SPKI, returning (canister_id, seed).
+fn parse_canister_pubkey<I: Identity>(inner: &I) -> Result<(Principal, Vec<u8>), DelegationError> {
+    let pubkey = inner.public_key().ok_or(DelegationError::Parse)?;
+    let spki = SubjectPublicKeyInfoRef::decode(
+        &mut SliceReader::new(&pubkey).map_err(|_| DelegationError::Parse)?,
+    )
+    .map_err(|_| DelegationError::Parse)?;
+    if spki.algorithm.oid != CANISTER_SIG_OID {
+        return Err(DelegationError::UnknownAlgorithm);
+    }
+    parse_canister_sig_pubkey(spki.subject_public_key.raw_bytes())
+}
+
+impl<I: Identity> Identity for InfoAwareIdentity<I> {
+    fn sender(&self) -> Result<Principal, String> {
+        self.inner.sender()
+    }
+
+    fn public_key(&self) -> Option<Vec<u8>> {
+        self.inner.public_key()
+    }
+
+    fn sign(&self, content: &EnvelopeContent) -> Result<Signature, String> {
+        self.inner.sign(content)
+    }
+
+    fn sign_delegation(&self, content: &Delegation) -> Result<Signature, String> {
+        self.inner.sign_delegation(content)
+    }
+
+    fn sign_arbitrary(&self, content: &[u8]) -> Result<Signature, String> {
+        self.inner.sign_arbitrary(content)
+    }
+
+    fn delegation_chain(&self) -> Vec<SignedDelegation> {
+        self.inner.delegation_chain()
+    }
+
+    fn sender_info(&self) -> Option<SenderInfo> {
+        Some(SenderInfo {
+            info: self.info.clone(),
+            signer: self.signer.as_slice().to_vec(),
+            sig: self.sig.clone(),
+        })
+    }
+}

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod anonymous;
 pub(crate) mod basic;
 pub(crate) mod delegated;
 pub(crate) mod error;
+pub(crate) mod info_aware;
 pub(crate) mod prime256v1;
 pub(crate) mod secp256k1;
 
@@ -19,7 +20,9 @@ pub use delegated::DelegatedIdentity;
 #[doc(inline)]
 pub use error::DelegationError;
 #[doc(inline)]
-pub use ic_transport_types::{Delegation, SignedDelegation};
+pub use ic_transport_types::{Delegation, SenderInfo, SignedDelegation};
+#[doc(inline)]
+pub use info_aware::InfoAwareIdentity;
 #[doc(inline)]
 pub use prime256v1::Prime256v1Identity;
 #[doc(inline)]
@@ -84,6 +87,13 @@ pub trait Identity: Send + Sync {
     fn delegation_chain(&self) -> Vec<SignedDelegation> {
         vec![]
     }
+
+    /// Returns canister-certified sender information to include in the request envelope, or `None`.
+    ///
+    /// Only implemented by [`InfoAwareIdentity`].
+    fn sender_info(&self) -> Option<SenderInfo> {
+        None
+    }
 }
 
 macro_rules! delegating_impl {
@@ -111,6 +121,10 @@ macro_rules! delegating_impl {
 
             fn delegation_chain(&$name) -> Vec<SignedDelegation> {
                 $self_expr.delegation_chain()
+            }
+
+            fn sender_info(&$name) -> Option<SenderInfo> {
+                $self_expr.sender_info()
             }
         }
     };

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -90,7 +90,7 @@ pub trait Identity: Send + Sync {
 
     /// Returns canister-certified sender information to include in the request envelope, or `None`.
     ///
-    /// Only implemented by [`InfoAwareIdentity`].
+    /// See [`InfoAwareIdentity`].
     fn sender_info(&self) -> Option<SenderInfo> {
         None
     }

--- a/ic-agent/src/identity/prime256v1.rs
+++ b/ic-agent/src/identity/prime256v1.rs
@@ -251,6 +251,7 @@ VwidXc26G4+/g7dUbMwbN4E3d3bpxHEP31M+2by6jY67MqFKKroR
             canister_id: "bkyz2-fmaaa-aaaaa-qaaaq-cai".parse().unwrap(),
             method_name: "greet".to_string(),
             arg: Encode!(&"world").unwrap(),
+            sender_info: None,
         };
         let signature = identity
             .sign(&message)

--- a/ic-agent/src/identity/secp256k1.rs
+++ b/ic-agent/src/identity/secp256k1.rs
@@ -249,6 +249,7 @@ FRL8jv/6Kmy74w/LB+cEUhlKSzjEZsD9ltrOysyXi/jjpTlQhXEIYZor
             canister_id: "bkyz2-fmaaa-aaaaa-qaaaq-cai".parse().unwrap(),
             method_name: "greet".to_string(),
             arg: Encode!(&"world").unwrap(),
+            sender_info: None,
         };
         let signature = identity
             .sign(&message)

--- a/ic-transport-types/src/lib.rs
+++ b/ic-transport-types/src/lib.rs
@@ -16,6 +16,23 @@ use thiserror::Error;
 mod request_id;
 pub mod signed;
 
+/// Canister-certified sender information attached to a request envelope.
+///
+/// `sig` must be a canister signature (domain separator `\x0Eic-sender-info`) over the `info`
+/// field, verifiable using the envelope's `sender_pubkey` as the canister sig public key.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SenderInfo {
+    /// The sender information to be passed to the canister.
+    #[serde(with = "serde_bytes")]
+    pub info: Vec<u8>,
+    /// The principal (as raw bytes) of the canister that signed the info.
+    #[serde(with = "serde_bytes")]
+    pub signer: Vec<u8>,
+    /// A canister signature over `\x0Eic-sender-info || info`.
+    #[serde(with = "serde_bytes")]
+    pub sig: Vec<u8>,
+}
+
 /// The authentication envelope, containing the contents and their signature. This struct can be passed to `Agent`'s
 /// `*_signed` methods via [`encode_bytes`](Envelope::encode_bytes).
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -66,6 +83,9 @@ pub enum EnvelopeContent {
         /// The argument to pass to the canister method.
         #[serde(with = "serde_bytes")]
         arg: Vec<u8>,
+        /// Canister-certified sender information. See [`SenderInfo`].
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sender_info: Option<SenderInfo>,
     },
     /// A request for information from the [IC state tree](https://internetcomputer.org/docs/current/references/ic-interface-spec#state-tree).
     ReadState {
@@ -92,6 +112,9 @@ pub enum EnvelopeContent {
         /// A random series of bytes to uniquely identify this message.
         #[serde(default, skip_serializing_if = "Option::is_none", with = "serde_bytes")]
         nonce: Option<Vec<u8>>,
+        /// Canister-certified sender information. See [`SenderInfo`].
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sender_info: Option<SenderInfo>,
     },
 }
 

--- a/ic-transport-types/src/signed.rs
+++ b/ic-transport-types/src/signed.rs
@@ -1,6 +1,6 @@
 //! Types representing signed messages.
 
-use crate::request_id::RequestId;
+use crate::{request_id::RequestId, SenderInfo};
 use candid::Principal;
 use serde::{Deserialize, Serialize};
 
@@ -32,6 +32,9 @@ pub struct SignedQuery {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "serde_bytes")]
     pub nonce: Option<Vec<u8>>,
+    /// Canister-certified sender information included in the request content.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_info: Option<SenderInfo>,
 }
 
 /// A signed update request message. Produced by
@@ -64,6 +67,9 @@ pub struct SignedUpdate {
     pub signed_update: Vec<u8>,
     /// The request ID.
     pub request_id: RequestId,
+    /// Canister-certified sender information included in the request content.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_info: Option<SenderInfo>,
 }
 
 /// A signed request-status request message. Produced by
@@ -102,6 +108,7 @@ mod tests {
             effective_canister_id: Principal::management_canister(),
             signed_query: vec![0, 1, 2, 3],
             nonce: None,
+            sender_info: None,
         };
         let serialized = serde_json::to_string(&query).unwrap();
         let deserialized = serde_json::from_str::<SignedQuery>(&serialized);
@@ -120,6 +127,7 @@ mod tests {
             effective_canister_id: Principal::management_canister(),
             signed_update: vec![0, 1, 2, 3],
             request_id: RequestId::new(&[0; 32]),
+            sender_info: None,
         };
         let serialized = serde_json::to_string(&update).unwrap();
         let deserialized = serde_json::from_str::<SignedUpdate>(&serialized);

--- a/ref-tests/src/universal_canister.rs
+++ b/ref-tests/src/universal_canister.rs
@@ -107,6 +107,8 @@ enum Ops {
     SetOnLowWasmMemoryMethod = 95,
     WasmMemoryGrow = 96,
     CostHttpRequestV2 = 97,
+    MsgCallerInfoData = 98,
+    MsgCallerInfoSigner = 99,
 }
 
 /// A succinct shortcut for creating a `PayloadBuilder`, which is used to encode
@@ -270,6 +272,16 @@ impl PayloadBuilder {
     /// Pop offset (i32) and size (i32), push the corresponding slice of the caller blob.
     pub fn msg_caller_copy(self) -> Self {
         self.op(Ops::MsgCallerCopy)
+    }
+
+    /// Push the caller info data blob (ic0.msg_caller_info_data_*).
+    pub fn msg_caller_info_data(self) -> Self {
+        self.op(Ops::MsgCallerInfoData)
+    }
+
+    /// Push the caller info signer blob (ic0.msg_caller_info_signer_*).
+    pub fn msg_caller_info_signer(self) -> Self {
+        self.op(Ops::MsgCallerInfoSigner)
     }
 
     /// Push the reject message size.

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -55,6 +55,7 @@ async fn wait_signed() {
             nonce: None,
             canister_id,
             method_name: "update".to_string(),
+            sender_info: None,
         };
 
         let call_request_id = call_envelope_content.to_request_id();

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -878,4 +878,132 @@ mod identity {
         })
         .await
     }
+
+    #[tokio::test]
+    async fn sender_info_via_canister_sig() {
+        use ic_agent::identity::InfoAwareIdentity;
+        use ic_certification::{fork, labeled, leaf};
+        use sha2::{Digest, Sha256};
+
+        with_universal_canister(async |pic, agent, canister_id| {
+            let root_key = agent
+                .status()
+                .await?
+                .root_key
+                .expect("root_key should be present in status");
+
+            // The seed identifies this key slot within the canister. A single seed is reused for
+            // both the delegation signature and the sender info signature — the combined tree
+            // covers both message hashes under the same seed hash.
+            let seed: &[u8] = b"sender-info-test";
+            let from_key = canister_sig_pubkey_der(canister_id, seed);
+
+            let signing_identity = create_basic_identity();
+
+            let delegation = Delegation {
+                pubkey: signing_identity.public_key().unwrap(),
+                expiration: i64::MAX as u64,
+                targets: None,
+            };
+
+            // Compute hash of the delegation message.
+            let deleg_msg = delegation.signable();
+            let seed_hash: [u8; 32] = Sha256::digest(seed).into();
+            let deleg_hash: [u8; 32] = Sha256::digest(&deleg_msg).into();
+
+            // Compute hash of the sender info payload: domain_sep || b"test".
+            let sender_info_data: &[u8] = b"test";
+            let mut sender_info_payload =
+                Vec::with_capacity(b"\x0Eic-sender-info".len() + sender_info_data.len());
+            sender_info_payload.extend_from_slice(b"\x0Eic-sender-info");
+            sender_info_payload.extend_from_slice(sender_info_data);
+            let sender_info_hash: [u8; 32] = Sha256::digest(&sender_info_payload).into();
+
+            // Build a combined signature tree covering both messages under the same seed.
+            // The certified_data is the digest of this tree; the same CBOR envelope is valid
+            // for both the delegation lookup and the sender info lookup.
+            //
+            // Hash tree lookup assumes sorted label order within a fork, so put the
+            // lexicographically smaller hash on the left.
+            let (left_hash, right_hash): (&[u8], &[u8]) = if deleg_hash <= sender_info_hash {
+                (&deleg_hash, &sender_info_hash)
+            } else {
+                (&sender_info_hash, &deleg_hash)
+            };
+            let sig_tree = labeled(
+                "sig",
+                labeled(
+                    seed_hash.as_ref(),
+                    fork(
+                        labeled(left_hash, leaf(vec![])),
+                        labeled(right_hash, leaf(vec![])),
+                    ),
+                ),
+            );
+
+            agent
+                .update(&canister_id, "update")
+                .with_arg(
+                    payload()
+                        .push_bytes(&sig_tree.digest())
+                        .certified_data_set()
+                        .reply()
+                        .build(),
+                )
+                .call_and_wait()
+                .await?;
+
+            let data_cert_bytes = agent
+                .query(&canister_id, "query")
+                .with_arg(payload().data_certificate().append_and_reply().build())
+                .call()
+                .await?;
+
+            let mut canister_sig = vec![0xd9u8, 0xd9, 0xf7];
+            serde_cbor::to_writer(
+                &mut canister_sig,
+                &CanisterSigEnvelope {
+                    certificate: &data_cert_bytes,
+                    tree: &sig_tree,
+                },
+            )?;
+
+            // The delegated identity presents the canister sig key as its public key; the inner
+            // signing_identity actually signs envelopes via the delegation chain.
+            let delegated_identity = DelegatedIdentity::new_with_root_key(
+                from_key,
+                Box::new(signing_identity),
+                vec![SignedDelegation {
+                    delegation,
+                    signature: canister_sig.clone(),
+                }],
+                &root_key,
+            )
+            .expect("canister signature delegation chain should be valid");
+
+            // Wrap the delegated identity so every request carries certified sender info.
+            // The same canister_sig is valid for the sender info lookup in the combined tree.
+            let info_identity = InfoAwareIdentity::new_with_root_key(
+                delegated_identity,
+                sender_info_data.to_vec(),
+                canister_sig,
+                &root_key,
+            )
+            .expect("sender info canister signature should be valid");
+
+            let info_agent = create_agent(pic, info_identity).await?;
+
+            // The UC reads the caller's sender info data blob and returns it in the reply.
+            let resp = info_agent
+                .query(&canister_id, "query")
+                .with_arg(payload().msg_caller_info_data().append_and_reply().build())
+                .call()
+                .await?;
+
+            assert_eq!(resp, sender_info_data);
+
+            Ok(())
+        })
+        .await
+    }
 }

--- a/scripts/download_reftest_assets.sh
+++ b/scripts/download_reftest_assets.sh
@@ -2,9 +2,9 @@
 set -e
 cd "$(dirname "$0")/.."
 
-# release-2026-03-02_11-09-base
-ic_commit_for_pic=781ef50bd6bfbcfac6769b55361d0624247009c1
-ic_commit_for_universal_canister=781ef50bd6bfbcfac6769b55361d0624247009c1
+# release-2026-04-16_04-20-base
+ic_commit_for_pic=719ff387aab462ce5759c4c20c30de959fe9538c
+ic_commit_for_universal_canister=719ff387aab462ce5759c4c20c30de959fe9538c
 wallet_ver=20230530
 
 case $(uname -s) in


### PR DESCRIPTION
Adds support for the `sender_info` API in ingress messages. The user point of entry is a new `InfoAwareIdentity` wrapper type which implements a new `Identity::sender_info` method.