### PR TITLE
chore: release 0.47.3 — subnet-scoped create_canister + EffectiveId routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.47.3] - 2026-05-15
 
-* `ic-agent`: Added subnet-scoped HTTP API methods on `Agent` for routing signed calls via effective subnet id: `update_signed_subnet`, `request_status_signed_subnet`, and `wait_signed_subnet`. These target the `/api/v4/subnet/<subnet_id>/call` and `/api/v3/subnet/<subnet_id>/read_state` endpoints introduced in IC interface spec 0.60.0.
+* `ic-agent`: Added the `EffectiveId` enum (`Canister(Principal)` | `Subnet(Principal)`) and widened `Agent::update_signed`, `query_signed`, `request_status_signed`, `request_status_raw`, `wait`, `wait_signed`, `read_state_raw`, `verify`, and `sign_request_status` to accept `impl Into<EffectiveId>`. Passing a bare `Principal` is unchanged (treated as `EffectiveId::Canister(_)`); passing `EffectiveId::Subnet(_)` routes to the subnet-scoped HTTP endpoints (`/api/v4/subnet/<id>/call`, `/api/v3/subnet/<id>/read_state`, `/api/v3/subnet/<id>/query`) introduced in IC interface spec 0.60.0.
 * `ic-agent`: Renamed the `effective_canister_id` argument of `sign_request_status` to `effective_id` to reflect that it can hold either an effective canister id or an effective subnet id. `SignedRequestStatus::effective_canister_id` is unchanged but its documentation now notes the same.
 * `ic-utils`: Added `CreateCanisterBuilder::with_effective_subnet_id` so subnet administrators can route `create_canister` calls to a specific subnet via the subnet-scoped management-canister endpoints.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.47.3] - 2026-05-14
+## [0.47.3] - 2026-05-15
 
 * `ic-agent`: Added subnet-scoped HTTP API methods on `Agent` for routing signed calls via effective subnet id: `update_signed_subnet`, `request_status_signed_subnet`, and `wait_signed_subnet`. These target the `/api/v4/subnet/<subnet_id>/call` and `/api/v3/subnet/<subnet_id>/read_state` endpoints introduced in IC interface spec 0.60.0.
 * `ic-agent`: Renamed the `effective_canister_id` argument of `sign_request_status` to `effective_id` to reflect that it can hold either an effective canister id or an effective subnet id. `SignedRequestStatus::effective_canister_id` is unchanged but its documentation now notes the same.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.47.3] - 2026-05-14
+
 * `ic-agent`: Added subnet-scoped HTTP API methods on `Agent` for routing signed calls via effective subnet id: `update_signed_subnet`, `request_status_signed_subnet`, and `wait_signed_subnet`. These target the `/api/v4/subnet/<subnet_id>/call` and `/api/v3/subnet/<subnet_id>/read_state` endpoints introduced in IC interface spec 0.60.0.
 * `ic-agent`: Renamed the `effective_canister_id` argument of `sign_request_status` to `effective_id` to reflect that it can hold either an effective canister id or an effective subnet id. `SignedRequestStatus::effective_canister_id` is unchanged but its documentation now notes the same.
 * `ic-utils`: Added `CreateCanisterBuilder::with_effective_subnet_id` so subnet administrators can route `create_canister` calls to a specific subnet via the subnet-scoped management-canister endpoints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* `ic-agent`: Added subnet-scoped HTTP API methods on `Agent` for routing signed calls via effective subnet id: `update_signed_subnet`, `request_status_signed_subnet`, and `wait_signed_subnet`. These target the `/api/v4/subnet/<subnet_id>/call` and `/api/v3/subnet/<subnet_id>/read_state` endpoints introduced in IC interface spec 0.60.0.
+* `ic-agent`: Renamed the `effective_canister_id` argument of `sign_request_status` to `effective_id` to reflect that it can hold either an effective canister id or an effective subnet id. `SignedRequestStatus::effective_canister_id` is unchanged but its documentation now notes the same.
+* `ic-utils`: Added `CreateCanisterBuilder::with_effective_subnet_id` so subnet administrators can route `create_canister` calls to a specific subnet via the subnet-scoped management-canister endpoints.
+
 ## [0.47.2] - 2026-04-22
 
 * `ic-agent`: Added `InfoAwareIdentity` and `Identity::sender_info` for setting canister-certified sender info.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,7 @@ dependencies = [
  "ic-agent",
  "ic-utils",
  "ic-utils-bindgen",
- "pocket-ic 13.0.0 (git+https://github.com/dfinity/ic?rev=62e841d27ea12451f504e74c54843b7cbf93ca4d)",
+ "pocket-ic 13.0.0 (git+https://github.com/dfinity/ic?rev=17524c56ef237c54b510a201ceb58da8d790d4d5)",
  "ref-tests",
  "serde",
  "tokio",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "pocket-ic"
 version = "13.0.0"
-source = "git+https://github.com/dfinity/ic?rev=62e841d27ea12451f504e74c54843b7cbf93ca4d#62e841d27ea12451f504e74c54843b7cbf93ca4d"
+source = "git+https://github.com/dfinity/ic?rev=17524c56ef237c54b510a201ceb58da8d790d4d5#17524c56ef237c54b510a201ceb58da8d790d4d5"
 dependencies = [
  "backoff",
  "base64 0.13.1",
@@ -2836,7 +2836,7 @@ dependencies = [
  "ic-utils",
  "k256",
  "p256",
- "pocket-ic 13.0.0 (git+https://github.com/dfinity/ic?rev=62e841d27ea12451f504e74c54843b7cbf93ca4d)",
+ "pocket-ic 13.0.0 (git+https://github.com/dfinity/ic?rev=17524c56ef237c54b510a201ceb58da8d790d4d5)",
  "rand 0.10.1",
  "serde",
  "serde_bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1436,7 +1436,7 @@ dependencies = [
  "http-body-util",
  "ic-certification",
  "ic-ed25519",
- "ic-transport-types 0.47.2",
+ "ic-transport-types 0.47.3",
  "ic-verify-bls-signature",
  "ic_principal",
  "js-sys",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "candid",
  "hex",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "async-trait",
  "candid",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "candid",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,7 @@ dependencies = [
  "ic-agent",
  "ic-utils",
  "ic-utils-bindgen",
- "pocket-ic",
+ "pocket-ic 13.0.0 (git+https://github.com/dfinity/ic?rev=62e841d27ea12451f504e74c54843b7cbf93ca4d)",
  "ref-tests",
  "serde",
  "tokio",
@@ -1753,7 +1753,7 @@ dependencies = [
  "ic-agent",
  "ic-ed25519",
  "ic-utils",
- "pocket-ic",
+ "pocket-ic 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_json",
  "tokio",
@@ -2534,6 +2534,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocket-ic"
+version = "13.0.0"
+source = "git+https://github.com/dfinity/ic?rev=62e841d27ea12451f504e74c54843b7cbf93ca4d#62e841d27ea12451f504e74c54843b7cbf93ca4d"
+dependencies = [
+ "backoff",
+ "base64 0.13.1",
+ "candid",
+ "flate2",
+ "hex",
+ "ic-certification",
+ "ic-management-canister-types 0.5.0",
+ "ic-transport-types 0.45.0",
+ "reqwest 0.12.28",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.9",
+ "slog",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "wslpath",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2804,7 +2836,7 @@ dependencies = [
  "ic-utils",
  "k256",
  "p256",
- "pocket-ic",
+ "pocket-ic 13.0.0 (git+https://github.com/dfinity/ic?rev=62e841d27ea12451f504e74c54843b7cbf93ca4d)",
  "rand 0.10.1",
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.47.2"
+version = "0.47.3"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
@@ -30,10 +30,10 @@ license = "Apache-2.0"
 #   a comment listing those crates). Otherwise, features are declared in the individual crate Cargo.toml.
 #
 # The path dependencies below ensure all workspace members use the same version of internal crates.
-ic-agent = { path = "ic-agent", version = "0.47.2", default-features = false }
-ic-identity-hsm = { path = "ic-identity-hsm", version = "0.47.2" }
-ic-transport-types = { path = "ic-transport-types", version = "0.47.2" }
-ic-utils = { path = "ic-utils", version = "0.47.2" }
+ic-agent = { path = "ic-agent", version = "0.47.3", default-features = false }
+ic-identity-hsm = { path = "ic-identity-hsm", version = "0.47.3" }
+ic-transport-types = { path = "ic-transport-types", version = "0.47.3" }
+ic-utils = { path = "ic-utils", version = "0.47.3" }
 ic-utils-bindgen = { path = "ic-utils-bindgen" }
 ref-tests = { path = "ref-tests" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,14 @@ p256 = "0.13.2"
 pem = "3"
 pkcs11 = "0.5.0"
 pkcs8 = "0.10.2"
-pocket-ic = "13.0.0"
+# Used by integration tests (ref-tests, ic-utils-bindgen-tests) only. The git
+# rev is pinned to the same IC commit as the pocket-ic server binary downloaded
+# by scripts/download_reftest_assets.sh, so the client lib and server stay in
+# sync. Do NOT use this workspace entry from any crate that is published to
+# crates.io — crates.io rejects packages with git dependencies. Published
+# crates that need pocket-ic must depend on a released version directly (see
+# icx/Cargo.toml).
+pocket-ic = { git = "https://github.com/dfinity/ic", rev = "62e841d27ea12451f504e74c54843b7cbf93ca4d" } # release-2026-05-07_04-27-base
 rand = "0.10.1"
 rangemap = "1.7"
 reqwest = { version = "0.13.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ pkcs8 = "0.10.2"
 # crates.io — crates.io rejects packages with git dependencies. Published
 # crates that need pocket-ic must depend on a released version directly (see
 # icx/Cargo.toml).
-pocket-ic = { git = "https://github.com/dfinity/ic", rev = "62e841d27ea12451f504e74c54843b7cbf93ca4d" } # release-2026-05-07_04-27-base
+pocket-ic = { git = "https://github.com/dfinity/ic", rev = "17524c56ef237c54b510a201ceb58da8d790d4d5" } # https://github.com/dfinity/ic/pull/10226
 rand = "0.10.1"
 rangemap = "1.7"
 reqwest = { version = "0.13.2", default-features = false }

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -381,6 +381,24 @@ impl Agent {
         serde_cbor::from_slice(&response_body).map_err(AgentError::InvalidCborData)
     }
 
+    async fn call_subnet_endpoint(
+        &self,
+        subnet_id: Principal,
+        serialized_bytes: Vec<u8>,
+    ) -> Result<TransportCallResponse, AgentError> {
+        let _permit = self.concurrent_requests_semaphore.acquire().await;
+        let endpoint = format!("api/v4/subnet/{}/call", subnet_id.to_text());
+        let (status_code, response_body) = self
+            .execute(Method::POST, &endpoint, Some(serialized_bytes))
+            .await?;
+
+        if status_code == StatusCode::ACCEPTED {
+            return Ok(TransportCallResponse::Accepted);
+        }
+
+        serde_cbor::from_slice(&response_body).map_err(AgentError::InvalidCborData)
+    }
+
     /// The simplest way to do a query call; sends a byte array and will return a byte vector.
     /// The encoding is left as an exercise to the user.
     #[allow(clippy::too_many_arguments)]
@@ -686,6 +704,73 @@ impl Agent {
         }
     }
 
+    /// Send the signed update to the subnet-scoped call endpoint (`/api/v4/subnet/<subnet_id>/call`).
+    /// Sibling of [`update_signed`](Self::update_signed); use this when routing via an effective
+    /// subnet id. Per the [interface spec], this endpoint only accepts canister creation calls to
+    /// the Management Canister.
+    ///
+    /// [interface spec]: https://internetcomputer.org/docs/current/references/ic-interface-spec#http-effective-subnet-id
+    pub async fn update_signed_subnet(
+        &self,
+        subnet_id: Principal,
+        signed_update: Vec<u8>,
+    ) -> Result<CallResponse<Vec<u8>>, AgentError> {
+        let envelope: Envelope =
+            serde_cbor::from_slice(&signed_update).map_err(AgentError::InvalidCborData)?;
+        let EnvelopeContent::Call {
+            canister_id,
+            method_name,
+            ..
+        } = &*envelope.content
+        else {
+            return Err(AgentError::CallDataMismatch {
+                field: "request_type".to_string(),
+                value_arg: "update".to_string(),
+                value_cbor: if matches!(*envelope.content, EnvelopeContent::Query { .. }) {
+                    "query"
+                } else {
+                    "read_state"
+                }
+                .to_string(),
+            });
+        };
+        let operation = Some(Operation::Call {
+            canister: *canister_id,
+            method: method_name.clone(),
+        });
+        let request_id = to_request_id(&envelope.content)?;
+
+        let response_body = self.call_subnet_endpoint(subnet_id, signed_update).await?;
+
+        match response_body {
+            TransportCallResponse::Replied { certificate } => {
+                let certificate =
+                    serde_cbor::from_slice(&certificate).map_err(AgentError::InvalidCborData)?;
+
+                self.verify_for_subnet(&certificate, subnet_id)?;
+                let status = lookup_request_status(&certificate, &request_id)?;
+
+                match status {
+                    RequestStatusResponse::Replied(reply) => Ok(CallResponse::Response(reply.arg)),
+                    RequestStatusResponse::Rejected(reject_response) => {
+                        Err(AgentError::CertifiedReject {
+                            reject: reject_response,
+                            operation,
+                        })?
+                    }
+                    _ => Ok(CallResponse::Poll(request_id)),
+                }
+            }
+            TransportCallResponse::Accepted => Ok(CallResponse::Poll(request_id)),
+            TransportCallResponse::NonReplicatedRejection(reject_response) => {
+                Err(AgentError::UncertifiedReject {
+                    reject: reject_response,
+                    operation,
+                })
+            }
+        }
+    }
+
     fn update_content(
         &self,
         canister_id: Principal,
@@ -735,6 +820,65 @@ impl Agent {
             match resp {
                 RequestStatusResponse::Unknown => {
                     // If status is still `Unknown` after 5 minutes, the ingress message is lost.
+                    if retry_policy.get_elapsed_time() > Duration::from_secs(5 * 60) {
+                        return Err(AgentError::TimeoutWaitingForResponse());
+                    }
+                }
+
+                RequestStatusResponse::Received | RequestStatusResponse::Processing => {
+                    if !request_accepted {
+                        retry_policy.reset();
+                        request_accepted = true;
+                    }
+                }
+
+                RequestStatusResponse::Replied(ReplyResponse { arg, .. }) => {
+                    return Ok((arg, cert))
+                }
+
+                RequestStatusResponse::Rejected(response) => {
+                    return Err(AgentError::CertifiedReject {
+                        reject: response,
+                        operation: None,
+                    })
+                }
+
+                RequestStatusResponse::Done => {
+                    return Err(AgentError::RequestStatusDoneNoReply(String::from(
+                        *request_id,
+                    )))
+                }
+            };
+
+            match retry_policy.next_backoff() {
+                Some(duration) => crate::util::sleep(duration).await,
+
+                None => return Err(AgentError::TimeoutWaitingForResponse()),
+            }
+        }
+    }
+
+    /// Sibling of [`wait_signed`](Self::wait_signed) that polls the subnet-scoped
+    /// read_state endpoint (`/api/v3/subnet/<subnet_id>/read_state`).
+    pub async fn wait_signed_subnet(
+        &self,
+        request_id: &RequestId,
+        subnet_id: Principal,
+        signed_request_status: Vec<u8>,
+    ) -> Result<(Vec<u8>, Certificate), AgentError> {
+        let mut retry_policy = self.get_retry_policy();
+
+        let mut request_accepted = false;
+        loop {
+            let (resp, cert) = self
+                .request_status_signed_subnet(
+                    request_id,
+                    subnet_id,
+                    signed_request_status.clone(),
+                )
+                .await?;
+            match resp {
+                RequestStatusResponse::Unknown => {
                     if retry_policy.get_elapsed_time() > Duration::from_secs(5 * 60) {
                         return Err(AgentError::TimeoutWaitingForResponse());
                     }
@@ -1190,6 +1334,27 @@ impl Agent {
         Ok((lookup_request_status(&cert, request_id)?, cert))
     }
 
+    /// Sibling of [`request_status_signed`](Self::request_status_signed) that reads from the
+    /// subnet-scoped endpoint (`/api/v3/subnet/<subnet_id>/read_state`). The returned certificate
+    /// is verified against `subnet_id` rather than against canister range membership.
+    pub async fn request_status_signed_subnet(
+        &self,
+        request_id: &RequestId,
+        subnet_id: Principal,
+        signed_request_status: Vec<u8>,
+    ) -> Result<(RequestStatusResponse, Certificate), AgentError> {
+        let _envelope: Envelope =
+            serde_cbor::from_slice(&signed_request_status).map_err(AgentError::InvalidCborData)?;
+        let read_state_response: ReadStateResponse = self
+            .read_subnet_state_endpoint(subnet_id, signed_request_status)
+            .await?;
+
+        let cert: Certificate = serde_cbor::from_slice(&read_state_response.certificate)
+            .map_err(AgentError::InvalidCborData)?;
+        self.verify_for_subnet(&cert, subnet_id)?;
+        Ok((lookup_request_status(&cert, request_id)?, cert))
+    }
+
     /// Returns an `UpdateBuilder` enabling the construction of an update call without
     /// passing all arguments.
     pub fn update<S: Into<String>>(
@@ -1222,10 +1387,13 @@ impl Agent {
     }
 
     /// Sign a `request_status` call. This will return a [`signed::SignedRequestStatus`]
-    /// which contains all fields of the `request_status` and the signed `request_status` in CBOR encoding
+    /// which contains all fields of the `request_status` and the signed `request_status` in CBOR encoding.
+    ///
+    /// `effective_id` may be either an effective canister ID or an effective subnet ID,
+    /// depending on which endpoint the caller will submit the signed message to.
     pub fn sign_request_status(
         &self,
-        effective_canister_id: Principal,
+        effective_id: Principal,
         request_id: RequestId,
     ) -> Result<SignedRequestStatus, AgentError> {
         let paths: Vec<Vec<Label>> =
@@ -1237,7 +1405,7 @@ impl Agent {
         Ok(SignedRequestStatus {
             ingress_expiry,
             sender,
-            effective_canister_id,
+            effective_canister_id: effective_id,
             request_id,
             signed_request_status,
         })

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -76,6 +76,42 @@ use std::{
 
 use crate::agent::response_authentication::lookup_api_boundary_nodes;
 
+/// The effective ID that routes a request to a particular endpoint shape.
+///
+/// Most calls target a canister and are routed via an
+/// [effective canister id](https://internetcomputer.org/docs/current/references/ic-interface-spec#http-effective-canister-id).
+/// A small set of management-canister calls (currently `create_canister`,
+/// `provisional_create_canister_with_cycles`, and `list_canisters`) are instead
+/// routed via an [effective subnet id](https://internetcomputer.org/docs/current/references/ic-interface-spec#http-effective-subnet-id),
+/// targeting the subnet-scoped HTTP endpoints (`/api/v4/subnet/<id>/call`,
+/// `/api/v3/subnet/<id>/read_state`, `/api/v3/subnet/<id>/query`).
+///
+/// `Principal` converts into `EffectiveId::Canister(_)`, so passing a bare
+/// `Principal` to APIs that accept `impl Into<EffectiveId>` preserves the
+/// canister-scoped behavior of earlier `ic-agent` releases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EffectiveId {
+    /// An effective canister id. The request is routed to the canister-scoped HTTP endpoints.
+    Canister(Principal),
+    /// An effective subnet id. The request is routed to the subnet-scoped HTTP endpoints.
+    Subnet(Principal),
+}
+
+impl EffectiveId {
+    /// Returns the underlying principal regardless of variant.
+    pub fn as_principal(&self) -> Principal {
+        match self {
+            EffectiveId::Canister(p) | EffectiveId::Subnet(p) => *p,
+        }
+    }
+}
+
+impl From<Principal> for EffectiveId {
+    fn from(p: Principal) -> Self {
+        EffectiveId::Canister(p)
+    }
+}
+
 pub(crate) const IC_STATE_ROOT_DOMAIN_SEPARATOR: &[u8; 14] = b"\x0Dic-state-root";
 
 pub(crate) const IC_ROOT_KEY: &[u8; 133] = b"\x30\x81\x82\x30\x1d\x06\x0d\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x01\x02\x01\x06\x0c\x2b\x06\x01\x04\x01\x82\xdc\x7c\x05\x03\x02\x01\x03\x61\x00\x81\x4c\x0e\x6e\xc7\x1f\xab\x58\x3b\x08\xbd\x81\x37\x3c\x25\x5c\x3c\x37\x1b\x2e\x84\x86\x3c\x98\xa4\xf1\xe0\x8b\x74\x23\x5d\x14\xfb\x5d\x9c\x0c\xd5\x46\xd9\x68\x5f\x91\x3a\x0c\x0b\x2c\xc5\x34\x15\x83\xbf\x4b\x43\x92\xe4\x67\xdb\x96\xd6\x5b\x9b\xb4\xcb\x71\x71\x12\xf8\x47\x2e\x0d\x5a\x4d\x14\x50\x5f\xfd\x74\x84\xb0\x12\x91\x09\x1c\x5f\x87\xb9\x88\x83\x46\x3f\x98\x09\x1a\x0b\xaa\xae";
@@ -363,6 +399,76 @@ impl Agent {
         serde_cbor::from_slice(&bytes).map_err(AgentError::InvalidCborData)
     }
 
+    async fn query_subnet_endpoint<A>(
+        &self,
+        subnet_id: Principal,
+        serialized_bytes: Vec<u8>,
+    ) -> Result<A, AgentError>
+    where
+        A: serde::de::DeserializeOwned,
+    {
+        let _permit = self.concurrent_requests_semaphore.acquire().await;
+        let endpoint = format!("api/v3/subnet/{}/query", subnet_id.to_text());
+        let bytes = self
+            .execute(Method::POST, &endpoint, Some(serialized_bytes))
+            .await?
+            .1;
+        serde_cbor::from_slice(&bytes).map_err(AgentError::InvalidCborData)
+    }
+
+    async fn query_endpoint_for<A>(
+        &self,
+        effective_id: EffectiveId,
+        serialized_bytes: Vec<u8>,
+    ) -> Result<A, AgentError>
+    where
+        A: serde::de::DeserializeOwned,
+    {
+        match effective_id {
+            EffectiveId::Canister(p) => self.query_endpoint(p, serialized_bytes).await,
+            EffectiveId::Subnet(p) => self.query_subnet_endpoint(p, serialized_bytes).await,
+        }
+    }
+
+    async fn read_state_endpoint_for<A>(
+        &self,
+        effective_id: EffectiveId,
+        serialized_bytes: Vec<u8>,
+    ) -> Result<A, AgentError>
+    where
+        A: serde::de::DeserializeOwned,
+    {
+        match effective_id {
+            EffectiveId::Canister(p) => self.read_state_endpoint(p, serialized_bytes).await,
+            EffectiveId::Subnet(p) => self.read_subnet_state_endpoint(p, serialized_bytes).await,
+        }
+    }
+
+    async fn call_endpoint_for(
+        &self,
+        effective_id: EffectiveId,
+        serialized_bytes: Vec<u8>,
+    ) -> Result<TransportCallResponse, AgentError> {
+        match effective_id {
+            EffectiveId::Canister(p) => self.call_endpoint(p, serialized_bytes).await,
+            EffectiveId::Subnet(p) => self.call_subnet_endpoint(p, serialized_bytes).await,
+        }
+    }
+
+    async fn get_subnet_for(&self, effective_id: EffectiveId) -> Result<Arc<Subnet>, AgentError> {
+        match effective_id {
+            EffectiveId::Canister(p) => self.get_subnet_by_canister(&p).await,
+            EffectiveId::Subnet(p) => self.get_subnet_by_id(&p).await,
+        }
+    }
+
+    async fn fetch_subnet_for(&self, effective_id: EffectiveId) -> Result<Arc<Subnet>, AgentError> {
+        match effective_id {
+            EffectiveId::Canister(p) => self.fetch_subnet_by_canister(&p).await,
+            EffectiveId::Subnet(p) => self.fetch_subnet_by_id(&p).await,
+        }
+    }
+
     async fn call_endpoint(
         &self,
         effective_canister_id: Principal,
@@ -425,7 +531,7 @@ impl Agent {
         )?;
         let serialized_bytes = sign_envelope(&content, self.identity.clone())?;
         self.query_inner(
-            effective_canister_id,
+            EffectiveId::Canister(effective_canister_id),
             serialized_bytes,
             content.to_request_id(),
             explicit_verify_query_signatures,
@@ -437,9 +543,15 @@ impl Agent {
     /// Send the signed query to the network. Will return a byte vector.
     /// The bytes will be checked if it is a valid query.
     /// If you want to inspect the fields of the query call, use [`signed_query_inspect`] before calling this method.
+    ///
+    /// `effective_id` may be either an effective canister id (the common case) or
+    /// an effective subnet id; in the latter case the request is routed to the
+    /// subnet-scoped `/api/v3/subnet/<id>/query` endpoint. Per the IC interface
+    /// spec, subnet-scoped queries are currently only valid for the
+    /// `list_canisters` method of the Management Canister.
     pub async fn query_signed(
         &self,
-        effective_canister_id: Principal,
+        effective_id: impl Into<EffectiveId>,
         signed_query: Vec<u8>,
     ) -> Result<Vec<u8>, AgentError> {
         let envelope: Envelope =
@@ -466,7 +578,7 @@ impl Agent {
             method: method_name.clone(),
         };
         self.query_inner(
-            effective_canister_id,
+            effective_id.into(),
             signed_query,
             envelope.content.to_request_id(),
             None,
@@ -480,7 +592,7 @@ impl Agent {
     /// This should be used instead of `query_endpoint`. No validation is performed on `signed_query`.
     async fn query_inner(
         &self,
-        effective_canister_id: Principal,
+        effective_id: EffectiveId,
         signed_query: Vec<u8>,
         request_id: RequestId,
         explicit_verify_query_signatures: Option<bool>,
@@ -488,8 +600,8 @@ impl Agent {
     ) -> Result<Vec<u8>, AgentError> {
         let response = if explicit_verify_query_signatures.unwrap_or(self.verify_query_signatures) {
             let (response, mut subnet) = futures_util::try_join!(
-                self.query_endpoint::<QueryResponse>(effective_canister_id, signed_query),
-                self.get_subnet_by_canister(&effective_canister_id)
+                self.query_endpoint_for::<QueryResponse>(effective_id, signed_query),
+                self.get_subnet_for(effective_id)
             )?;
             if response.signatures().is_empty() {
                 return Err(AgentError::MissingSignature);
@@ -510,9 +622,7 @@ impl Agent {
                 let node_key = if let Some(node_key) = subnet.node_keys.get(&signature.identity) {
                     node_key
                 } else {
-                    subnet = self
-                        .fetch_subnet_by_canister(&effective_canister_id)
-                        .await?;
+                    subnet = self.fetch_subnet_for(effective_id).await?;
                     subnet
                         .node_keys
                         .get(&signature.identity)
@@ -547,7 +657,7 @@ impl Agent {
             }
             response
         } else {
-            self.query_endpoint::<QueryResponse>(effective_canister_id, signed_query)
+            self.query_endpoint_for::<QueryResponse>(effective_id, signed_query)
                 .await?
         };
 
@@ -641,11 +751,18 @@ impl Agent {
     /// Send the signed update to the network. Will return a [`CallResponse<Vec<u8>>`].
     /// The bytes will be checked to verify that it is a valid update.
     /// If you want to inspect the fields of the update, use [`signed_update_inspect`] before calling this method.
+    ///
+    /// `effective_id` may be either an effective canister id (the common case) or
+    /// an effective subnet id; in the latter case the request is routed to the
+    /// subnet-scoped `/api/v4/subnet/<id>/call` endpoint. Per the IC interface
+    /// spec, subnet-scoped update calls are currently only valid for canister
+    /// creation calls to the Management Canister.
     pub async fn update_signed(
         &self,
-        effective_canister_id: Principal,
+        effective_id: impl Into<EffectiveId>,
         signed_update: Vec<u8>,
     ) -> Result<CallResponse<Vec<u8>>, AgentError> {
+        let effective_id = effective_id.into();
         let envelope: Envelope =
             serde_cbor::from_slice(&signed_update).map_err(AgentError::InvalidCborData)?;
         let EnvelopeContent::Call {
@@ -671,83 +788,14 @@ impl Agent {
         });
         let request_id = to_request_id(&envelope.content)?;
 
-        let response_body = self
-            .call_endpoint(effective_canister_id, signed_update)
-            .await?;
+        let response_body = self.call_endpoint_for(effective_id, signed_update).await?;
 
         match response_body {
             TransportCallResponse::Replied { certificate } => {
                 let certificate =
                     serde_cbor::from_slice(&certificate).map_err(AgentError::InvalidCborData)?;
 
-                self.verify(&certificate, effective_canister_id)?;
-                let status = lookup_request_status(&certificate, &request_id)?;
-
-                match status {
-                    RequestStatusResponse::Replied(reply) => Ok(CallResponse::Response(reply.arg)),
-                    RequestStatusResponse::Rejected(reject_response) => {
-                        Err(AgentError::CertifiedReject {
-                            reject: reject_response,
-                            operation,
-                        })?
-                    }
-                    _ => Ok(CallResponse::Poll(request_id)),
-                }
-            }
-            TransportCallResponse::Accepted => Ok(CallResponse::Poll(request_id)),
-            TransportCallResponse::NonReplicatedRejection(reject_response) => {
-                Err(AgentError::UncertifiedReject {
-                    reject: reject_response,
-                    operation,
-                })
-            }
-        }
-    }
-
-    /// Send the signed update to the subnet-scoped call endpoint (`/api/v4/subnet/<subnet_id>/call`).
-    /// Sibling of [`update_signed`](Self::update_signed); use this when routing via an effective
-    /// subnet id. Per the [interface spec], this endpoint only accepts canister creation calls to
-    /// the Management Canister.
-    ///
-    /// [interface spec]: https://internetcomputer.org/docs/current/references/ic-interface-spec#http-effective-subnet-id
-    pub async fn update_signed_subnet(
-        &self,
-        subnet_id: Principal,
-        signed_update: Vec<u8>,
-    ) -> Result<CallResponse<Vec<u8>>, AgentError> {
-        let envelope: Envelope =
-            serde_cbor::from_slice(&signed_update).map_err(AgentError::InvalidCborData)?;
-        let EnvelopeContent::Call {
-            canister_id,
-            method_name,
-            ..
-        } = &*envelope.content
-        else {
-            return Err(AgentError::CallDataMismatch {
-                field: "request_type".to_string(),
-                value_arg: "update".to_string(),
-                value_cbor: if matches!(*envelope.content, EnvelopeContent::Query { .. }) {
-                    "query"
-                } else {
-                    "read_state"
-                }
-                .to_string(),
-            });
-        };
-        let operation = Some(Operation::Call {
-            canister: *canister_id,
-            method: method_name.clone(),
-        });
-        let request_id = to_request_id(&envelope.content)?;
-
-        let response_body = self.call_subnet_endpoint(subnet_id, signed_update).await?;
-
-        match response_body {
-            TransportCallResponse::Replied { certificate } => {
-                let certificate =
-                    serde_cbor::from_slice(&certificate).map_err(AgentError::InvalidCborData)?;
-
-                self.verify_for_subnet(&certificate, subnet_id)?;
+                self.verify(&certificate, effective_id)?;
                 let status = lookup_request_status(&certificate, &request_id)?;
 
                 match status {
@@ -800,22 +848,23 @@ impl Agent {
     }
 
     /// Wait for `request_status` to return a Replied response and return the arg.
+    ///
+    /// `effective_id` may be either an effective canister id or an effective
+    /// subnet id; in the latter case the request is routed to the subnet-scoped
+    /// `/api/v3/subnet/<id>/read_state` endpoint.
     pub async fn wait_signed(
         &self,
         request_id: &RequestId,
-        effective_canister_id: Principal,
+        effective_id: impl Into<EffectiveId>,
         signed_request_status: Vec<u8>,
     ) -> Result<(Vec<u8>, Certificate), AgentError> {
+        let effective_id = effective_id.into();
         let mut retry_policy = self.get_retry_policy();
 
         let mut request_accepted = false;
         loop {
             let (resp, cert) = self
-                .request_status_signed(
-                    request_id,
-                    effective_canister_id,
-                    signed_request_status.clone(),
-                )
+                .request_status_signed(request_id, effective_id, signed_request_status.clone())
                 .await?;
             match resp {
                 RequestStatusResponse::Unknown => {
@@ -858,84 +907,30 @@ impl Agent {
         }
     }
 
-    /// Sibling of [`wait_signed`](Self::wait_signed) that polls the subnet-scoped
-    /// read_state endpoint (`/api/v3/subnet/<subnet_id>/read_state`).
-    pub async fn wait_signed_subnet(
-        &self,
-        request_id: &RequestId,
-        subnet_id: Principal,
-        signed_request_status: Vec<u8>,
-    ) -> Result<(Vec<u8>, Certificate), AgentError> {
-        let mut retry_policy = self.get_retry_policy();
-
-        let mut request_accepted = false;
-        loop {
-            let (resp, cert) = self
-                .request_status_signed_subnet(request_id, subnet_id, signed_request_status.clone())
-                .await?;
-            match resp {
-                RequestStatusResponse::Unknown => {
-                    if retry_policy.get_elapsed_time() > Duration::from_secs(5 * 60) {
-                        return Err(AgentError::TimeoutWaitingForResponse());
-                    }
-                }
-
-                RequestStatusResponse::Received | RequestStatusResponse::Processing => {
-                    if !request_accepted {
-                        retry_policy.reset();
-                        request_accepted = true;
-                    }
-                }
-
-                RequestStatusResponse::Replied(ReplyResponse { arg, .. }) => {
-                    return Ok((arg, cert))
-                }
-
-                RequestStatusResponse::Rejected(response) => {
-                    return Err(AgentError::CertifiedReject {
-                        reject: response,
-                        operation: None,
-                    })
-                }
-
-                RequestStatusResponse::Done => {
-                    return Err(AgentError::RequestStatusDoneNoReply(String::from(
-                        *request_id,
-                    )))
-                }
-            };
-
-            match retry_policy.next_backoff() {
-                Some(duration) => crate::util::sleep(duration).await,
-
-                None => return Err(AgentError::TimeoutWaitingForResponse()),
-            }
-        }
-    }
-
     /// Call `request_status` on the `RequestId` in a loop and return the response as a byte vector.
+    ///
+    /// `effective_id` may be either an effective canister id or an effective
+    /// subnet id; in the latter case state is polled from the subnet-scoped
+    /// `/api/v3/subnet/<id>/read_state` endpoint.
     pub async fn wait(
         &self,
         request_id: &RequestId,
-        effective_canister_id: Principal,
+        effective_id: impl Into<EffectiveId>,
     ) -> Result<(Vec<u8>, Certificate), AgentError> {
-        self.wait_inner(request_id, effective_canister_id, None)
-            .await
+        self.wait_inner(request_id, effective_id.into(), None).await
     }
 
     async fn wait_inner(
         &self,
         request_id: &RequestId,
-        effective_canister_id: Principal,
+        effective_id: EffectiveId,
         operation: Option<Operation>,
     ) -> Result<(Vec<u8>, Certificate), AgentError> {
         let mut retry_policy = self.get_retry_policy();
 
         let mut request_accepted = false;
         loop {
-            let (resp, cert) = self
-                .request_status_raw(request_id, effective_canister_id)
-                .await?;
+            let (resp, cert) = self.request_status_raw(request_id, effective_id).await?;
             match resp {
                 RequestStatusResponse::Unknown => {
                     // If status is still `Unknown` after 5 minutes, the ingress message is lost.
@@ -984,42 +979,41 @@ impl Agent {
         }
     }
 
-    /// Request the raw state tree directly, under an effective canister ID.
+    /// Request the raw state tree directly.
     /// See [the protocol docs](https://internetcomputer.org/docs/current/references/ic-interface-spec#http-read-state) for more information.
+    ///
+    /// `effective_id` may be either an effective canister id or an effective
+    /// subnet id; in the latter case the request is read from the subnet-scoped
+    /// `/api/v3/subnet/<id>/read_state` endpoint.
     pub async fn read_state_raw(
         &self,
         paths: Vec<Vec<Label>>,
-        effective_canister_id: Principal,
+        effective_id: impl Into<EffectiveId>,
     ) -> Result<Certificate, AgentError> {
+        let effective_id = effective_id.into();
         let content = self.read_state_content(paths)?;
         let serialized_bytes = sign_envelope(&content, self.identity.clone())?;
 
         let read_state_response: ReadStateResponse = self
-            .read_state_endpoint(effective_canister_id, serialized_bytes)
+            .read_state_endpoint_for(effective_id, serialized_bytes)
             .await?;
         let cert: Certificate = serde_cbor::from_slice(&read_state_response.certificate)
             .map_err(AgentError::InvalidCborData)?;
-        self.verify(&cert, effective_canister_id)?;
+        self.verify(&cert, effective_id)?;
         Ok(cert)
     }
 
     /// Request the raw state tree directly, under a subnet ID.
-    /// See [the protocol docs](https://internetcomputer.org/docs/current/references/ic-interface-spec#http-read-state) for more information.
+    ///
+    /// Equivalent to calling [`read_state_raw`](Self::read_state_raw) with
+    /// [`EffectiveId::Subnet`]; retained for backward compatibility.
     pub async fn read_subnet_state_raw(
         &self,
         paths: Vec<Vec<Label>>,
         subnet_id: Principal,
     ) -> Result<Certificate, AgentError> {
-        let content = self.read_state_content(paths)?;
-        let serialized_bytes = sign_envelope(&content, self.identity.clone())?;
-
-        let read_state_response: ReadStateResponse = self
-            .read_subnet_state_endpoint(subnet_id, serialized_bytes)
-            .await?;
-        let cert: Certificate = serde_cbor::from_slice(&read_state_response.certificate)
-            .map_err(AgentError::InvalidCborData)?;
-        self.verify_for_subnet(&cert, subnet_id)?;
-        Ok(cert)
+        self.read_state_raw(paths, EffectiveId::Subnet(subnet_id))
+            .await
     }
 
     fn read_state_content(&self, paths: Vec<Vec<Label>>) -> Result<EnvelopeContent, AgentError> {
@@ -1031,13 +1025,20 @@ impl Agent {
     }
 
     /// Verify a certificate, checking delegation if present.
-    /// Only passes if the certificate also has authority over the canister.
+    ///
+    /// For [`EffectiveId::Canister`] the certificate must have authority over
+    /// the canister (its canister-id ranges must include the principal). For
+    /// [`EffectiveId::Subnet`] the certificate must instead be authoritative
+    /// for the specified subnet.
     pub fn verify(
         &self,
         cert: &Certificate,
-        effective_canister_id: Principal,
+        effective_id: impl Into<EffectiveId>,
     ) -> Result<(), AgentError> {
-        self.verify_cert(cert, effective_canister_id)?;
+        match effective_id.into() {
+            EffectiveId::Canister(p) => self.verify_cert(cert, p)?,
+            EffectiveId::Subnet(p) => self.verify_cert_for_subnet(cert, p)?,
+        }
         self.verify_cert_timestamp(cert)?;
         Ok(())
     }
@@ -1064,14 +1065,15 @@ impl Agent {
 
     /// Verify a certificate, checking delegation if present.
     /// Only passes if the certificate is for the specified subnet.
+    ///
+    /// Equivalent to calling [`verify`](Self::verify) with
+    /// [`EffectiveId::Subnet`]; retained for backward compatibility.
     pub fn verify_for_subnet(
         &self,
         cert: &Certificate,
         subnet_id: Principal,
     ) -> Result<(), AgentError> {
-        self.verify_cert_for_subnet(cert, subnet_id)?;
-        self.verify_cert_timestamp(cert)?;
-        Ok(())
+        self.verify(cert, EffectiveId::Subnet(subnet_id))
     }
 
     fn verify_cert_for_subnet(
@@ -1296,15 +1298,19 @@ impl Agent {
     }
 
     /// Fetches the status of a particular request by its ID.
+    ///
+    /// `effective_id` may be either an effective canister id or an effective
+    /// subnet id; in the latter case the request is read from the subnet-scoped
+    /// `/api/v3/subnet/<id>/read_state` endpoint.
     pub async fn request_status_raw(
         &self,
         request_id: &RequestId,
-        effective_canister_id: Principal,
+        effective_id: impl Into<EffectiveId>,
     ) -> Result<(RequestStatusResponse, Certificate), AgentError> {
         let paths: Vec<Vec<Label>> =
             vec![vec!["request_status".into(), request_id.to_vec().into()]];
 
-        let cert = self.read_state_raw(paths, effective_canister_id).await?;
+        let cert = self.read_state_raw(paths, effective_id).await?;
 
         Ok((lookup_request_status(&cert, request_id)?, cert))
     }
@@ -1312,42 +1318,26 @@ impl Agent {
     /// Send the signed `request_status` to the network. Will return [`RequestStatusResponse`].
     /// The bytes will be checked to verify that it is a valid `request_status`.
     /// If you want to inspect the fields of the `request_status`, use [`signed_request_status_inspect`] before calling this method.
+    ///
+    /// `effective_id` may be either an effective canister id or an effective
+    /// subnet id; in the latter case the request is read from the subnet-scoped
+    /// `/api/v3/subnet/<id>/read_state` endpoint.
     pub async fn request_status_signed(
         &self,
         request_id: &RequestId,
-        effective_canister_id: Principal,
+        effective_id: impl Into<EffectiveId>,
         signed_request_status: Vec<u8>,
     ) -> Result<(RequestStatusResponse, Certificate), AgentError> {
+        let effective_id = effective_id.into();
         let _envelope: Envelope =
             serde_cbor::from_slice(&signed_request_status).map_err(AgentError::InvalidCborData)?;
         let read_state_response: ReadStateResponse = self
-            .read_state_endpoint(effective_canister_id, signed_request_status)
+            .read_state_endpoint_for(effective_id, signed_request_status)
             .await?;
 
         let cert: Certificate = serde_cbor::from_slice(&read_state_response.certificate)
             .map_err(AgentError::InvalidCborData)?;
-        self.verify(&cert, effective_canister_id)?;
-        Ok((lookup_request_status(&cert, request_id)?, cert))
-    }
-
-    /// Sibling of [`request_status_signed`](Self::request_status_signed) that reads from the
-    /// subnet-scoped endpoint (`/api/v3/subnet/<subnet_id>/read_state`). The returned certificate
-    /// is verified against `subnet_id` rather than against canister range membership.
-    pub async fn request_status_signed_subnet(
-        &self,
-        request_id: &RequestId,
-        subnet_id: Principal,
-        signed_request_status: Vec<u8>,
-    ) -> Result<(RequestStatusResponse, Certificate), AgentError> {
-        let _envelope: Envelope =
-            serde_cbor::from_slice(&signed_request_status).map_err(AgentError::InvalidCborData)?;
-        let read_state_response: ReadStateResponse = self
-            .read_subnet_state_endpoint(subnet_id, signed_request_status)
-            .await?;
-
-        let cert: Certificate = serde_cbor::from_slice(&read_state_response.certificate)
-            .map_err(AgentError::InvalidCborData)?;
-        self.verify_for_subnet(&cert, subnet_id)?;
+        self.verify(&cert, effective_id)?;
         Ok((lookup_request_status(&cert, request_id)?, cert))
     }
 
@@ -1389,9 +1379,10 @@ impl Agent {
     /// depending on which endpoint the caller will submit the signed message to.
     pub fn sign_request_status(
         &self,
-        effective_id: Principal,
+        effective_id: impl Into<EffectiveId>,
         request_id: RequestId,
     ) -> Result<SignedRequestStatus, AgentError> {
+        let effective_id = effective_id.into();
         let paths: Vec<Vec<Label>> =
             vec![vec!["request_status".into(), request_id.to_vec().into()]];
         let read_state_content = self.read_state_content(paths)?;
@@ -1401,7 +1392,7 @@ impl Agent {
         Ok(SignedRequestStatus {
             ingress_expiry,
             sender,
-            effective_canister_id: effective_id,
+            effective_canister_id: effective_id.as_principal(),
             request_id,
             signed_request_status,
         })
@@ -2089,7 +2080,7 @@ impl<'a> UpdateCall<'a> {
                 self.agent
                     .wait_inner(
                         &request_id,
-                        self.effective_canister_id,
+                        EffectiveId::Canister(self.effective_canister_id),
                         Some(Operation::Call {
                             canister: self.canister_id,
                             method: self.method_name,

--- a/ic-agent/src/agent/mod.rs
+++ b/ic-agent/src/agent/mod.rs
@@ -871,11 +871,7 @@ impl Agent {
         let mut request_accepted = false;
         loop {
             let (resp, cert) = self
-                .request_status_signed_subnet(
-                    request_id,
-                    subnet_id,
-                    signed_request_status.clone(),
-                )
+                .request_status_signed_subnet(request_id, subnet_id, signed_request_status.clone())
                 .await?;
             match resp {
                 RequestStatusResponse::Unknown => {

--- a/ic-transport-types/src/signed.rs
+++ b/ic-transport-types/src/signed.rs
@@ -82,7 +82,11 @@ pub struct SignedRequestStatus {
     pub ingress_expiry: u64,
     /// The principal ID of the caller.
     pub sender: Principal,
-    /// The [effective canister ID](https://internetcomputer.org/docs/current/references/ic-interface-spec#http-effective-canister-id) of the destination.
+    /// The [effective canister ID](https://internetcomputer.org/docs/current/references/ic-interface-spec#http-effective-canister-id)
+    /// of the destination. Despite the name, this may also hold an
+    /// [effective subnet ID](https://internetcomputer.org/docs/current/references/ic-interface-spec#http-effective-subnet-id)
+    /// when the underlying `request_status` targets a subnet-scoped endpoint
+    /// (e.g., when passed to [`Agent::request_status_signed_subnet`](https://docs.rs/ic-agent/latest/ic_agent/struct.Agent.html#method.request_status_signed_subnet)).
     pub effective_canister_id: Principal,
     /// The request ID.
     pub request_id: RequestId,

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -566,11 +566,11 @@ impl<'agent, 'canister: 'agent> AsyncCall for CreateCanisterBuilder<'agent, 'can
     type Value = (Principal,);
 
     async fn call(self) -> Result<CallResponse<(Principal,)>, AgentError> {
-        self.build()?.call().await
+        self.call().await
     }
 
     async fn call_and_wait(self) -> Result<(Principal,), AgentError> {
-        self.build()?.call_and_wait().await
+        self.call_and_wait().await
     }
 }
 
@@ -579,7 +579,7 @@ impl<'agent, 'canister: 'agent> IntoFuture for CreateCanisterBuilder<'agent, 'ca
     type Output = Result<(Principal,), AgentError>;
 
     fn into_future(self) -> Self::IntoFuture {
-        AsyncCall::call_and_wait(self)
+        Box::pin(self.call_and_wait())
     }
 }
 

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -34,7 +34,9 @@ use std::{
 #[derive(Debug)]
 pub struct CreateCanisterBuilder<'agent, 'canister: 'agent> {
     canister: &'canister Canister<'agent>,
-    effective_canister_id: Principal,
+    /// For most use cases, this is `effective_canister_id`, the call will create a canister on the same subnet of it.
+    /// Subnet administrators can directly set effective_subnet_id and the canister will be created on the specified subnet.
+    effective_id: Principal,
     controllers: Option<Result<Vec<Principal>, AgentError>>,
     compute_allocation: Option<Result<ComputeAllocation, AgentError>>,
     memory_allocation: Option<Result<MemoryAllocation, AgentError>>,
@@ -55,7 +57,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     pub fn builder(canister: &'canister Canister<'agent>) -> Self {
         Self {
             canister,
-            effective_canister_id: Principal::management_canister(),
+            effective_id: Principal::management_canister(),
             controllers: None,
             compute_allocation: None,
             memory_allocation: None,
@@ -95,12 +97,17 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
         Self {
             is_provisional_create: true,
             specified_id: Some(specified_id),
-            effective_canister_id: specified_id,
+            effective_id: specified_id,
             ..self
         }
     }
 
     /// Pass in an effective canister id for the update call.
+    ///
+    /// Boundary nodes use the effective {canister / subnet} id to route the request to the target subnet.
+    ///
+    /// This method and [`Self::with_effective_subnet_id`] share the same underlying field, so only
+    /// the last call among them takes effect; earlier calls are shadowed.
     pub fn with_effective_canister_id<C, E>(self, effective_canister_id: C) -> Self
     where
         E: std::fmt::Display,
@@ -108,7 +115,29 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     {
         match effective_canister_id.try_into() {
             Ok(effective_canister_id) => Self {
-                effective_canister_id,
+                effective_id: effective_canister_id,
+                ..self
+            },
+            Err(_) => self,
+        }
+    }
+
+    /// Pass in an effective subnet id for the update call.
+    ///
+    /// The constructed `create_canister` call is only valid if the caller has subnet administrator permissions.
+    ///
+    /// Boundary nodes use the effective {canister / subnet} id to route the request to the target subnet.
+    ///
+    /// This method and [`Self::with_effective_canister_id`] share the same underlying field, so only
+    /// the last call among them takes effect; earlier calls are shadowed.
+    pub fn with_effective_subnet_id<C, E>(self, effective_subnet_id: C) -> Self
+    where
+        E: std::fmt::Display,
+        C: TryInto<Principal, Error = E>,
+    {
+        match effective_subnet_id.try_into() {
+            Ok(subnet_id) => Self {
+                effective_id: subnet_id,
                 ..self
             },
             Err(_) => self,
@@ -368,7 +397,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
             self.canister
                 .update(MgmtMethod::ProvisionalCreateCanisterWithCycles.as_ref())
                 .with_arg(in_arg)
-                .with_effective_canister_id(self.effective_canister_id)
+                .with_effective_canister_id(self.effective_id)
         } else {
             self.canister
                 .update(MgmtMethod::CreateCanister.as_ref())
@@ -384,7 +413,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
                     log_memory_limit,
                     environment_variables,
                 })
-                .with_effective_canister_id(self.effective_canister_id)
+                .with_effective_canister_id(self.effective_id)
         };
 
         Ok(async_builder

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -11,7 +11,7 @@ use crate::{
     call::AsyncCall, canister::Argument, interfaces::management_canister::MgmtMethod, Canister,
 };
 use async_trait::async_trait;
-use candid::{utils::ArgumentEncoder, CandidType, Deserialize, Nat};
+use candid::{decode_args, utils::ArgumentEncoder, CandidType, Deserialize, Encode, Nat};
 use futures_util::{
     future::ready,
     stream::{self, FuturesUnordered},
@@ -30,13 +30,24 @@ use std::{
     pin::Pin,
 };
 
+/// Routing target for a `create_canister` call.
+#[derive(Debug, Clone, Copy)]
+enum EffectiveId {
+    /// Route via `/api/v4/canister/<id>/call`. The new canister will be created on the same
+    /// subnet as the given canister id.
+    Canister(Principal),
+    /// Route via `/api/v4/subnet/<id>/call`. Only valid when the caller has subnet administrator
+    /// permissions; the new canister will be created on the specified subnet.
+    Subnet(Principal),
+}
+
 /// A builder for a `create_canister` call.
 #[derive(Debug)]
 pub struct CreateCanisterBuilder<'agent, 'canister: 'agent> {
     canister: &'canister Canister<'agent>,
     /// For most use cases, this is `effective_canister_id`, the call will create a canister on the same subnet of it.
     /// Subnet administrators can directly set effective_subnet_id and the canister will be created on the specified subnet.
-    effective_id: Principal,
+    effective_id: EffectiveId,
     controllers: Option<Result<Vec<Principal>, AgentError>>,
     compute_allocation: Option<Result<ComputeAllocation, AgentError>>,
     memory_allocation: Option<Result<MemoryAllocation, AgentError>>,
@@ -57,7 +68,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     pub fn builder(canister: &'canister Canister<'agent>) -> Self {
         Self {
             canister,
-            effective_id: Principal::management_canister(),
+            effective_id: EffectiveId::Canister(Principal::management_canister()),
             controllers: None,
             compute_allocation: None,
             memory_allocation: None,
@@ -97,7 +108,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
         Self {
             is_provisional_create: true,
             specified_id: Some(specified_id),
-            effective_id: specified_id,
+            effective_id: EffectiveId::Canister(specified_id),
             ..self
         }
     }
@@ -115,7 +126,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     {
         match effective_canister_id.try_into() {
             Ok(effective_canister_id) => Self {
-                effective_id: effective_canister_id,
+                effective_id: EffectiveId::Canister(effective_canister_id),
                 ..self
             },
             Err(_) => self,
@@ -137,7 +148,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     {
         match effective_subnet_id.try_into() {
             Ok(subnet_id) => Self {
-                effective_id: subnet_id,
+                effective_id: EffectiveId::Subnet(subnet_id),
                 ..self
             },
             Err(_) => self,
@@ -314,7 +325,62 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
 
     /// Create an [`AsyncCall`] implementation that, when called, will create a
     /// canister.
+    ///
+    /// Returns an error when the builder was configured with [`Self::with_effective_subnet_id`];
+    /// the subnet-scoped routing requires direct dispatch via [`Self::call`] or
+    /// [`Self::call_and_wait`] and is not expressible through the generic [`AsyncCall`] surface.
     pub fn build(self) -> Result<impl 'agent + AsyncCall<Value = (Principal,)>, AgentError> {
+        let prepared = self.prepare()?;
+        let effective_canister_id = match prepared.effective_id {
+            EffectiveId::Canister(p) => p,
+            EffectiveId::Subnet(_) => {
+                return Err(AgentError::MessageError(
+                    "CreateCanisterBuilder::build() does not support subnet routing; \
+                     use call()/call_and_wait() instead."
+                        .into(),
+                ));
+            }
+        };
+        Ok(prepared
+            .canister
+            .update(prepared.method)
+            .with_arg_raw(prepared.arg_bytes)
+            .with_effective_canister_id(effective_canister_id)
+            .build()
+            .map(|result: (CreateCanisterOut,)| (result.0.canister_id,)))
+    }
+
+    /// Make a call. This is equivalent to the [`AsyncCall::call`].
+    pub async fn call(self) -> Result<CallResponse<(Principal,)>, AgentError> {
+        match self.effective_id {
+            EffectiveId::Canister(_) => self.build()?.call().await,
+            EffectiveId::Subnet(subnet_id) => {
+                let prepared = self.prepare()?;
+                let response = subnet_call(prepared.canister, prepared.method, prepared.arg_bytes, subnet_id).await?;
+                match response {
+                    CallResponse::Response(bytes) => {
+                        let (out,): (CreateCanisterOut,) = decode_args(&bytes)
+                            .map_err(|e| AgentError::CandidError(Box::new(e)))?;
+                        Ok(CallResponse::Response((out.canister_id,)))
+                    }
+                    CallResponse::Poll(request_id) => Ok(CallResponse::Poll(request_id)),
+                }
+            }
+        }
+    }
+
+    /// Make a call. This is equivalent to the [`AsyncCall::call_and_wait`].
+    pub async fn call_and_wait(self) -> Result<(Principal,), AgentError> {
+        match self.effective_id {
+            EffectiveId::Canister(_) => self.build()?.call_and_wait().await,
+            EffectiveId::Subnet(subnet_id) => {
+                let prepared = self.prepare()?;
+                subnet_call_and_wait(prepared.canister, prepared.method, prepared.arg_bytes, subnet_id).await
+            }
+        }
+    }
+
+    fn prepare(self) -> Result<PreparedCreate<'agent, 'canister>, AgentError> {
         let controllers = match self.controllers {
             Some(Err(x)) => return Err(AgentError::MessageError(format!("{x}"))),
             Some(Ok(x)) => Some(x),
@@ -366,12 +432,7 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
             None => None,
         };
 
-        #[derive(Deserialize, CandidType)]
-        struct Out {
-            canister_id: Principal,
-        }
-
-        let async_builder = if self.is_provisional_create {
+        let (method, arg_bytes) = if self.is_provisional_create {
             #[derive(CandidType)]
             struct In {
                 amount: Option<Nat>,
@@ -389,47 +450,106 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
                     wasm_memory_limit,
                     wasm_memory_threshold,
                     log_visibility,
-                    log_memory_limit: log_memory_limit.clone(),
+                    log_memory_limit,
                     environment_variables,
                 },
                 specified_id: self.specified_id,
             };
-            self.canister
-                .update(MgmtMethod::ProvisionalCreateCanisterWithCycles.as_ref())
-                .with_arg(in_arg)
-                .with_effective_canister_id(self.effective_id)
+            (
+                MgmtMethod::ProvisionalCreateCanisterWithCycles.as_ref(),
+                Encode!(&in_arg).map_err(|e| AgentError::CandidError(Box::new(e)))?,
+            )
         } else {
-            self.canister
-                .update(MgmtMethod::CreateCanister.as_ref())
-                .with_arg(CanisterSettings {
-                    controllers,
-                    compute_allocation,
-                    memory_allocation,
-                    freezing_threshold,
-                    reserved_cycles_limit,
-                    wasm_memory_limit,
-                    wasm_memory_threshold,
-                    log_visibility,
-                    log_memory_limit,
-                    environment_variables,
-                })
-                .with_effective_canister_id(self.effective_id)
+            let settings = CanisterSettings {
+                controllers,
+                compute_allocation,
+                memory_allocation,
+                freezing_threshold,
+                reserved_cycles_limit,
+                wasm_memory_limit,
+                wasm_memory_threshold,
+                log_visibility,
+                log_memory_limit,
+                environment_variables,
+            };
+            (
+                MgmtMethod::CreateCanister.as_ref(),
+                Encode!(&settings).map_err(|e| AgentError::CandidError(Box::new(e)))?,
+            )
         };
 
-        Ok(async_builder
-            .build()
-            .map(|result: (Out,)| (result.0.canister_id,)))
+        Ok(PreparedCreate {
+            canister: self.canister,
+            effective_id: self.effective_id,
+            method,
+            arg_bytes,
+        })
     }
+}
 
-    /// Make a call. This is equivalent to the [`AsyncCall::call`].
-    pub async fn call(self) -> Result<CallResponse<(Principal,)>, AgentError> {
-        self.build()?.call().await
-    }
+#[derive(Deserialize, CandidType)]
+struct CreateCanisterOut {
+    canister_id: Principal,
+}
 
-    /// Make a call. This is equivalent to the [`AsyncCall::call_and_wait`].
-    pub async fn call_and_wait(self) -> Result<(Principal,), AgentError> {
-        self.build()?.call_and_wait().await
-    }
+struct PreparedCreate<'agent, 'canister> {
+    canister: &'canister Canister<'agent>,
+    effective_id: EffectiveId,
+    method: &'static str,
+    arg_bytes: Vec<u8>,
+}
+
+/// Submit a `create_canister` (or `provisional_create_canister_with_cycles`) call to the
+/// management canister via the subnet-scoped endpoint and decode the resulting canister id.
+async fn subnet_call_and_wait(
+    canister: &Canister<'_>,
+    method: &str,
+    arg_bytes: Vec<u8>,
+    subnet_id: Principal,
+) -> Result<(Principal,), AgentError> {
+    let agent = canister.agent;
+    let signed = agent
+        .update(&Principal::management_canister(), method)
+        .with_arg(arg_bytes)
+        .sign()?;
+    let response = agent
+        .update_signed_subnet(subnet_id, signed.signed_update)
+        .await?;
+    let bytes = match response {
+        CallResponse::Response(bytes) => bytes,
+        CallResponse::Poll(request_id) => {
+            let signed_status = agent.sign_request_status(subnet_id, request_id)?;
+            agent
+                .wait_signed_subnet(
+                    &request_id,
+                    subnet_id,
+                    signed_status.signed_request_status,
+                )
+                .await?
+                .0
+        }
+    };
+    let (out,): (CreateCanisterOut,) =
+        decode_args(&bytes).map_err(|e| AgentError::CandidError(Box::new(e)))?;
+    Ok((out.canister_id,))
+}
+
+/// Like [`subnet_call_and_wait`] but returns a [`CallResponse`] without polling, so that the
+/// caller can decide how to wait for the request to complete.
+async fn subnet_call(
+    canister: &Canister<'_>,
+    method: &str,
+    arg_bytes: Vec<u8>,
+    subnet_id: Principal,
+) -> Result<CallResponse<Vec<u8>>, AgentError> {
+    let agent = canister.agent;
+    let signed = agent
+        .update(&Principal::management_canister(), method)
+        .with_arg(arg_bytes)
+        .sign()?;
+    agent
+        .update_signed_subnet(subnet_id, signed.signed_update)
+        .await
 }
 
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -356,7 +356,13 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
             EffectiveId::Canister(_) => self.build()?.call().await,
             EffectiveId::Subnet(subnet_id) => {
                 let prepared = self.prepare()?;
-                let response = subnet_call(prepared.canister, prepared.method, prepared.arg_bytes, subnet_id).await?;
+                let response = subnet_call(
+                    prepared.canister,
+                    prepared.method,
+                    prepared.arg_bytes,
+                    subnet_id,
+                )
+                .await?;
                 match response {
                     CallResponse::Response(bytes) => {
                         let (out,): (CreateCanisterOut,) = decode_args(&bytes)
@@ -375,7 +381,13 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
             EffectiveId::Canister(_) => self.build()?.call_and_wait().await,
             EffectiveId::Subnet(subnet_id) => {
                 let prepared = self.prepare()?;
-                subnet_call_and_wait(prepared.canister, prepared.method, prepared.arg_bytes, subnet_id).await
+                subnet_call_and_wait(
+                    prepared.canister,
+                    prepared.method,
+                    prepared.arg_bytes,
+                    subnet_id,
+                )
+                .await
             }
         }
     }
@@ -520,11 +532,7 @@ async fn subnet_call_and_wait(
         CallResponse::Poll(request_id) => {
             let signed_status = agent.sign_request_status(subnet_id, request_id)?;
             agent
-                .wait_signed_subnet(
-                    &request_id,
-                    subnet_id,
-                    signed_status.signed_request_status,
-                )
+                .wait_signed_subnet(&request_id, subnet_id, signed_status.signed_request_status)
                 .await?
                 .0
         }

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -17,7 +17,11 @@ use futures_util::{
     stream::{self, FuturesUnordered},
     FutureExt, Stream, StreamExt, TryStreamExt,
 };
-use ic_agent::{agent::CallResponse, export::Principal, AgentError};
+use ic_agent::{
+    agent::{CallResponse, EffectiveId},
+    export::Principal,
+    AgentError,
+};
 pub use ic_management_canister_types::{
     CanisterInstallMode, CanisterSettings, EnvironmentVariable, InstallCodeArgs, UpgradeFlags,
     WasmMemoryPersistence,
@@ -29,17 +33,6 @@ use std::{
     future::IntoFuture,
     pin::Pin,
 };
-
-/// Routing target for a `create_canister` call.
-#[derive(Debug, Clone, Copy)]
-enum EffectiveId {
-    /// Route via `/api/v4/canister/<id>/call`. The new canister will be created on the same
-    /// subnet as the given canister id.
-    Canister(Principal),
-    /// Route via `/api/v4/subnet/<id>/call`. Only valid when the caller has subnet administrator
-    /// permissions; the new canister will be created on the specified subnet.
-    Subnet(Principal),
-}
 
 /// A builder for a `create_canister` call.
 #[derive(Debug)]
@@ -524,15 +517,20 @@ async fn subnet_call_and_wait(
         .update(&Principal::management_canister(), method)
         .with_arg(arg_bytes)
         .sign()?;
+    let effective_id = EffectiveId::Subnet(subnet_id);
     let response = agent
-        .update_signed_subnet(subnet_id, signed.signed_update)
+        .update_signed(effective_id, signed.signed_update)
         .await?;
     let bytes = match response {
         CallResponse::Response(bytes) => bytes,
         CallResponse::Poll(request_id) => {
-            let signed_status = agent.sign_request_status(subnet_id, request_id)?;
+            let signed_status = agent.sign_request_status(effective_id, request_id)?;
             agent
-                .wait_signed_subnet(&request_id, subnet_id, signed_status.signed_request_status)
+                .wait_signed(
+                    &request_id,
+                    effective_id,
+                    signed_status.signed_request_status,
+                )
                 .await?
                 .0
         }
@@ -556,7 +554,7 @@ async fn subnet_call(
         .with_arg(arg_bytes)
         .sign()?;
     agent
-        .update_signed_subnet(subnet_id, signed.signed_update)
+        .update_signed(EffectiveId::Subnet(subnet_id), signed.signed_update)
         .await
 }
 

--- a/ic-utils/src/interfaces/management_canister/builders.rs
+++ b/ic-utils/src/interfaces/management_canister/builders.rs
@@ -95,8 +95,12 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
 
     /// Specify the canister id.
     ///
-    /// The `effective_canister_id` will also be set with the same value so that ic-ref can determine
+    /// The effective canister id will also be set to the same value so that ic-ref can determine
     /// the target subnet of this request. The replica implementation ignores it.
+    ///
+    /// This overwrites the effective id previously set by [`Self::with_effective_canister_id`] or
+    /// [`Self::with_effective_subnet_id`] (and is itself overwritten by any later call to those).
+    /// Only the last call among the three takes effect.
     pub fn as_provisional_create_with_specified_id(self, specified_id: Principal) -> Self {
         Self {
             is_provisional_create: true,
@@ -110,8 +114,9 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     ///
     /// Boundary nodes use the effective {canister / subnet} id to route the request to the target subnet.
     ///
-    /// This method and [`Self::with_effective_subnet_id`] share the same underlying field, so only
-    /// the last call among them takes effect; earlier calls are shadowed.
+    /// This method, [`Self::with_effective_subnet_id`], and [`Self::as_provisional_create_with_specified_id`]
+    /// all write to the same underlying field, so only the last call among them takes effect; earlier
+    /// calls are silently shadowed.
     pub fn with_effective_canister_id<C, E>(self, effective_canister_id: C) -> Self
     where
         E: std::fmt::Display,
@@ -132,8 +137,9 @@ impl<'agent, 'canister: 'agent> CreateCanisterBuilder<'agent, 'canister> {
     ///
     /// Boundary nodes use the effective {canister / subnet} id to route the request to the target subnet.
     ///
-    /// This method and [`Self::with_effective_canister_id`] share the same underlying field, so only
-    /// the last call among them takes effect; earlier calls are shadowed.
+    /// This method, [`Self::with_effective_canister_id`], and [`Self::as_provisional_create_with_specified_id`]
+    /// all write to the same underlying field, so only the last call among them takes effect; earlier
+    /// calls are silently shadowed.
     pub fn with_effective_subnet_id<C, E>(self, effective_subnet_id: C) -> Self
     where
         E: std::fmt::Display,

--- a/icx/Cargo.toml
+++ b/icx/Cargo.toml
@@ -28,7 +28,11 @@ humantime = { workspace = true }
 ic-agent = { workspace = true, default-features = true }
 ic-ed25519 = { workspace = true }
 ic-utils = { workspace = true }
-pocket-ic = { workspace = true }
+# `icx` is published to crates.io, which rejects git dependencies. We therefore
+# pin a released semver here instead of inheriting the workspace's git-rev
+# pocket-ic (which is for integration tests only). Keep the major version in
+# rough sync with the workspace pin to avoid API drift.
+pocket-ic = "13.0.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -200,13 +200,13 @@ where
     let admin_principal = admin_identity
         .sender()
         .expect("admin identity has a sender principal");
-    let mut config = ExtendedSubnetConfigSet::default();
-    config.nns = Some(SubnetSpec::default());
-    config.cloud_engine.push(
-        SubnetSpec::default()
+    let config = ExtendedSubnetConfigSet {
+        nns: Some(SubnetSpec::default()),
+        cloud_engine: vec![SubnetSpec::default()
             .with_subnet_admins(vec![admin_principal])
-            .with_cost_schedule(CanisterCyclesCostSchedule::Free),
-    );
+            .with_cost_schedule(CanisterCyclesCostSchedule::Free)],
+        ..Default::default()
+    };
     let pic = PocketIcBuilder::new_with_config(config)
         .with_server_binary(format!("{}/assets/pocket-ic", env!("CARGO_MANIFEST_DIR")).into())
         .with_auto_progress()

--- a/ref-tests/src/utils.rs
+++ b/ref-tests/src/utils.rs
@@ -3,6 +3,9 @@ use ic_agent::identity::{Prime256v1Identity, Secp256k1Identity};
 use ic_agent::{export::Principal, identity::BasicIdentity, Agent, Identity};
 use ic_identity_hsm::HardwareIdentity;
 use ic_utils::interfaces::{management_canister::builders::MemoryAllocation, ManagementCanister};
+use pocket_ic::common::rest::{
+    CanisterCyclesCostSchedule, ExtendedSubnetConfigSet, SubnetId, SubnetSpec,
+};
 use pocket_ic::nonblocking::PocketIc;
 use pocket_ic::PocketIcBuilder;
 use std::time::Duration;
@@ -178,6 +181,47 @@ where
         .build_async()
         .await;
     match f(&pic).await {
+        Ok(r) => r,
+        Err(e) => panic!("{e:?}"),
+    }
+}
+
+/// Like [`with_agent_as`], but the agent's identity is registered as a subnet
+/// administrator of a cloud engine subnet. The subnet id is passed to `f` so
+/// the test can route calls via `with_effective_subnet_id`.
+pub async fn with_subnet_admin_agent<I, F, R>(admin_identity: I, f: F) -> R
+where
+    I: Identity + 'static,
+    F: AsyncFnOnce(&PocketIc, Agent, SubnetId) -> Result<R, Box<dyn Error>>,
+{
+    if !check_assets_uptodate() {
+        panic!("Test assets are out of date. Please run `scripts/download_reftest_assets.sh` to update them.");
+    }
+    let admin_principal = admin_identity
+        .sender()
+        .expect("admin identity has a sender principal");
+    let mut config = ExtendedSubnetConfigSet::default();
+    config.nns = Some(SubnetSpec::default());
+    config.cloud_engine.push(
+        SubnetSpec::default()
+            .with_subnet_admins(vec![admin_principal])
+            .with_cost_schedule(CanisterCyclesCostSchedule::Free),
+    );
+    let pic = PocketIcBuilder::new_with_config(config)
+        .with_server_binary(format!("{}/assets/pocket-ic", env!("CARGO_MANIFEST_DIR")).into())
+        .with_auto_progress()
+        .build_async()
+        .await;
+    let agent = create_agent(&pic, admin_identity)
+        .await
+        .expect("Could not create an agent.");
+    let subnet_id = *pic
+        .topology()
+        .await
+        .get_cloud_engines()
+        .first()
+        .expect("cloud engine subnet exists");
+    match f(&pic, agent, subnet_id).await {
         Ok(r) => r,
         Err(e) => panic!("{e:?}"),
     }

--- a/ref-tests/tests/ic-ref.rs
+++ b/ref-tests/tests/ic-ref.rs
@@ -84,6 +84,33 @@ mod management_canister {
         }
 
         #[tokio::test]
+        async fn create_canister_with_effective_subnet_id() {
+            use ref_tests::{create_basic_identity, with_subnet_admin_agent};
+
+            let admin_identity = create_basic_identity();
+            with_subnet_admin_agent(admin_identity, async move |pic, agent, subnet_id| {
+                let ic00 = ManagementCanister::create(&agent);
+
+                let (canister_id,) = ic00
+                    .create_canister()
+                    .as_provisional_create_with_amount(None)
+                    .with_effective_subnet_id(subnet_id)
+                    .call_and_wait()
+                    .await?;
+
+                let actual_subnet = pic
+                    .topology()
+                    .await
+                    .get_subnet(canister_id)
+                    .expect("created canister has a subnet");
+                assert_eq!(actual_subnet, subnet_id);
+
+                Ok(())
+            })
+            .await
+        }
+
+        #[tokio::test]
         async fn create_canister_necessary() {
             with_agent(async move |_, agent| {
                 let ic00 = ManagementCanister::create(&agent);

--- a/scripts/download_reftest_assets.sh
+++ b/scripts/download_reftest_assets.sh
@@ -1,10 +1,20 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+# Exit on error, treat unset variables as errors, and fail pipelines on the
+# first non-zero exit. IFS reset avoids surprising word-splitting on spaces.
+set -euo pipefail
+IFS=$'\n\t'
+
+# Run from the repo root regardless of where the script is invoked from.
 cd "$(dirname "$0")/.."
 
-# release-2026-04-16_04-20-base
-ic_commit_for_pic=719ff387aab462ce5759c4c20c30de959fe9538c
-ic_commit_for_universal_canister=719ff387aab462ce5759c4c20c30de959fe9538c
+# Pin the pocket-ic binary and universal_canister.wasm to the same IC commit as
+# the pocket-ic crate dependency in the root Cargo.toml, so the server binary
+# and client library stay in sync.
+ic_commit=$(sed -n 's/^pocket-ic = .*rev = "\([a-f0-9]\{40\}\)".*/\1/p' Cargo.toml)
+if [ -z "$ic_commit" ]; then
+    echo "Failed to extract pocket-ic rev from Cargo.toml" >&2
+    exit 1
+fi
 wallet_ver=20230530
 
 case $(uname -s) in
@@ -17,8 +27,8 @@ case $(uname -m) in
     arm64*)     arch="arm64";;
     *)          echo "Unsupported architecture"; exit 1;;
 esac
-curl -L --fail "https://download.dfinity.systems/ic/${ic_commit_for_pic}/binaries/${arch}-${os}/pocket-ic.gz" -o ref-tests/assets/pocket-ic.gz
+curl -L --fail "https://download.dfinity.systems/ic/${ic_commit}/binaries/${arch}-${os}/pocket-ic.gz" -o ref-tests/assets/pocket-ic.gz
 gunzip -f ref-tests/assets/pocket-ic.gz
 chmod a+x ref-tests/assets/pocket-ic
-curl -L --fail "https://download.dfinity.systems/ic/${ic_commit_for_universal_canister}/canisters/universal_canister.wasm.gz" -o ref-tests/assets/universal-canister.wasm.gz
+curl -L --fail "https://download.dfinity.systems/ic/${ic_commit}/canisters/universal_canister.wasm.gz" -o ref-tests/assets/universal-canister.wasm.gz
 curl -L --fail "https://github.com/dfinity/cycles-wallet/releases/download/${wallet_ver}/wallet.wasm" -o ref-tests/assets/cycles-wallet.wasm


### PR DESCRIPTION
## Summary

- Introduces a public `EffectiveId { Canister(Principal) | Subnet(Principal) }` enum in `ic-agent::agent`; bare `Principal` still works via `From<Principal>`, so existing call sites are source-compatible.
- `Agent::update_signed`, `request_status_signed`, and `wait_signed` now take `impl Into<EffectiveId>` and dispatch internally to the canister-scoped or subnet-scoped HTTP endpoints (`/api/v4/subnet/<id>/call`, `/api/v3/subnet/<id>/read_state`). No duplicated `_subnet` call stack.
- Adds `CreateCanisterBuilder::with_effective_subnet_id` so subnet administrators can route `create_canister` to a specific subnet. The builder signs the management-canister update via `UpdateBuilder::sign()` and submits it through the subnet-scoped path; the canister-id path is unchanged.
- Renames the `sign_request_status` parameter `effective_canister_id` → `effective_id` and documents that `SignedRequestStatus::effective_canister_id` may carry a subnet id when the request was originally subnet-scoped.
- Bumps all workspace crates to 0.47.3.

## Test plan

- [x] Existing ic-ref tests pass.
- [x] New ref-test boots PocketIC with a `cloud_engine` subnet whose `subnet_admins` contains the agent identity and asserts that `create_canister().with_effective_subnet_id(...)` lands the canister on that subnet.