### PR TITLE
feat: delegation permissions — release 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.48.0] - 2026-07-04
+
+* `ic-transport-types` / `ic-agent`: Added a `permissions` field to `Delegation` and a new `DelegationPermissions` enum (`Queries` | `All`) describing which request kinds a signed delegation authorizes, matching the IC interface-spec addition for read-only delegations. The field serializes as `"queries"`/`"all"` and is omitted when `None`, so existing delegations (which leave it `None`) hash and verify exactly as before. `DelegationPermissions` is re-exported from `ic_agent::identity` alongside `Delegation` and `SignedDelegation`.
+
+### Breaking Changes
+
+* `ic-transport-types`: `Delegation` gained a `permissions: Option<DelegationPermissions>` field. `Delegation` is not `#[non_exhaustive]`, so code that constructs it with a struct literal must add `permissions: None` (or the desired value).
+
 ## [0.47.3] - 2026-05-15
 
 * `ic-agent`: Added the `EffectiveId` enum (`Canister(Principal)` | `Subnet(Principal)`) and widened `Agent::update_signed`, `query_signed`, `request_status_signed`, `request_status_raw`, `wait`, `wait_signed`, `read_state_raw`, `verify`, and `sign_request_status` to accept `impl Into<EffectiveId>`. Passing a bare `Principal` is unchanged (treated as `EffectiveId::Canister(_)`); passing `EffectiveId::Subnet(_)` routes to the subnet-scoped HTTP endpoints (`/api/v4/subnet/<id>/call`, `/api/v3/subnet/<id>/read_state`, `/api/v3/subnet/<id>/query`) introduced in IC interface spec 0.60.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1436,7 +1436,7 @@ dependencies = [
  "http-body-util",
  "ic-certification",
  "ic-ed25519",
- "ic-transport-types 0.47.3",
+ "ic-transport-types 0.48.0",
  "ic-verify-bls-signature",
  "ic_principal",
  "js-sys",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "candid",
  "hex",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "async-trait",
  "candid",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "candid",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.47.3"
+version = "0.48.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
@@ -30,10 +30,10 @@ license = "Apache-2.0"
 #   a comment listing those crates). Otherwise, features are declared in the individual crate Cargo.toml.
 #
 # The path dependencies below ensure all workspace members use the same version of internal crates.
-ic-agent = { path = "ic-agent", version = "0.47.3", default-features = false }
-ic-identity-hsm = { path = "ic-identity-hsm", version = "0.47.3" }
-ic-transport-types = { path = "ic-transport-types", version = "0.47.3" }
-ic-utils = { path = "ic-utils", version = "0.47.3" }
+ic-agent = { path = "ic-agent", version = "0.48.0", default-features = false }
+ic-identity-hsm = { path = "ic-identity-hsm", version = "0.48.0" }
+ic-transport-types = { path = "ic-transport-types", version = "0.48.0" }
+ic-utils = { path = "ic-utils", version = "0.48.0" }
 ic-utils-bindgen = { path = "ic-utils-bindgen" }
 ref-tests = { path = "ref-tests" }
 

--- a/ic-agent/src/identity/mod.rs
+++ b/ic-agent/src/identity/mod.rs
@@ -20,7 +20,7 @@ pub use delegated::DelegatedIdentity;
 #[doc(inline)]
 pub use error::DelegationError;
 #[doc(inline)]
-pub use ic_transport_types::{Delegation, SenderInfo, SignedDelegation};
+pub use ic_transport_types::{Delegation, DelegationPermissions, SenderInfo, SignedDelegation};
 #[doc(inline)]
 pub use info_aware::InfoAwareIdentity;
 #[doc(inline)]

--- a/ic-transport-types/src/lib.rs
+++ b/ic-transport-types/src/lib.rs
@@ -391,6 +391,20 @@ pub struct Delegation {
     /// If present, this delegation only applies to requests sent to one of these canisters.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub targets: Option<Vec<Principal>>,
+    /// If present, this delegation only applies to the specified kinds of requests.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<DelegationPermissions>,
+}
+
+/// The kinds of requests a [`Delegation`] permits.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum DelegationPermissions {
+    /// Only query calls and `read_state` requests are permitted.
+    #[serde(rename = "queries")]
+    Queries,
+    /// All request types are permitted.
+    #[serde(rename = "all")]
+    All,
 }
 
 const IC_REQUEST_DELEGATION_DOMAIN_SEPARATOR: &[u8] = b"\x1Aic-request-auth-delegation";

--- a/ref-tests/tests/integration.rs
+++ b/ref-tests/tests/integration.rs
@@ -717,6 +717,7 @@ mod identity {
             expiration: i64::MAX as u64,
             pubkey: signing_identity.public_key().unwrap(),
             targets: None,
+            permissions: None,
         };
         let signature = sending_identity.sign_delegation(&delegation).unwrap();
         let delegated_identity = DelegatedIdentity::new(
@@ -755,6 +756,7 @@ mod identity {
             expiration: i64::MAX as u64,
             pubkey: signing_identity.public_key().unwrap(),
             targets: None,
+            permissions: None,
         };
         let signature = sending_identity.sign_delegation(&delegation).unwrap();
         let delegated_identity = DelegatedIdentity::new(
@@ -808,6 +810,7 @@ mod identity {
                 pubkey: signing_identity.public_key().unwrap(),
                 expiration: i64::MAX as u64,
                 targets: None,
+                permissions: None,
             };
 
             // Build the signature tree:
@@ -904,6 +907,7 @@ mod identity {
                 pubkey: signing_identity.public_key().unwrap(),
                 expiration: i64::MAX as u64,
                 targets: None,
+                permissions: None,
             };
 
             // Compute hash of the delegation message.


### PR DESCRIPTION
## What

Support the new `permissions` field on delegations, and cut release **0.48.0**.

- `ic-transport-types`: add `permissions: Option<DelegationPermissions>` to `Delegation`, plus a new `DelegationPermissions` enum (`Queries` | `All`) describing which request kinds a signed delegation authorizes. Serializes as `"queries"`/`"all"`; omitted when `None`.
- `ic-agent`: re-export `DelegationPermissions` from `ic_agent::identity` alongside `Delegation`/`SignedDelegation`, so callers can name the type when setting the field without a direct `ic-transport-types` dependency.

## Why

Requested by the Identity team — blocking the MCP read-only permissions feature. Matches the protocol addition in dfinity/ic#10449.

## Release: 0.48.0 (minor bump)

`Delegation` is a public struct that is **not** `#[non_exhaustive]`, so adding a field is a breaking change under SemVer (struct-literal construction now requires `permissions: None`). For a `0.x` crate the breaking position is the minor version, so `0.47.3 → 0.48.0`. The `0.48.0` number is free — the earlier 0.48.0 (rustls change, #732) was reverted before release and never published to crates.io.

## Compatibility

`permissions` uses `#[serde(default, skip_serializing_if = "Option::is_none")]`, so a `None` value is omitted from serialization and `to_request_id` produces the identical hash to a pre-permissions delegation. Existing signed delegations still verify unchanged; new/old wire formats deserialize interchangeably.

## Changes for release

- Workspace version `0.47.3 → 0.48.0` (`Cargo.toml` + `Cargo.lock`)
- `CHANGELOG.md` `## [0.48.0]` entry with a Breaking Changes note

Publish to crates.io via the manual **Publish to crates.io** workflow after merge.
