### PR TITLE
ci: make crates.io publish idempotent and retry index lag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,36 @@ jobs:
       - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
         id: auth
       - run: |
-          cargo publish -p ic-transport-types
-          cargo publish -p ic-agent
-          cargo publish -p ic-identity-hsm
-          cargo publish -p ic-utils
-          cargo publish -p icx
-          cargo publish -p icx-cert
+          set -euo pipefail
+
+          # Publish one crate, tolerating the two things that make a naive
+          # `cargo publish` loop brittle:
+          #   1. Re-running after a partial release: a crate already uploaded at
+          #      this version is a success, not a failure (lets a re-dispatch
+          #      finish the crates that didn't make it the first time).
+          #   2. crates.io index lag: a dependent crate can fail to resolve a
+          #      just-uploaded dependency for up to a minute or two. Retry.
+          publish() {
+            local crate="$1" attempt
+            for attempt in $(seq 1 6); do
+              if cargo publish -p "$crate" 2>&1 | tee /tmp/publish.log; then
+                echo "== $crate published"
+                return 0
+              fi
+              if grep -qiE "already (uploaded|exists)" /tmp/publish.log; then
+                echo "== $crate already published at this version; skipping"
+                return 0
+              fi
+              echo "== $crate publish attempt $attempt failed (likely dependency index lag); retrying in 30s"
+              sleep 30
+            done
+            echo "== ERROR: $crate failed to publish after retries" >&2
+            return 1
+          }
+
+          # Order matters: dependencies before dependents.
+          for crate in ic-transport-types ic-agent ic-identity-hsm ic-utils icx icx-cert; do
+            publish "$crate"
+          done
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,8 @@ jobs:
           #   2. crates.io index lag: a dependent crate can fail to resolve a
           #      just-uploaded dependency for up to a minute or two. Retry.
           publish() {
-            local crate="$1" attempt
-            for attempt in $(seq 1 6); do
+            local crate="$1" attempt max=6
+            for attempt in $(seq 1 "$max"); do
               if cargo publish -p "$crate" 2>&1 | tee /tmp/publish.log; then
                 echo "== $crate published"
                 return 0
@@ -31,10 +31,12 @@ jobs:
                 echo "== $crate already published at this version; skipping"
                 return 0
               fi
-              echo "== $crate publish attempt $attempt failed (likely dependency index lag); retrying in 30s"
-              sleep 30
+              if [ "$attempt" -lt "$max" ]; then
+                echo "== $crate publish attempt $attempt/$max failed (likely dependency index lag); retrying in 30s"
+                sleep 30
+              fi
             done
-            echo "== ERROR: $crate failed to publish after retries" >&2
+            echo "== ERROR: $crate failed to publish after $max attempts" >&2
             return 1
           }
 


### PR DESCRIPTION
## What

Make the **Publish to crates.io** workflow idempotent and resilient to crates.io index lag.

## Why — the 0.48.0 release half-failed

The publish job ran six `cargo publish` commands unguarded under `set -e`. During the 0.48.0 release ([run](https://github.com/dfinity/agent-rs/actions/runs/28726312703/job/85184235386)):

- ✅ `ic-transport-types`, `ic-agent`, `ic-identity-hsm`, `ic-utils` uploaded 0.48.0
- ❌ `cargo publish -p icx` then failed: `failed to select a version for the requirement ic-utils = "^0.48.0"` — `ic-utils 0.48.0` had been uploaded ~60s earlier but hadn't yet appeared in the crates.io index (cargo's built-in wait timed out, then the resolve hard-failed). `icx-cert` never ran.

Two brittleness sources:

1. **Partial release can't be resumed.** Re-dispatching aborts on the first command, since `cargo publish -p ic-transport-types` now errors with "crate version already uploaded" and `set -e` kills the step.
2. **Index lag.** A dependent crate can fail to resolve a just-uploaded dependency for a minute or two.

## Fix

Wrap each publish in a helper that:
- treats **"already uploaded/exists"** as success → idempotent, so a re-dispatch finishes the crates that didn't make it without re-publishing the ones already live;
- **retries** other failures up to 6× with a 30s backoff → rides out index lag between dependent crates.

Order (dependencies before dependents) is unchanged.

## Rollout

The Identity team's blocker is already resolved — `ic-agent 0.48.0` and `ic-transport-types 0.48.0` are live. After merging this, re-dispatch the workflow: it will skip the four published crates and publish `icx` + `icx-cert` (both currently still at 0.47.3).
