### PR TITLE
chore: release 0.48.1 — derive CandidType for delegation types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.48.1] - 2026-07-07
+
+* `ic-transport-types`: `Delegation`, `SignedDelegation`, and `DelegationPermissions` now derive `candid::CandidType`, so they can be used directly in Candid interfaces (e.g. matching Internet Identity's `Delegation`/`SignedDelegation` types). The generated Candid maps the byte fields to `blob` and `DelegationPermissions` to `variant { queries; all }`; the added `permissions` field is `opt`, so the encoding stays subtype-compatible with delegation interfaces that omit it.
+
 ## [0.48.0] - 2026-07-04
 
 * `ic-transport-types` / `ic-agent`: Added a `permissions` field to `Delegation` and a new `DelegationPermissions` enum (`Queries` | `All`) describing which request kinds a signed delegation authorizes, matching the IC interface-spec addition for read-only delegations. The field serializes as `"queries"`/`"all"` and is omitted when `None`, so existing delegations (which leave it `None`) hash and verify exactly as before. `DelegationPermissions` is re-exported from `ic_agent::identity` alongside `Delegation` and `SignedDelegation`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1436,7 +1436,7 @@ dependencies = [
  "http-body-util",
  "ic-certification",
  "ic-ed25519",
- "ic-transport-types 0.48.0",
+ "ic-transport-types 0.48.1",
  "ic-verify-bls-signature",
  "ic_principal",
  "js-sys",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "hex",
  "ic-agent",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "candid",
  "hex",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "async-trait",
  "candid",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "icx"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "anyhow",
  "candid",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "icx-cert"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.48.0"
+version = "0.48.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2021"
 repository = "https://github.com/dfinity/agent-rs"
@@ -30,10 +30,10 @@ license = "Apache-2.0"
 #   a comment listing those crates). Otherwise, features are declared in the individual crate Cargo.toml.
 #
 # The path dependencies below ensure all workspace members use the same version of internal crates.
-ic-agent = { path = "ic-agent", version = "0.48.0", default-features = false }
-ic-identity-hsm = { path = "ic-identity-hsm", version = "0.48.0" }
-ic-transport-types = { path = "ic-transport-types", version = "0.48.0" }
-ic-utils = { path = "ic-utils", version = "0.48.0" }
+ic-agent = { path = "ic-agent", version = "0.48.1", default-features = false }
+ic-identity-hsm = { path = "ic-identity-hsm", version = "0.48.1" }
+ic-transport-types = { path = "ic-transport-types", version = "0.48.1" }
+ic-utils = { path = "ic-utils", version = "0.48.1" }
 ic-utils-bindgen = { path = "ic-utils-bindgen" }
 ref-tests = { path = "ref-tests" }
 

--- a/ic-transport-types/src/lib.rs
+++ b/ic-transport-types/src/lib.rs
@@ -6,7 +6,7 @@
 
 use std::borrow::Cow;
 
-use candid::Principal;
+use candid::{CandidType, Principal};
 use ic_certification::Label;
 pub use request_id::{to_request_id, RequestId, RequestIdError};
 use serde::{Deserialize, Serialize};
@@ -381,7 +381,7 @@ pub struct ReplyResponse {
 ///
 /// If key A signs a delegation containing key B, then key B may be used to
 /// authenticate as key A's corresponding principal(s).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, CandidType, Serialize, Deserialize)]
 pub struct Delegation {
     /// The delegated-to key.
     #[serde(with = "serde_bytes")]
@@ -397,7 +397,7 @@ pub struct Delegation {
 }
 
 /// The kinds of requests a [`Delegation`] permits.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, CandidType, Serialize, Deserialize)]
 pub enum DelegationPermissions {
     /// Only query calls and `read_state` requests are permitted.
     #[serde(rename = "queries")]
@@ -422,7 +422,7 @@ impl Delegation {
 }
 
 /// A [`Delegation`] that has been signed by an [`Identity`](https://docs.rs/ic-agent/latest/ic_agent/trait.Identity.html).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, CandidType, Serialize, Deserialize)]
 pub struct SignedDelegation {
     /// The signed delegation.
     pub delegation: Delegation,


### PR DESCRIPTION
## Summary

Prepares the **0.48.1** release (targeting 2026-07-07).

Follow-up to #734: derive `candid::CandidType` for `Delegation`, `SignedDelegation`, and `DelegationPermissions` so downstreams can use them directly in Candid interfaces (e.g. matching Internet Identity's `Delegation`/`SignedDelegation`).

## Changes

- `ic-transport-types`: added `CandidType` to the derives on `Delegation`, `SignedDelegation`, `DelegationPermissions`. Generated Candid:
  ```candid
  type Delegation = record { pubkey: blob; expiration: nat64; targets: opt vec principal; permissions: opt DelegationPermissions };
  type SignedDelegation = record { delegation: Delegation; signature: blob };
  type DelegationPermissions = variant { queries; all };
  ```
  The `serde_bytes` byte fields map to `blob`, serde renames are honored, and the extra `permissions` field is `opt` — so the encoding stays Candid-subtype-compatible with delegation interfaces that omit it.
- Version bump `0.48.0` → `0.48.1` (workspace `version` + internal path-dep pins in `Cargo.toml`, `Cargo.lock` refreshed).
- `CHANGELOG.md`: new `## [0.48.1] - 2026-07-07` section.

This is a purely additive trait impl — no breaking changes.

## Verification

- `cargo build --workspace --locked` ✅
- `cargo test -p ic-transport-types` ✅ (12 passed)
- `cargo clippy -p ic-transport-types` ✅ (clean)

## Release steps after merge

- [ ] Merge to `main`
- [ ] Manually dispatch the **Publish to crates.io** workflow (`workflow_dispatch`) — publishes in dependency order, idempotent/retry-safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)